### PR TITLE
fix: appId and engine not found in Windows development

### DIFF
--- a/.electron-vue/webpack.main.config.js
+++ b/.electron-vue/webpack.main.config.js
@@ -68,7 +68,8 @@ let mainConfig = {
 if (devMode) {
   mainConfig.plugins.push(
     new webpack.DefinePlugin({
-      '__static': `"${path.join(__dirname, '../static').replace(/\\/g, '\\\\')}"`
+      '__static': `"${path.join(__dirname, '../static').replace(/\\/g, '\\\\')}"`,
+      'appId': `"${build.appId}"`
     })
   )
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   | tar -xz -C /tmp/git-lfs --strip-components 1 && /tmp/git-lfs/git-lfs pull
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install --no-install-recommends -y icnsutils graphicsmagick xz-utils; fi
 install:
-- nvm install 7
+- nvm install 10
 - curl -o- -L https://yarnpkg.com/install.sh | bash
 - source ~/.bashrc
 - npm install -g xvfb-maybe

--- a/src/main/configs/engine.js
+++ b/src/main/configs/engine.js
@@ -1,5 +1,5 @@
 export default {
   'darwin': 'aria2c',
-  'win32': 'aria2c.exe',
+  'win32': 'aria2.exe',
   'linux': 'aria2c'
 }


### PR DESCRIPTION
Windows 本地调试报 appId 和 engine 未找到，PR 修复了这些问题。如果需要 Windows 测试，我可以提供帮助。