### PR TITLE
fix: process is not defined at node 12.x #267

### DIFF
--- a/.electron-vue/webpack.renderer.config.js
+++ b/.electron-vue/webpack.renderer.config.js
@@ -166,6 +166,18 @@ let rendererConfig = {
       filename: 'index.html',
       chunks: ['index'],
       template: path.resolve(__dirname, '../src/index.ejs'),
+      templateParameters(compilation, assets, options) {
+        return {
+          compilation: compilation,
+          webpack: compilation.getStats().toJson(),
+          webpackConfig: compilation.options,
+          htmlWebpackPlugin: {
+            files: assets,
+            options: options
+          },
+          process
+        }
+      },
       // minify: {
       //   collapseWhitespace: true,
       //   removeAttributeQuotes: true,

--- a/.electron-vue/webpack.web.config.js
+++ b/.electron-vue/webpack.web.config.js
@@ -134,6 +134,18 @@ let webConfig = {
       filename: 'index.html',
       chunks: ['index'],
       template: path.resolve(__dirname, '../src/index.ejs'),
+      templateParameters(compilation, assets, options) {
+        return {
+          compilation: compilation,
+          webpack: compilation.getStats().toJson(),
+          webpackConfig: compilation.options,
+          htmlWebpackPlugin: {
+            files: assets,
+            options: options
+          },
+          process
+        }
+      },
       // minify: {
       //   collapseWhitespace: true,
       //   removeAttributeQuotes: true,


### PR DESCRIPTION
## Description

```javascript
npm run dev
...
ERROR in Template execution failed: ReferenceError: process is not defined

ERROR in   ReferenceError: process is not defined

  - index.ejs:11 eval
    [.]/[html-webpack-plugin]/lib/loader.js!./src/index.ejs:11:2

  - index.ejs:16 module.exports
    [.]/[html-webpack-plugin]/lib/loader.js!./src/index.ejs:16:3

  - index.js:284
    [Motrix]/[html-webpack-plugin]/index.js:284:18

  - runMicrotasks

  - task_queues.js:93 processTicksAndRejections
    internal/process/task_queues.js:93:5
...
```

https://github.com/SimulatedGREG/electron-vue/issues/871#issuecomment-490370237

## Related Issues
Fixes #267 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?
