### PR TITLE
fix: replace TrackersListCollection other.txt with http.txt

### DIFF
--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -42,7 +42,7 @@ export const NGOSANG_TRACKERS_ALL_IP_URL = 'https://raw.githubusercontent.com/ng
  */
 export const XIU2_TRACKERS_BEST_URL = 'https://raw.githubusercontent.com/XIU2/TrackersListCollection/master/best.txt'
 export const XIU2_TRACKERS_ALL_URL = 'https://raw.githubusercontent.com/XIU2/TrackersListCollection/master/all.txt'
-export const XIU2_TRACKERS_OTHER_URL = 'https://raw.githubusercontent.com/XIU2/TrackersListCollection/master/other.txt'
+export const XIU2_TRACKERS_HTTP_URL = 'https://raw.githubusercontent.com/XIU2/TrackersListCollection/master/http.txt'
 
 // For bt-exclude-tracker
 export const XIU2_TRACKERS_BLACK_URL = 'https://raw.githubusercontent.com/XIU2/TrackersListCollection/master/blacklist.txt'
@@ -81,8 +81,8 @@ export const trackerSourceOptions = [
         label: 'all.txt'
       },
       {
-        value: XIU2_TRACKERS_OTHER_URL,
-        label: 'other.txt'
+        value: XIU2_TRACKERS_HTTP_URL,
+        label: 'http.txt'
       }
     ]
   }


### PR DESCRIPTION
## Description

突然发现 Motrix 把我的 [XIU2/TrackersListCollection](https://github.com/XIU2/TrackersListCollection) 项目加到 Tracker 推荐列表里了 😲 点个赞！  

不过我突然发现怎么有个 `other.txt` 😅...  
这个文件只是我偶尔把一些单独的 Tracker 地址放进去以集成到最终成品列表中（`all.txt、best.txt、http.txt`）。  

正好 7 月的时候，添加了一个仅 HTTP(S) 列表：`http.txt` ，可以用来更换 other.txt ！  

****

发了个 [Issues](https://github.com/agalwood/Motrix/issues/782) 后发现没人吭声，好尴尬，于是我就自己修改并请求合并了~  

只是将 `src/shared/constants.js` 文件内的 `other.txt` 更换为 `http.txt` 。

## Related Issues

#782 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?
