### PR TITLE
fix: electron v7 dialog showOpenDialog promisify

### DIFF
--- a/src/main/Application.js
+++ b/src/main/Application.js
@@ -366,8 +366,8 @@ export default class Application extends EventEmitter {
             extensions: ['torrent']
           }
         ]
-      }, (filePaths) => {
-        if (!filePaths || filePaths.length === 0) {
+      }).then(({ canceled, filePaths }) => {
+        if (canceled || filePaths.length === 0) {
           return
         }
 

--- a/src/renderer/components/Native/SelectDirectory.vue
+++ b/src/renderer/components/Native/SelectDirectory.vue
@@ -18,11 +18,12 @@
       onFolderClick: function () {
         const self = this
         this.$electron.remote.dialog.showOpenDialog({
-          properties: ['openDirectory']
-        }, (filePaths) => {
-          if (!filePaths) {
+          properties: ['openDirectory', 'createDirectory']
+        }).then(({ canceled, filePaths }) => {
+          if (canceled || filePaths.length === 0) {
             return
           }
+
           const [path] = filePaths
           self.$emit('selected', path)
         })


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
Selecting the folder failed and found that dialog.showOpenDialog is also promisify.

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?
