### PR TITLE
Disable want-digest header in aria2.conf

### DIFF
--- a/extra/darwin/engine/aria2.conf
+++ b/extra/darwin/engine/aria2.conf
@@ -73,3 +73,5 @@ enable-peer-exchange=true
 peer-agent=Transmission/2.94
 # Specify the prefix of peer ID.
 peer-id-prefix=-TR2940-
+# Circumvent Aria2 client detection by disabling the want-digest http header
+http-want-digest=false

--- a/extra/linux/engine/aria2.conf
+++ b/extra/linux/engine/aria2.conf
@@ -73,3 +73,5 @@ enable-peer-exchange=true
 peer-agent=Transmission/2.94
 # Specify the prefix of peer ID.
 peer-id-prefix=-TR2940-
+# Circumvent Aria2 client detection by disabling the want-digest http header
+http-want-digest=false

--- a/extra/win32/engine/aria2.conf
+++ b/extra/win32/engine/aria2.conf
@@ -73,3 +73,5 @@ enable-peer-exchange=true
 peer-agent=Transmission/2.94
 # Specify the prefix of peer ID.
 peer-id-prefix=-TR2940-
+# Circumvent Aria2 client detection by disabling the want-digest http header
+http-want-digest=false


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
#Disable want-digest header in aria2.conf
## Disable want-digest header in aria2.conf
Aria2 client will send a want-digest header aside with the http request by default. Some websites use this as a characteristic and will prohibit aria2 download by the header. The modification of the configuration file add the option of disabling want-digest header


