### PR TITLE
fix: linux tray not support right-click event

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -43,7 +43,7 @@ brew update && brew cask install motrix
 
 你可以下载 AppImage（适用于所有 Linux 发行版）软件包或 snap 或从源代码构建安装 Motrix（构建请阅读 **编译打包** 部分）
 
-Motrix 已经上架 [Snapcraft](https://snapcraft.io/motrix) ，Ubuntu 用户推荐从 Snap 应用商店下载。
+Motrix 已经上架 [Snapcraft](https://snapcraft.io/motrix) ，Ubuntu 用户推荐从 Snap 商店下载。
 
 Deepin 20 Beta 用户安装 Motrix 失败的问题，请按照以下方法处理：
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ brew update && brew cask install motrix
 
 You can download the AppImage (for all Linux distributions) package or snap or just build from source code to install Motrix (Please read the **Build** section).
 
-Motrix has been listed on [Snapcraft](https://snapcraft.io/motrix), Ubuntu users recommend downloading from the Snap App Store.
+Motrix has been listed on [Snapcraft](https://snapcraft.io/motrix) , Ubuntu users recommend downloading from the Snap Store.
 
 Deepin 20 Beta users failed to install Motrix, please follow the steps below:
 

--- a/src/main/Application.js
+++ b/src/main/Application.js
@@ -347,9 +347,9 @@ export default class Application extends EventEmitter {
 
       this.energyManager.stopPowerSaveBlocker()
 
-      this.trayManager.destroy()
-
       await this.stopEngine()
+
+      this.trayManager.destroy()
     } catch (err) {
       logger.warn('[Motrix] stop error: ', err.message)
     }

--- a/src/main/ui/TrayManager.js
+++ b/src/main/ui/TrayManager.js
@@ -150,6 +150,13 @@ export default class TrayManager extends EventEmitter {
   }
 
   destroy () {
+    if (tray) {
+      tray.removeListener('click', this.handleTrayClick)
+      tray.removeListener('double-click', this.handleTrayDbClick)
+      tray.removeListener('right-click', this.handleTrayRightClick)
+      tray.removeListener('drop-files', this.handleTrayDropFile)
+    }
+
     tray.destroy()
   }
 }

--- a/src/main/ui/TrayManager.js
+++ b/src/main/ui/TrayManager.js
@@ -88,6 +88,11 @@ export default class TrayManager extends EventEmitter {
 
   handleTrayClick = (event) => {
     event.preventDefault()
+    if (is.linux()) {
+      tray.popUpContextMenu(this.menu)
+      return
+    }
+
     global.application.toggle()
   }
 

--- a/src/renderer/components/Logo/Logo.vue
+++ b/src/renderer/components/Logo/Logo.vue
@@ -37,6 +37,7 @@
     display: block;
     width: 100%;
     height: 100%;
+    outline: none;
     text-align: center;
     font-size: 0;
     color: $--app-logo-color;

--- a/src/shared/keymap.json
+++ b/src/shared/keymap.json
@@ -1,10 +1,10 @@
 {
-  "cmd-q": "application:quit",
-  "cmd-n": "application:new-task",
-  "cmd-shift-n": "application:new-bt-task",
-  "cmd-o": "application:open-file",
-  "cmd-,": "application:preferences",
-  "cmd-shift-p": "application:pause-all-task",
-  "cmd-shift-r": "application:resume-all-task",
+  "cmdctrl-q": "application:quit",
+  "cmdctrl-n": "application:new-task",
+  "cmdctrl-shift-n": "application:new-bt-task",
+  "cmdctrl-o": "application:open-file",
+  "cmdctrl-,": "application:preferences",
+  "cmdctrl-shift-p": "application:pause-all-task",
+  "cmdctrl-shift-r": "application:resume-all-task",
   "ctrl-shift-a": "application:select-all-task"
 }


### PR DESCRIPTION
## Description
- docs: update readme snapcraft link
- fix: linux tray not support right-click event
https://www.electronjs.org/docs/api/tray#event-right-click-macos-windows

## Related Issues
None

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?
