### PR TITLE
fix: bug regarding cookie/referer

### DIFF
--- a/src/shared/utils/index.js
+++ b/src/shared/utils/index.js
@@ -598,7 +598,11 @@ export function formatOptionsForEngine (options = {}) {
 
   Object.keys(options).forEach((key) => {
     const kebabCaseKey = kebabCase(key)
-    result[kebabCaseKey] = `${options[key]}`
+    if (Array.isArray(options[key])) {
+      result[kebabCaseKey] = options[key].join('\n')
+    } else {
+      result[kebabCaseKey] = `${options[key]}`
+    }
   })
 
   return result


### PR DESCRIPTION
## Problem
When cookie/referer are set at the same time, aria2 failed to parse the cookie/referer arguments, and the target cannot be downloaded.
If only cookie is set, aria2 can successfully download the target.

## Description
Because 
```javascript
result[kebabCaseKey] = `${options[key]}`
```
joins the array element with ','

Adapt it to 
```javascript
result[kebabCaseKey] = options[key].join('\n')
```
works on my side

## Related Issues

### Checklist:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Have you linted your code locally prior to submission?
* [X] Have you successfully ran app with your changes locally?
