### PR TITLE
fix: stop bt task seeding notification #604

### DIFF
--- a/src/renderer/components/Task/Index.vue
+++ b/src/renderer/components/Task/Index.vue
@@ -252,6 +252,10 @@
       handleStopTaskSeeding (payload) {
         const { task } = payload
         this.$store.dispatch('task/stopSeeding', task)
+        this.$msg.info({
+          message: this.$t('task.bt-stopping-seeding-tip'),
+          duration: 8000
+        })
       },
       handleRestartTask (payload) {
         const { task, taskName, showDialog } = payload

--- a/src/renderer/components/Task/TaskItem.vue
+++ b/src/renderer/components/Task/TaskItem.vue
@@ -16,12 +16,9 @@
 </template>
 
 <script>
-  import {
-    getTaskFullPath,
-    getTaskName
-  } from '@shared/utils'
+  import { getTaskName } from '@shared/utils'
   import { TASK_STATUS } from '@shared/constants'
-  import { openItem } from '@/utils/native'
+  import { openItem, getTaskFullPath } from '@/utils/native'
   import TaskItemActions from './TaskItemActions'
   import TaskProgress from './TaskProgress'
   import TaskProgressInfo from './TaskProgressInfo'

--- a/src/renderer/components/Task/TaskItemActions.vue
+++ b/src/renderer/components/Task/TaskItemActions.vue
@@ -43,9 +43,9 @@
   import { TASK_STATUS } from '@shared/constants'
   import {
     checkTaskIsSeeder,
-    getTaskFullPath,
     getTaskName
   } from '@shared/utils'
+  import { getTaskFullPath } from '@/utils/native'
   import '@/components/Icons/task-start-line'
   import '@/components/Icons/task-pause-line'
   import '@/components/Icons/task-stop-line'

--- a/src/renderer/store/modules/task.js
+++ b/src/renderer/store/modules/task.js
@@ -6,6 +6,7 @@ const state = {
   currentList: 'active',
   taskItemInfoVisible: false,
   currentTaskItem: null,
+  seedingList: [],
   taskList: [],
   selectedGidList: []
 }
@@ -14,6 +15,9 @@ const getters = {
 }
 
 const mutations = {
+  UPDATE_SEEDING_LIST (state, seedingList) {
+    state.seedingList = seedingList
+  },
   UPDATE_TASK_LIST (state, taskList) {
     state.taskList = taskList
   },
@@ -159,8 +163,29 @@ const actions = {
         dispatch('saveSession')
       })
   },
