### PR TITLE
docs: Fix installation instructions in README.md

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -36,7 +36,7 @@ scoop install motrix
 macOS 用户可以使用 `brew cask` 安装 Motrix，感谢 [Mitscherlich](https://github.com/Mitscherlich) 的 [PR](https://github.com/Homebrew/homebrew-cask/pull/59494)。
 
 ```bash
-brew update && brew cask install motrix
+brew update && brew install --cask motrix
 ```
 
 ### Linux

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ scoop install motrix
 The macOS users can install Motrix using `brew cask`, thanks to [PR](https://github.com/Homebrew/homebrew-cask/pull/59494) of [Mitscherlich](https://github.com/Mitscherlich).
 
 ```bash
-brew update && brew cask install motrix
+brew update && brew install --cask motrix
 ```
 
 ### Linux


### PR DESCRIPTION
Fix error when installing using latest Homebrew in macOS. Just fix README.md.

screenshot:

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103118067-a0268700-46b0-11eb-80b5-87b32b3e5269.png)
