### PR TITLE
feat: add background under form-actions in preferences

### DIFF
--- a/src/renderer/components/Preference/Index.vue
+++ b/src/renderer/components/Preference/Index.vue
@@ -57,6 +57,8 @@
     bottom: 0;
     left: auto;
     z-index: 10;
+    width: -webkit-fill-available;
+    margin-right: 20.1rem;
     box-sizing: border-box;
     padding: 24px 36px 24px 0;
   }

--- a/src/renderer/components/Theme/Dark.scss
+++ b/src/renderer/components/Theme/Dark.scss
@@ -56,7 +56,9 @@
       }
     }
   }
-
+  .form-actions {
+    background: $--dk-form-actions-background;
+  }
   .panel {
     background-color: $--dk-panel-background;
   }

--- a/src/renderer/components/Theme/Dark/Variables.scss
+++ b/src/renderer/components/Theme/Dark/Variables.scss
@@ -30,6 +30,10 @@ $--dk-panel-background: #343434 !default;
 $--dk-panel-title-color: #fff !default;
 $--dk-panel-border-color: #EBECF0 !default;
 
+/* Form Actions
+-------------------------- */
+$--dk-form-actions-background: #343434 !default;
+
 /* Task
 -------------------------- */
 $--dk-task-action-color: #eee !default;

--- a/src/renderer/components/Theme/Default.scss
+++ b/src/renderer/components/Theme/Default.scss
@@ -235,3 +235,7 @@ img {
     height: 100%;
   }
 }
+
+.form-actions {
+  background: $--form-actions-background;
+}

--- a/src/renderer/components/Theme/Light/Variables.scss
+++ b/src/renderer/components/Theme/Light/Variables.scss
@@ -30,6 +30,10 @@ $--panel-background: $--color-white !default;
 $--panel-title-color: $--color-text-primary !default;
 $--panel-border-color: rgba(0, 0, 0, 0.1) !default;
 
+/* Form Actions
+-------------------------- */
+$--form-actions-background: $--color-white !default;
+
 /* Task
 -------------------------- */
 $--task-action-color: #4d515a !default;


### PR DESCRIPTION
Currently, the form action buttons overlap the underlying preferences giving poor readability. I have added a background to the `form-actions div` so the UI maintains good readability. I also added the appropriate themeing styles.

This is a quick & dirty fix that _works_ without changing too much of the layout.