### PR TITLE
fix: tasks list has old wrong items and add switch for auto download torrent

### DIFF
--- a/src/main/core/ConfigManager.js
+++ b/src/main/core/ConfigManager.js
@@ -59,6 +59,8 @@ export default class ConfigManager {
         'dht-file-path6': getDhtPath(IP_VERSION.V6),
         'dht-listen-port': 26701,
         'dir': getUserDownloadsPath(),
+        'follow-metalink': false,
+        'follow-torrent': false,
         'listen-port': 21301,
         'max-concurrent-downloads': 5,
         'max-connection-per-server': getMaxConnectionPerServer(),

--- a/src/renderer/components/Preference/Basic.vue
+++ b/src/renderer/components/Preference/Basic.vue
@@ -186,14 +186,14 @@
           <el-col class="form-item-sub" :span="24">
             <el-switch
               v-model="form.followMetalink"
-              :active-text="$t('preferences.no-auto-download-files-in-magnet-link')"
+              :active-text="$t('preferences.follow-metalink')"
             >
             </el-switch>
           </el-col>
           <el-col class="form-item-sub" :span="24">
             <el-switch
               v-model="form.followTorrent"
-              :active-text="$t('preferences.auto-download-files-in-torrent-link')"
+              :active-text="$t('preferences.follow-torrent')"
             >
             </el-switch>
           </el-col>
@@ -285,6 +285,8 @@
       btSaveMetadata,
       dir,
       engineMaxConnectionPerServer,
+      followMetalink,
+      followTorrent,
       hideAppMenu,
       keepSeeding,
       keepWindowState,
@@ -302,9 +304,7 @@
       seedTime,
       taskNotification,
       theme,
-      traySpeedometer,
-      followMetalink,
-      followTorrent
+      traySpeedometer
     } = config
     const result = {
       autoHideWindow,
@@ -312,6 +312,8 @@
       continue: config.continue,
       dir,
       engineMaxConnectionPerServer,
+      followMetalink,
+      followTorrent,
       hideAppMenu,
       keepSeeding,
       keepWindowState,
@@ -329,9 +331,7 @@
       seedTime,
       taskNotification,
       theme,
-      traySpeedometer,
-      followMetalink,
-      followTorrent
+      traySpeedometer
     }
     return result
   }

--- a/src/renderer/components/Preference/Basic.vue
+++ b/src/renderer/components/Preference/Basic.vue
@@ -183,6 +183,20 @@
               :label="$t('preferences.seed-time')">
             </el-input-number>
           </el-col>
+          <el-col class="form-item-sub" :span="24">
+            <el-switch
+              v-model="form.followMetalink"
+              :active-text="$t('preferences.no-auto-download-files-in-magnet-link')"
+            >
+            </el-switch>
+          </el-col>
+          <el-col class="form-item-sub" :span="24">
+            <el-switch
+              v-model="form.followTorrent"
+              :active-text="$t('preferences.auto-download-files-in-torrent-link')"
+            >
+            </el-switch>
+          </el-col>
           <div class="el-form-item__info" style="margin-top: 8px;">
           </div>
         </el-form-item>
@@ -288,7 +302,9 @@
       seedTime,
       taskNotification,
       theme,
-      traySpeedometer
+      traySpeedometer,
+      followMetalink,
+      followTorrent
     } = config
     const result = {
       autoHideWindow,
@@ -313,7 +329,9 @@
       seedTime,
       taskNotification,
       theme,
-      traySpeedometer
+      traySpeedometer,
+      followMetalink,
+      followTorrent
     }
     return result
   }

--- a/src/renderer/components/TaskDetail/Index.vue
+++ b/src/renderer/components/TaskDetail/Index.vue
@@ -168,7 +168,6 @@
           }
         })
         merge(cached.files, result)
-        cached.files.splice(result.length, cached.files.length - result.length)
         return cached.files
       },
       selectedFileList () {
@@ -184,6 +183,11 @@
     destroyed () {
       window.removeEventListener('resize', this.handleAppResize)
       cached.files = []
+    },
+    watch: {
+      gid () {
+        cached.files = []
+      }
     },
     methods: {
       handleClose (done) {

--- a/src/renderer/components/TaskDetail/Index.vue
+++ b/src/renderer/components/TaskDetail/Index.vue
@@ -168,7 +168,7 @@
           }
         })
         merge(cached.files, result)
