### PR TITLE
fix: stopPowerSaveBlocker when psbId = 0

### DIFF
--- a/src/main/core/EnergyManager.js
+++ b/src/main/core/EnergyManager.js
@@ -1,6 +1,6 @@
 import { powerSaveBlocker } from 'electron'
 
-let psbId = null
+let psbId
 export default class EnergyManager {
   startPowerSaveBlocker () {
     if (psbId && powerSaveBlocker.isStarted(psbId)) {
@@ -12,12 +12,12 @@ export default class EnergyManager {
   }
 
   stopPowerSaveBlocker () {
-    if (!psbId || !powerSaveBlocker.isStarted(psbId)) {
+    if (typeof psbId === 'undefined' || !powerSaveBlocker.isStarted(psbId)) {
       return
     }
 
     powerSaveBlocker.stop(psbId)
     console.log('stopPowerSaveBlocker===>', psbId)
-    psbId = null
+    psbId = undefined
   }
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
Energy management stopPowerSaveBlocker does not correctly handle the case where psbId is 0.

## Related Issues
Fixes #418 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?
