### PR TITLE
fix: copy "app-update.yml" in app release folder for linux version

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,13 +163,17 @@
         "rpm",
         "snap"
       ],
-      "extraResources": {
+      "extraResources": [
+        {
         "from": "./extra/linux/",
         "to": "./",
-        "filter": [
-          "**/*"
-        ]
-      }
+        "filter": ["**/*"]
+	      },
+	      {
+		      "from": "./app-update.yml",
+		      "to":"./"
+        }
+      ]
     },
     "snap": {
       "publish": [


### PR DESCRIPTION
## Description
### electron package builder does not copy "app-update.yml" to resources folder in application root folder (in linux version) and it's thrown an error

## Related Issues
### refer to #1083 issue

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?
