### PR TITLE
fix: add nullcheck for legacy speed settings

### DIFF
--- a/src/renderer/components/Preference/Basic.vue
+++ b/src/renderer/components/Preference/Basic.vue
@@ -414,7 +414,10 @@
       },
       downloadUnits: {
         get () {
-          const speedEnding = this.form.maxOverallDownloadLimit?.slice(-1)
+          const speed = this.form.maxOverallDownloadLimit
+          // Fallback to K if Speed is 0 (previously unlimited)
+          if (!speed) return 'K'
+          const speedEnding = speed.slice(-1)
           // Fall back to KB if the downloadlimit doesnt have a unit
           if (!speedEnding || !isNaN(parseInt(speedEnding))) return 'K'
           return speedEnding
@@ -425,7 +428,10 @@
       },
       uploadUnits: {
         get () {
-          const speedEnding = this.form.maxOverallUploadLimit?.slice(-1)
+          const speed = this.form.maxOverallUploadLimit
+          // Fallback to K if Speed is 0 (previously unlimited)
+          if (!speed) return 'K'
+          const speedEnding = speed.slice(-1)
           // Fall back to KB if the downloadlimit doesnt have a unit
           if (!speedEnding || !isNaN(parseInt(speedEnding))) return 'K'
           return speedEnding


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
A bug in my PR (#1413) lead to erroneous behavior when the transfer speed was 0 (unlimited) as pointed out by @shatyuka [here](https://github.com/agalwood/Motrix/pull/1413#issuecomment-1493745615). 
This PR adds a check for this and falls back to K for this case.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?
