### PR TITLE
fix: webpack copy plugin path

### DIFF
--- a/.electron-vue/webpack.renderer.config.js
+++ b/.electron-vue/webpack.renderer.config.js
@@ -239,8 +239,8 @@ if (!devMode) {
   rendererConfig.plugins.push(
     new CopyWebpackPlugin({
       patterns: [{
-        from: '../static',
-        to: '../dist/electron/static',
+        from: path.join(__dirname, '../static'),
+        to: path.join(__dirname, '../dist/electron/static'),
         globOptions: { ignore: [ '.*' ] }
       }]
     }),

--- a/.electron-vue/webpack.web.config.js
+++ b/.electron-vue/webpack.web.config.js
@@ -211,8 +211,8 @@ if (!devMode) {
   webConfig.plugins.push(
     new CopyWebpackPlugin({
       patterns: [{
-        from: '../static',
-        to: '../dist/electron/static',
+        from: path.join(__dirname, '../static'),
+        to: path.join(__dirname, '../dist/electron/static'),
         globOptions: { ignore: [ '.*' ] }
       }]
     }),


### PR DESCRIPTION
## Description
- fix: webpack copy plugin path

## Related Issues
None

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?