-
+        cached.files.splice(result.length, cached.files.length - result.length)
         return cached.files
       },
       selectedFileList () {

--- a/src/renderer/utils/task.js
+++ b/src/renderer/utils/task.js
@@ -14,17 +14,19 @@ export const initTaskForm = state => {
     allProxy,
     dir,
     engineMaxConnectionPerServer,
+    followMetalink,
+    followTorrent,
     maxConnectionPerServer,
     newTaskShowDownloading,
-    split,
-    followTorrent,
-    followMetalink
+    split
   } = state.preference.config
   const result = {
     allProxy,
     cookie: '',
     dir,
     engineMaxConnectionPerServer,
+    followMetalink,
+    followTorrent,
     maxConnectionPerServer,
     newTaskShowDownloading,
     out: '',
@@ -34,8 +36,6 @@ export const initTaskForm = state => {
     torrent: '',
     uris: addTaskUrl,
     userAgent: '',
-    notFollowMetalink: followMetalink,
-    followTorrent,
     ...addTaskOptions
   }
   return result
@@ -98,7 +98,7 @@ export const buildOption = (type, form) => {
     result.header = header
   }
 
-  result.pauseMetadata = !!form.notFollowMetalink
+  result.pauseMetadata = !form.followMetalink
   result.followTorrent = !!form.followTorrent
   return result
 }

--- a/src/renderer/utils/task.js
+++ b/src/renderer/utils/task.js
@@ -16,7 +16,9 @@ export const initTaskForm = state => {
     engineMaxConnectionPerServer,
     maxConnectionPerServer,
     newTaskShowDownloading,
-    split
+    split,
+    followTorrent,
+    followMetalink
   } = state.preference.config
   const result = {
     allProxy,
@@ -32,6 +34,8 @@ export const initTaskForm = state => {
     torrent: '',
     uris: addTaskUrl,
     userAgent: '',
+    notFollowMetalink: followMetalink,
+    followTorrent,
     ...addTaskOptions
   }
   return result
@@ -93,6 +97,9 @@ export const buildOption = (type, form) => {
   if (!isEmpty(header)) {
     result.header = header
   }
+
+  result.pauseMetadata = !!form.notFollowMetalink
+  result.followTorrent = !!form.followTorrent
   return result
 }
 

--- a/src/shared/locales/zh-CN/preferences.js
+++ b/src/shared/locales/zh-CN/preferences.js
@@ -77,5 +77,7 @@ export default {
   'baidu-exporter-help': '点此查看使用说明',
   'auto-update': '自动更新',
   'auto-check-update': '自动检查更新',
-  'last-check-update-time': '上次检查更新时间'
+  'last-check-update-time': '上次检查更新时间',
+  'no-auto-download-files-in-magnet-link': '禁止自动下载磁力链接、种子内的文件',
+  'auto-download-files-in-torrent-link': '种子下载完后下载种子内容'
 }

--- a/src/shared/locales/zh-CN/preferences.js
+++ b/src/shared/locales/zh-CN/preferences.js
@@ -78,6 +78,6 @@ export default {
   'auto-update': '自动更新',
   'auto-check-update': '自动检查更新',
   'last-check-update-time': '上次检查更新时间',
-  'no-auto-download-files-in-magnet-link': '禁止自动下载磁力链接、种子内的文件',
-  'auto-download-files-in-torrent-link': '种子下载完后下载种子内容'
+  'follow-metalink': '自动开始下载磁力链接、种子内的文件',
+  'follow-torrent': '种子下载完后自动下载种子内容'
 }


### PR DESCRIPTION
## Description
Tasks list in task detail has wrong items when user switch between different task. I remove old items which shouldn't appear in new list.
Add a switch for auto download magnet link and torrent. Users can choose whether to automatically start downloading all the files in the torrent or whether to download only the torrent file itself.

## Related Issues
Fixes #971
Close #934
Close #440

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?
