### PR TITLE
fix: UI Changes to Messages

### DIFF
--- a/src/renderer/components/Native/EngineClient.vue
+++ b/src/renderer/components/Native/EngineClient.vue
@@ -47,7 +47,7 @@
             let taskName = getTaskName(task)
             if (taskName.length > 60) taskName = `${taskName.substring(0, 60)}...`
             const message = this.$t('task.download-start-message', { taskName })
-            this.$message.info(message)
+            this.$message.info({ message, showClose: true })
           })
       },
       onDownloadPause: function (event) {
@@ -58,7 +58,7 @@
             let taskName = getTaskName(task)
             if (taskName.length > 60) taskName = `${taskName.substring(0, 60)}...`
             const message = this.$t('task.download-pause-message', { taskName })
-            this.$message.info(message)
+            this.$message.info({ message, showClose: true })
           })
       },
       onDownloadStop: function (event) {
@@ -69,7 +69,7 @@
             let taskName = getTaskName(task)
             if (taskName.length > 60) taskName = `${taskName.substring(0, 60)}...`
             const message = this.$t('task.download-stop-message', { taskName })
-            this.$message.info(message)
+            this.$message.info({ message, showClose: true })
           })
       },
       onDownloadError: function (event) {
@@ -80,7 +80,7 @@
             let taskName = getTaskName(task)
             if (taskName.length > 60) taskName = `${taskName.substring(0, 60)}...`
             const message = this.$t('task.download-error-message', { taskName })
-            this.$message.error(message)
+            this.$message.error({ message, showClose: true })
           })
       },
       onDownloadComplete: function (event) {
@@ -114,7 +114,7 @@
         openDownloadDock(path)
 
         const message = this.$t('task.download-complete-message', { taskName })
-        this.$message.success(message)
+        this.$message.success({ message, showClose: true })
 
         /* eslint-disable no-new */
         const notify = new Notification(this.$t('task.download-complete-notify'), {
@@ -135,7 +135,7 @@
         if (taskName.length > 60) taskName = `${taskName.substring(0, 60)}...`
 
         const message = this.$t('task.download-fail-message', { taskName })
-        this.$message.success(message)
+        this.$message.success({ message, showClose: true })
 
         /* eslint-disable no-new */
         new Notification(this.$t('task.download-fail-notify'), {

--- a/src/renderer/components/Native/EngineClient.vue
+++ b/src/renderer/components/Native/EngineClient.vue
@@ -44,7 +44,8 @@
         const [{ gid }] = event
         api.fetchTaskItem({ gid })
           .then((task) => {
-            const taskName = getTaskName(task)
+            let taskName = getTaskName(task)
+            if (taskName.length > 60) taskName = `${taskName.substring(0, 60)}...`
             const message = this.$t('task.download-start-message', { taskName })
             this.$message.info(message)
           })
@@ -54,7 +55,8 @@
         const [{ gid }] = event
         api.fetchTaskItem({ gid })
           .then((task) => {
-            const taskName = getTaskName(task)
+            let taskName = getTaskName(task)
+            if (taskName.length > 60) taskName = `${taskName.substring(0, 60)}...`
             const message = this.$t('task.download-pause-message', { taskName })
             this.$message.info(message)
           })
@@ -64,7 +66,8 @@
         const [{ gid }] = event
         api.fetchTaskItem({ gid })
           .then((task) => {
-            const taskName = getTaskName(task)
+            let taskName = getTaskName(task)
+            if (taskName.length > 60) taskName = `${taskName.substring(0, 60)}...`
             const message = this.$t('task.download-stop-message', { taskName })
             this.$message.info(message)
           })
@@ -74,7 +77,8 @@
         const [{ gid }] = event
         api.fetchTaskItem({ gid })
           .then((task) => {
-            const taskName = getTaskName(task)
+            let taskName = getTaskName(task)
+            if (taskName.length > 60) taskName = `${taskName.substring(0, 60)}...`
             const message = this.$t('task.download-error-message', { taskName })
             this.$message.error(message)
           })
@@ -102,7 +106,8 @@
           return
         }
 
-        const taskName = getTaskName(task)
+        let taskName = getTaskName(task)
+        if (taskName.length > 60) taskName = `${taskName.substring(0, 60)}...`
         const path = getTaskFullPath(task)
 
         addToRecentTask(task)
@@ -126,7 +131,8 @@
           return
         }
 
-        const taskName = getTaskName(task)
+        let taskName = getTaskName(task)
+        if (taskName.length > 60) taskName = `${taskName.substring(0, 60)}...`
 
         const message = this.$t('task.download-fail-message', { taskName })
         this.$message.success(message)


### PR DESCRIPTION
Long task names now truncate and messages are dismissible.

Before:
<img width="1015" alt="Before" src="https://user-images.githubusercontent.com/3370615/52839678-efedac00-3131-11e9-81ad-27a02563ed90.png">

After:
<img width="1015" alt="After" src="https://user-images.githubusercontent.com/3370615/52839687-f67c2380-3131-11e9-985d-eb35435b6de8.png">
