### PR TITLE
fix: macos dark menu

### DIFF
--- a/src/main/ui/TrayManager.js
+++ b/src/main/ui/TrayManager.js
@@ -4,7 +4,7 @@ import { Tray, Menu, nativeImage } from 'electron'
 import is from 'electron-is'
 
 import { APP_THEME } from '@shared/constants'
-import { getInverseTheme, getSystemMajorVersion } from '@shared/utils'
+import { getInverseTheme } from '@shared/utils'
 import { getI18n } from './Locale'
 import {
   translateTemplate,
@@ -26,7 +26,7 @@ export default class TrayManager extends EventEmitter {
 
     this.systemTheme = options.systemTheme
     this.inverseSystemTheme = getInverseTheme(this.systemTheme)
-    this.bigSur = platform === 'darwin' && getSystemMajorVersion() >= 20
+    this.macOS = platform === 'darwin'
 
     this.speedometer = options.speedometer
 
@@ -77,25 +77,7 @@ export default class TrayManager extends EventEmitter {
   }
 
   loadImagesForMacOS () {
-    if (this.bigSur) {
-      const {
-        systemTheme,
-        inverseSystemTheme
-      } = this
-
-      this.normalIcon = this.getFromCacheOrCreateImage(`mo-tray-${systemTheme}-normal.png`)
-      this.activeIcon = this.getFromCacheOrCreateImage(`mo-tray-${systemTheme}-active.png`)
-
-      // if (systemTheme === APP_THEME.DARK) {
-      //   this.inverseNormalIcon = this.normalIcon
-      //   this.inverseActiveIcon = this.activeIcon
-      // } else {
-      this.inverseNormalIcon = this.getFromCacheOrCreateImage(`mo-tray-${inverseSystemTheme}-normal.png`)
-      this.inverseActiveIcon = this.getFromCacheOrCreateImage(`mo-tray-${inverseSystemTheme}-active.png`)
-      // }
-    } else {
-      this.normalIcon = this.getFromCacheOrCreateImage('mo-tray-light-normal.png')
-    }
+    this.normalIcon = this.getFromCacheOrCreateImage('mo-tray-light-normal.png')
   }
 
   loadImagesForWindows () {
@@ -126,7 +108,7 @@ export default class TrayManager extends EventEmitter {
     }
 
     file = nativeImage.createFromPath(join(__static, `./${key}`))
-    file.setTemplateImage(this.bigSur)
+    file.setTemplateImage(this.macOS)
     this.setCache(key, file)
     return file
   }
@@ -238,7 +220,7 @@ export default class TrayManager extends EventEmitter {
   }
 
   getIcons () {
-    if (this.bigSur) {
+    if (this.macOS) {
       return { icon: this.normalIcon }
     }
 
@@ -336,7 +318,7 @@ export default class TrayManager extends EventEmitter {
     const image = nativeImage.createFromBuffer(buffer, {
       scaleFactor: 2
     })
-    image.setTemplateImage(this.bigSur)
+    image.setTemplateImage(this.macOS)
     tray.setImage(image)
   }
 

--- a/src/main/ui/WindowManager.js
+++ b/src/main/ui/WindowManager.js
@@ -202,7 +202,7 @@ export default class WindowManager extends EventEmitter {
 
   showWindow (page) {
     const window = this.getWindow(page)
-    if (!window || window.isVisible()) {
+    if (!window || (window.isVisible() && !window.isMinimized())) {
       return
     }
 

--- a/src/renderer/components/Native/DynamicTray.vue
+++ b/src/renderer/components/Native/DynamicTray.vue
@@ -31,7 +31,6 @@
     name: 'mo-dynamic-tray',
     computed: {
       ...mapState('app', {
-        bigSur: state => state.bigSur,
         iconStatus: state => state.stat.numActive > 0 ? 'active' : 'normal',
         theme: state => state.systemTheme,
         focused: state => state.trayFocused,

--- a/src/renderer/store/modules/app.js
+++ b/src/renderer/store/modules/app.js
@@ -1,6 +1,6 @@
 import { ADD_TASK_TYPE } from '@shared/constants'
 import api from '@/api'
-import { getSystemTheme, isBigSur } from '@/utils/native'
+import { getSystemTheme } from '@/utils/native'
 
 const BASE_INTERVAL = 1000
 const PER_INTERVAL = 100
@@ -9,7 +9,6 @@ const MAX_INTERVAL = 6000
 
 const state = {
   systemTheme: getSystemTheme(),
-  bigSur: isBigSur(),
   trayFocused: false,
   aboutPanelVisible: false,
   engineInfo: {

--- a/src/renderer/utils/native.js
+++ b/src/renderer/utils/native.js
@@ -6,8 +6,7 @@ import { Message } from 'element-ui'
 
 import {
   getFileNameFromFile,
-  isMagnetTask,
-  getSystemMajorVersion
+  isMagnetTask
 } from '@shared/utils'
 import { APP_THEME, TASK_STATUS } from '@shared/constants'
 
@@ -121,10 +120,6 @@ export function getSystemTheme () {
   }
   result = nativeTheme.shouldUseDarkColors ? APP_THEME.DARK : APP_THEME.LIGHT
   return result
-}
-
-export function isBigSur () {
-  return is.macOS() && getSystemMajorVersion() >= 20
 }
 
 export const delayDeleteTaskFiles = (task, delay) => {

--- a/src/shared/utils/index.js
+++ b/src/shared/utils/index.js
@@ -706,8 +706,3 @@ export const intersection = (array1 = [], array2 = []) => {
 export const getInverseTheme = (theme) => {
   return (theme === APP_THEME.LIGHT) ? APP_THEME.DARK : APP_THEME.LIGHT
 }
-
-export const getSystemMajorVersion = () => {
-  const version = require('os').release()
-  return parseInt(version.substr(0, version.indexOf('.')))
-}


### PR DESCRIPTION
## Description
Always use template icon.
Fixes dark menu tray icon for macOS 10.13 High Sierra and before.
<img width="685" src="https://user-images.githubusercontent.com/31368738/128660141-05dc7644-f69e-49c9-93a8-391e9c12f041.png">


## Related Issues
Fixes #1008
Related to #951

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?