-  stopSeeding ({ dispatch }, task) {
-    const { gid } = task
+  addToSeedingList ({ state, commit }, gid) {
+    const { seedingList } = state
+    if (seedingList.includes(gid)) {
+      return
+    }
+
+    const list = [
+      ...seedingList,
+      gid
+    ]
+    commit('UPDATE_SEEDING_LIST', list)
+  },
+  removeFromSeedingList ({ state, commit }, gid) {
+    const { seedingList } = state
+    const idx = seedingList.indexOf(gid)
+    if (idx === -1) {
+      return
+    }
+
+    const list = [...seedingList.slice(0, idx), ...seedingList.slice(idx + 1)]
+    commit('UPDATE_SEEDING_LIST', list)
+  },
+  stopSeeding ({ dispatch }, gid) {
     const options = {
       seedTime: 0
     }

--- a/src/renderer/utils/native.js
+++ b/src/renderer/utils/native.js
@@ -1,10 +1,11 @@
 import is from 'electron-is'
 import { access, constants } from 'fs'
+import { resolve } from 'path'
 import { Message } from 'element-ui'
 
 import {
   bytesToSize,
-  getTaskFullPath,
+  getFileName,
   isMagnetTask
 } from '@shared/utils'
 import { APP_THEME, TASK_STATUS } from '@shared/constants'
@@ -45,6 +46,38 @@ export function openItem (fullPath, { errorMsg }) {
   if (!result && errorMsg) {
     Message.error(errorMsg)
   }
+  return result
+}
+
+export function getTaskFullPath (task) {
+  const { dir, files, bittorrent } = task
+  let result = resolve(dir)
+
+  // Magnet link task
+  if (isMagnetTask(task)) {
+    return result
+  }
+
+  if (bittorrent && bittorrent.info && bittorrent.info.name) {
+    result = resolve(result, bittorrent.info.name)
+    return result
+  }
+
+  const [file] = files
+  const path = file.path ? resolve(file.path) : ''
+  let fileName = ''
+
+  if (path) {
+    result = path
+  } else {
+    if (files && files.length === 1) {
+      fileName = getFileName(file)
+      if (fileName) {
+        result = resolve(result, fileName)
+      }
+    }
+  }
+
   return result
 }
 

--- a/src/shared/locales/bg/task.js
+++ b/src/shared/locales/bg/task.js
@@ -88,6 +88,7 @@ export default {
   'BT-download-complete-message': 'завършено изтегляне {{TaskName}}, раздаване',
   'BT-download-complete-notify': 'BT изтеглянето приключи, раздаване...',
   'BT-download-complete-tips': 'съвет: можете да спрете задачата, за да спрете раздаването',
+  'bt-stopping-seeding-tip': 'Спирането на засяването ще отнеме известно време, за да прекъснете връзката, моля изчакайте...',
   'download-fail-message': 'не може да бъде изтеглено {{taskName}}',
   'download-fail-notify': 'грешка при зареждане'
 }

--- a/src/shared/locales/ca/task.js
+++ b/src/shared/locales/ca/task.js
@@ -88,6 +88,7 @@ export default {
   'bt-download-complete-message': 'Descàrrega completada {{taskName}}. Compartint...',
   'bt-download-complete-notify': 'Descàrrega BT completa. Compartint...',
   'bt-download-complete-tips': 'Tips: Pot detenir una tasca per deixar de compartir',
+  'bt-stopping-seeding-tip': 'Aturar la sembra, es necessitarà un temps per desconnectar-se, espereu...',
   'download-fail-message': 'No s\'ha pogut descarregar {{taskName}}',
   'download-fail-notify': 'Descàrrega fallida'
 }

--- a/src/shared/locales/de/task.js
+++ b/src/shared/locales/de/task.js
@@ -88,6 +88,7 @@ export default {
   'bt-download-complete-message': 'Download von {{taskName}} abgeschlossen, aussaat...',
   'bt-download-complete-notify': 'BT Download abgeschlossen, Aussaat...',
   'bt-download-complete-tips': 'Tipps: Sie können die Aufgabe stoppen, die aussaat zu beenden',
+  'bt-stopping-seeding-tip': 'Wenn Sie die Aussaat beenden, dauert es einige Zeit, bis die Verbindung getrennt ist. Bitte warten Sie ...',
   'download-fail-message': 'Download von {{taskName}} fehlgeschlagen',
   'download-fail-notify': 'Download fehlgeschlagen'
 }

--- a/src/shared/locales/en-US/task.js
+++ b/src/shared/locales/en-US/task.js
@@ -88,6 +88,7 @@ export default {
   'bt-download-complete-message': 'Completed downloading {{taskName}}, seeding',
   'bt-download-complete-notify': 'BT Download Completed, seeding...',
   'bt-download-complete-tips': 'Tips: You can stop a task to end its seeding',
+  'bt-stopping-seeding-tip': 'Stopping seeding, it will take some time to disconnect, please wait...',
   'download-fail-message': 'Failed to download {{taskName}}',
   'download-fail-notify': 'Download Failed'
 }

--- a/src/shared/locales/es/task.js
+++ b/src/shared/locales/es/task.js
@@ -88,6 +88,7 @@ export default {
   'bt-download-complete-message': 'Descarga completada {{taskName}}, compartiendo',
   'bt-download-complete-notify': 'Descarga BT completa, compartiendo...',
   'bt-download-complete-tips': 'Consejo: Puede detener una tarea para dejar de compartir',
+  'bt-stopping-seeding-tip': 'Detener la siembra, tomará un tiempo desconectarse, por favor espere...',
   'download-fail-message': 'No se pudo descargar {{taskName}}',
   'download-fail-notify': 'Descarga fallida'
 }

--- a/src/shared/locales/fa/task.js
+++ b/src/shared/locales/fa/task.js
@@ -86,8 +86,9 @@ export default {
   'download-complete-message': '{{taskName}} دانلود کامل شد',
   'download-complete-notify': 'دانلود کامل شد',
   'bt-download-complete-message': '{{taskName}} download completed, seeding',
-  'bt-download-complete-notify': 'BT Download Completed, Seeding...',
-  'bt-download-complete-tips': 'Tips: You can stop the task to end the seeding',
+  'bt-download-complete-notify': 'بارگیری BT به پایان رسید ، بذر ...',
+  'bt-download-complete-tips': 'نکات: می توانید کار را برای خاتمه دادن به بذر متوقف کنید.',
+  'bt-stopping-seeding-tip': 'متوقف کردن بذر ، قطع ارتباطی مدتی طول خواهد کشید ، لطفا صبر کنید ...',
   'download-fail-message': '{{taskName}} دانلود شکست خورد',
   'download-fail-notify': 'دانلود شکست خورد'
 }

--- a/src/shared/locales/fr/task.js
+++ b/src/shared/locales/fr/task.js
@@ -88,6 +88,7 @@ export default {
   'bt-download-complete-message': '{{taskName}} téléchargement terminé, ensemencement...',
   'bt-download-complete-notify': 'BT Télécharger Terminé, Ensemencement...',
   'bt-download-complete-tips': 'Astuces: Vous pouvez arrêter la tâche pour mettre fin à l\'ensemencement',
+  'bt-stopping-seeding-tip': 'Arrêt de l\'ensemencement, la déconnexion prendra un certain temps, veuillez patienter ...',
   'download-fail-message': '{{taskName}} téléchargement échoué',
   'download-fail-notify': 'Téléchargement Échoué'
 }

--- a/src/shared/locales/id/task.js
+++ b/src/shared/locales/id/task.js
@@ -88,6 +88,7 @@ export default {
   'bt-download-complete-message': 'Selesai mengunduh {{taskName}}, penyemaian',
   'bt-download-complete-notify': 'BT Unduh Selesai, penyemaian...',
   'bt-download-complete-tips': 'Tips: Anda dapat menghentikan tugas untuk mengakhiri penyemaian',
+  'bt-stopping-seeding-tip': 'Menghentikan penyemaian, perlu beberapa saat untuk memutuskan, harap tunggu...',
   'download-fail-message': 'Gagal mengunduh {{taskName}}',
   'download-fail-notify': 'Unduhan Gagal'
 }

--- a/src/shared/locales/ja/task.js
+++ b/src/shared/locales/ja/task.js
@@ -88,6 +88,7 @@ export default {
   'bt-download-complete-message': '{{taskName}} のダウンロードに成功、seedを作成中...',
   'bt-download-complete-notify': 'torrentタスクのダウンロードに成功，seedを作成中...',
   'bt-download-complete-tips': 'ヒント：タスクを停止しseedの作成を終了することができます',
+  'bt-stopping-seeding-tip': 'シードを停止しています。切断するにはしばらく時間がかかります。お待ちください...',
   'download-fail-message': '{{taskName}} のダウンロードに失敗',
   'download-fail-notify': 'ダウンロード失敗'
 }

--- a/src/shared/locales/ko/task.js
+++ b/src/shared/locales/ko/task.js
@@ -88,6 +88,7 @@ export default {
   'bt-download-complete-message': '{{taskName}} 다운로드 완료, 시딩 중...',
   'bt-download-complete-notify': 'BT 다운로드 완료, 시딩 중...',
   'bt-download-complete-tips': '팁 : 당신은 시딩 작업을 중지할 수 있습니다.',
+  'bt-stopping-seeding-tip': '파종을 중지하면 연결을 끊는 데 시간이 걸립니다. 잠시만 기다려주십시오 ...',
   'download-fail-message': '{{taskName}} 다운로드 실패',
   'download-fail-notify': '다운로드 실패'
 }

--- a/src/shared/locales/pt-BR/task.js
+++ b/src/shared/locales/pt-BR/task.js
@@ -88,6 +88,7 @@ export default {
   'bt-download-complete-message': '{{taskName}} download completado, propagação ...',
   'bt-download-complete-notify': 'Download do BT concluído, Propagação ...',
   'bt-download-complete-tips': 'Dicas: você pode parar a tarefa para terminar a propagação',
+  'bt-stopping-seeding-tip': 'Parando a propagação, levará algum tempo para desconectar, aguarde ...',
   'download-fail-message': '{{taskName}} falha no download',
   'download-fail-notify': 'Falha no Download'
 }

--- a/src/shared/locales/ru/task.js
+++ b/src/shared/locales/ru/task.js
@@ -88,6 +88,7 @@ export default {
   'bt-download-complete-message': 'Завершена загрузка {{taskName}}, раздача',
   'bt-download-complete-notify': 'BT Загрузка завершена, раздача...',
   'bt-download-complete-tips': 'Совет: Вы можете остановить задачу, чтобы остановить раздачу',
+  'bt-stopping-seeding-tip': 'Остановка посева, потребуется некоторое время, чтобы отключиться, пожалуйста, подождите...',
   'download-fail-message': 'Не удалось загрузить {{taskName}}',
   'download-fail-notify': 'Ошибка загрузки'
 }

--- a/src/shared/locales/tr/task.js
+++ b/src/shared/locales/tr/task.js
@@ -88,6 +88,7 @@ export default {
   'bt-download-complete-message': '{{taskName}} indirme tamamlandı, tohumlama...',
   'bt-download-complete-notify': 'BT Indirme tamamlandı, tohumlama...',
   'bt-download-complete-tips': 'Ipuçları: Eğer tohumlama sona erdirmek için görev durdurabilirsiniz',
+  'bt-stopping-seeding-tip': 'Ekim işlemini durdurmak, bağlantıyı kesmek biraz zaman alacak, lütfen bekleyin...',
   'download-fail-message': '{{taskName}} görevi indirilemedi',
   'download-fail-notify': 'İndirme başarısız'
 }

--- a/src/shared/locales/uk/task.js
+++ b/src/shared/locales/uk/task.js
@@ -88,6 +88,7 @@ export default {
   'bt-download-complete-message': 'Виконане завантаження {{taskName}}, раздача',
   'bt-download-complete-notify': 'BT Виконане завантаження, роздача...',
   'bt-download-complete-tips': 'Порада: Ви можите зупинити завдання щоб зупинити роздачу',
+  'bt-stopping-seeding-tip': 'Припиняючи посів, потрібно буде трохи часу відключити, зачекайте, будь ласка ...',
   'download-fail-message': 'Не вдалося завантажити {{taskName}}',
   'download-fail-notify': 'Помилка завантаження'
 }

--- a/src/shared/locales/vi/task.js
+++ b/src/shared/locales/vi/task.js
@@ -88,6 +88,7 @@ export default {
   'bt-download-complete-message': 'Đã hoàn tất tải xuống {{taskName}}, đang seed',
   'bt-download-complete-notify': 'BT đã hoàn tất tải xuống, đang seed...',
   'bt-download-complete-tips': 'Mẹo: Bạn có thể dừng một tác vụ để kết thúc việc seed',
+  'bt-stopping-seeding-tip': 'Ngừng gieo hạt, sẽ mất một thời gian để ngắt kết nối, vui lòng đợi...',
   'download-fail-message': 'Không thể tải xuống {{taskName}}',
   'download-fail-notify': 'Tải xuống thất bại'
 }

--- a/src/shared/locales/zh-CN/task.js
+++ b/src/shared/locales/zh-CN/task.js
@@ -88,6 +88,7 @@ export default {
   'bt-download-complete-message': '{{taskName}} 下载完成，正在做种...',
   'bt-download-complete-notify': 'BT 任务下载完成，正在做种...',
   'bt-download-complete-tips': '提示：你可以停止任务结束做种',
+  'bt-stopping-seeding-tip': '正在停止做种，断开连接需要些时间，请耐心等待...',
   'download-fail-message': '{{taskName}} 下载失败',
   'download-fail-notify': '下载失败'
 }

--- a/src/shared/locales/zh-TW/task.js
+++ b/src/shared/locales/zh-TW/task.js
@@ -88,6 +88,7 @@ export default {
   'bt-download-complete-message': '{{taskName}} 下載完成，正在做種...',
   'bt-download-complete-notify': 'BT 任務下載完成，正在做種...',
   'bt-download-complete-tips': '提示：你可以停止任務結束做種',
+  'bt-stopping-seeding-tip': '停止做種中，需要些時間才能斷開連接，請稍候...',
   'download-fail-message': '{{taskName}} 下載失敗',
   'download-fail-notify': '下載失敗'
 }

--- a/src/shared/utils/index.js
+++ b/src/shared/utils/index.js
@@ -11,7 +11,6 @@ import {
   parseInt,
   pick
 } from 'lodash'
-import { resolve } from 'path'
 
 import { userKeys, systemKeys, needRestartKeys } from '@shared/configKeys'
 import { ENGINE_RPC_HOST } from '@shared/constants'
@@ -142,38 +141,6 @@ export function getFileName (file) {
   }
 
   return path.substring(index + 1)
-}
-
-export function getTaskFullPath (task) {
-  const { dir, files, bittorrent } = task
-  let result = resolve(dir)
-
-  // Magnet link task
-  if (isMagnetTask(task)) {
-    return result
-  }
-
-  if (bittorrent && bittorrent.info && bittorrent.info.name) {
-    result = resolve(result, bittorrent.info.name)
-    return result
-  }
-
-  const [file] = files
-  const path = file.path ? resolve(file.path) : ''
-  let fileName = ''
-
-  if (path) {
-    result = path
-  } else {
-    if (files && files.length === 1) {
-      fileName = getFileName(file)
-      if (fileName) {
-        result = resolve(result, fileName)
-      }
-    }
-  }
-
-  return result
 }
 
 export function isMagnetTask (task) {


### PR DESCRIPTION
## Description
The aria2 BT task stops seeding by calling [changeOption](https://aria2.github.io/manual/en/html/aria2c.html#aria2.changeOption) to modify the `seed-time` of the task. 

After calling changeOption, aria2 will suspend the task and restart the task, so the corresponding notification will be triggered.

Refactored the logic of task notification to reduce the interference to users.

## Related Issues
Closed #604 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?
