### PR TITLE
Change translation of "cancel" in PT-BR

### DIFF
--- a/src/shared/locales/pt-BR/task.js
+++ b/src/shared/locales/pt-BR/task.js
@@ -1,7 +1,7 @@
 export default {
   'active': 'Baixando',
   'waiting': 'Aguardando',
-  'stopped': 'Cancelado',
+  'stopped': 'Finalizado',
   'new-task': 'Nova Tarefa',
   'new-bt-task': 'Nova Tarefa BT',
   'open-file': 'Abra o arquivo Torrent...',


### PR DESCRIPTION
## Description
"Cancelado" is like I've stopped the download, "Finalizado" is ideal as the files actually canceled and successfully downloaded stay there.

### Checklist:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Have you linted your code locally prior to submission?
* [ ] Have you successfully ran app with your changes locally?
