### PR TITLE
modify delete task dialog

### DIFF
--- a/src/renderer/components/Task/TaskItemActions.vue
+++ b/src/renderer/components/Task/TaskItemActions.vue
@@ -246,22 +246,50 @@
           })
       },
       onDeleteClick (event) {
-        const self = this
+        // const { self } = this
+        // let isChecked = !!event.shiftKey
         const { task } = this
-        const isChecked = !!event.shiftKey
-        this.$electron.remote.dialog.showMessageBox({
+        const key = Date.now()
+        const h = this.$createElement
+        this.$msgbox({
           type: 'warning',
           title: this.$t('task.delete-task'),
-          message: this.$t('task.delete-task-confirm', { taskName: this.taskName }),
-          buttons: [this.$t('app.yes'), this.$t('app.no')],
-          cancelId: 1,
-          checkboxLabel: this.$t('task.delete-task-label'),
-          checkboxChecked: isChecked
-        }, (buttonIndex, checkboxChecked) => {
-          if (buttonIndex === 0) {
-            self.removeTaskItem(task, checkboxChecked)
-          }
+          message: h('div', [
+            h('p', this.$t('task.delete-task-confirm', { taskName: this.taskName })),
+            h('el-checkbox', {
+              props: {
+                key,
+                label: '同时删除文件'
+              },
+              ref: key
+            })
+          ]),
+          lockScroll: true,
+          showCancelButton: true,
+          confirmButtonText: this.$t('app.yes'),
+          cancelButtonText: this.$t('app.no')
+        }).then(() => {
+          const { isChecked } = this.$refs[key]
+          this.removeTaskItem(task, isChecked)
+        }).catch(() => {}).finally(() => {
+          this.$refs[key].model = false
         })
+        this.$nextTick(() => {
+          this.$refs[key].model = !!event.shiftKey
+        })
+        // this.$electron.remote.dialog.showMessageBox({
+        //   type: 'warning',
+        //   title: this.$t('task.delete-task'),
+        //   message: this.$t('task.delete-task-confirm', { taskName: this.taskName }),
+        //   buttons: [this.$t('app.yes'), this.$t('app.no')],
+        //   cancelId: 1,
+        //   checkboxLabel: this.$t('task.delete-task-label'),
+        //   checkboxChecked: isChecked
+        // }, (buttonIndex, checkboxChecked) => {
+        //   if (buttonIndex === 0) {
+        //     self.removeTaskItem(task, checkboxChecked)
+        //   }
+        // })
       },
       onTrashClick (event) {
         const self = this


### PR DESCRIPTION
删除任务时, 取消使用系统弹出对话框, 改为element ui的MessageBox
针对同时删除文件选项 MessageBox的message属性使用VNode时, 内部的Checkbox无法实现响应式渲染
不得已, 使用ref直接修改组建状态