### PR TITLE
feat: adjust the order of downloading tasks with vuedraggable [WIP]

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "vue": "^2.6.4",
     "vue-electron": "^1.0.6",
     "vue-router": "^3.0.2",
+    "vuedraggable": "^2.17.0",
     "vuex": "^3.1.0",
     "vuex-router-sync": "^5.0.0"
   },

--- a/src/renderer/components/Task/TaskItem.vue
+++ b/src/renderer/components/Task/TaskItem.vue
@@ -122,7 +122,7 @@
     border: 1px solid #ccc;
     border-radius: 6px;
     margin-bottom: 16px;
-    transition: $--border-transition-base;
+    transition: $--all-transition;
     &:hover {
       border-color: $--task-item-hover-border-color;
     }

--- a/src/renderer/components/Task/TaskList.vue
+++ b/src/renderer/components/Task/TaskList.vue
@@ -1,7 +1,12 @@
 <template>
-  <ul class="task-list" v-if="taskList.length > 0">
-    <mo-task-item v-for="task in taskList" :key="task.gid" :task="task" />
-  </ul>
+  <vue-draggable v-model="$store.state.taskList" v-if="taskList.length > 0"
+    @start="isDragging = true" @end="isDragging = false"
+    :options="{ animation: 100, ghostClass: 'drag-ghost' }"
+  >
+    <transition-group name="task-item" tag="ul" class="task-list">
+      <mo-task-item v-for="task in taskList" :key="task.gid" :task="task" />
+    </transition-group>
+  </vue-draggable>
   <div class="no-task" v-else>
     <div class="no-task-inner">
       {{ $t('task.no-task') }}
@@ -12,12 +17,17 @@
 <script>
   import { mapState } from 'vuex'
   import TaskItem from './TaskItem'
+  import VueDraggable from 'vuedraggable'
 
   export default {
     name: 'mo-task-list',
     components: {
-      [TaskItem.name]: TaskItem
+      [TaskItem.name]: TaskItem,
+      VueDraggable
     },
+    data: () => ({
+      isDragging: false
+    }),
     computed: {
       ...mapState('task', {
         taskList: state => state.taskList
@@ -29,6 +39,9 @@
 </script>
 
 <style lang="scss">
+  .drag-ghost {
+    opacity: 0.3;
+  }
   .task-list {
     list-style: none;
     padding: 0;
@@ -46,5 +59,13 @@
     width: 100%;
     padding-top: 360px;
     background: transparent url('~@/assets/no-task.svg') top center no-repeat;
+  }
+  .task-item-enter {
+    opacity: 0;
+    transform: translateX(-100%);
+  }
+  .task-item-leave-to {
+    opacity: 0;
+    transform: translateX(100%);
   }
 </style>


### PR DESCRIPTION
看到了[这个](https://trello.com/c/iZejHxJ4/22-%E8%B0%83%E6%95%B4%E4%BB%BB%E5%8A%A1%E4%B8%8B%E8%BD%BD%E9%A1%BA%E5%BA%8F)就写了。

- 可以上下拖动每个任务卡片
- 任务卡片在 enter, leave, move 时会给予相应的动画效果:
  - enter/leave 时采用向右滑动淡入/向右滑动淡出
  - 所有动作采用 element 默认的 `$--all-transition`

可能存在的问题:
- 有一处 `v-model` 使用了 `$store.state.xxx` 这种写法
- 原因是不想改太多地方
- 如果觉得这个 PR 是合理的, 但这种写法不好, 我就去改一下~