### PR TITLE
fix: rebuild darwin aria2c v1.35

### DIFF
--- a/extra/darwin/engine/aria2.conf
+++ b/extra/darwin/engine/aria2.conf
@@ -46,7 +46,7 @@ user-agent=Transmission/2.94
 # Enable Local Peer Discovery.
 bt-enable-lpd=true
 # Requires BitTorrent message payload encryption with arc4.
-bt-force-encryption=true
+# bt-force-encryption=true
 # If true is given, after hash check using --check-integrity option and file is complete, continue to seed file.
 bt-hash-check-seed=true
 # Specify the maximum number of peers per torrent.

--- a/extra/linux/engine/aria2.conf
+++ b/extra/linux/engine/aria2.conf
@@ -46,7 +46,7 @@ user-agent=Transmission/2.94
 # Enable Local Peer Discovery.
 bt-enable-lpd=true
 # Requires BitTorrent message payload encryption with arc4.
-bt-force-encryption=true
+# bt-force-encryption=true
 # If true is given, after hash check using --check-integrity option and file is complete, continue to seed file.
 bt-hash-check-seed=true
 # Specify the maximum number of peers per torrent.

--- a/extra/win32/engine/aria2.conf
+++ b/extra/win32/engine/aria2.conf
@@ -46,7 +46,7 @@ user-agent=Transmission/2.94
 # Enable Local Peer Discovery.
 bt-enable-lpd=true
 # Requires BitTorrent message payload encryption with arc4.
-bt-force-encryption=true
+# bt-force-encryption=true
 # If true is given, after hash check using --check-integrity option and file is complete, continue to seed file.
 bt-hash-check-seed=true
 # Specify the maximum number of peers per torrent.


### PR DESCRIPTION
## Description
- fix rebuild aria2c
- chore: disable bt-force-encryption

static build script:
https://github.com/aria2/aria2/blob/master/makerelease-osx.mk

## Related Issues
Fix #628 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?
