### PR TITLE
fix: do not show tray tooltip for macOS

### DIFF
--- a/src/main/ui/TrayManager.js
+++ b/src/main/ui/TrayManager.js
@@ -145,7 +145,9 @@ export default class TrayManager extends EventEmitter {
     tray = new Tray(icon)
     // tray.setPressedImage(inverseIcon)
 
-    tray.setToolTip('Motrix')
+    if (!this.macOS) {
+      tray.setToolTip('Motrix')
+    }
   }
 
   handleEvents () {


### PR DESCRIPTION
## Description
macOS should not have tray icon tooltip.
Also, it‘s wierd sometimes.

<img width="101" alt="" src="https://user-images.githubusercontent.com/31368738/141415151-cc4091b4-7a73-439b-8a4f-ae93697953c0.png">

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?
