### PR TITLE
fix: big sur tray color

### DIFF
--- a/src/renderer/components/Native/DynamicTray.vue
+++ b/src/renderer/components/Native/DynamicTray.vue
@@ -42,6 +42,7 @@
     },
     computed: {
       ...mapState('app', {
+        bigSur: state => state.bigSur,
         iconStatus: state => state.stat.numActive > 0 ? 'active' : 'normal',
         theme: state => state.systemTheme,
         focused: state => state.trayFocused,
@@ -61,8 +62,8 @@
         return focused ? getInverseTheme(theme) : theme
       },
       iconKey () {
-        const { iconStatus, currentTheme } = this
-        return `tray-icon-${currentTheme}-${iconStatus}`
+        const { bigSur, iconStatus, currentTheme } = this
+        return bigSur ? 'tray-icon-light-normal' : `tray-icon-${currentTheme}-${iconStatus}`
       }
     },
     watch: {

--- a/src/renderer/store/modules/app.js
+++ b/src/renderer/store/modules/app.js
@@ -1,6 +1,6 @@
 import { ADD_TASK_TYPE } from '@shared/constants'
 import api from '@/api'
-import { getSystemTheme } from '@/utils/native'
+import { getSystemTheme, isBigSur } from '@/utils/native'
 
 const BASE_INTERVAL = 1000
 const PER_INTERVAL = 100
@@ -9,6 +9,7 @@ const MAX_INTERVAL = 6000
 
 const state = {
   systemTheme: getSystemTheme(),
+  bigSur: isBigSur(),
   trayFocused: false,
   aboutPanelVisible: false,
   engineInfo: {

--- a/src/renderer/utils/native.js
+++ b/src/renderer/utils/native.js
@@ -5,7 +5,8 @@ import { Message } from 'element-ui'
 
 import {
   getFileName,
-  isMagnetTask
+  isMagnetTask,
+  getSystemMajorVersion
 } from '@shared/utils'
 import { APP_THEME, TASK_STATUS } from '@shared/constants'
 
@@ -148,6 +149,10 @@ export function getSystemTheme () {
   }
   result = remote.nativeTheme.shouldUseDarkColors ? APP_THEME.DARK : APP_THEME.LIGHT
   return result
+}
+
+export function isBigSur () {
+  return is.macOS() && getSystemMajorVersion() >= 20
 }
 
 export const openExternal = (url, options) => {

--- a/src/shared/utils/index.js
+++ b/src/shared/utils/index.js
@@ -598,3 +598,8 @@ export const intersection = (array1 = [], array2 = []) => {
 export const getInverseTheme = (theme) => {
   return (theme === APP_THEME.LIGHT) ? APP_THEME.DARK : APP_THEME.LIGHT
 }
+
+export const getSystemMajorVersion = () => {
+  const version = require('os').release()
+  return parseInt(version.substr(0, version.indexOf('.')))
+}


### PR DESCRIPTION
## Description
Use template image as tray icon when runs on macOS big sur.
The color is handled by system, so the active status green dot is not able to show.
However, according to [Apple Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/macos/extensions/menu-bar-extras/), we shall use template image to represent a uniform appearance style.

## Related Issues
Fixes #804
Fixes #820

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?

<img width="202" alt="20201228-195012@2x" src="https://user-images.githubusercontent.com/31368738/103213280-26102f80-4948-11eb-9e74-7f1439f54df9.png">