### PR TITLE
fix: btAutoDownloadContent boolean is inverted

### DIFF
--- a/src/renderer/components/Preference/Advanced.vue
+++ b/src/renderer/components/Preference/Advanced.vue
@@ -428,7 +428,12 @@
   import ShowInFolder from '@/components/Native/ShowInFolder'
   import SubnavSwitcher from '@/components/Subnav/SubnavSwitcher'
   import userAgentMap from '@shared/ua'
-  import { trackerSourceOptions, ENGINE_RPC_PORT, EMPTY_STRING, LOG_LEVELS } from '@shared/constants'
+  import {
+    EMPTY_STRING,
+    ENGINE_RPC_PORT,
+    LOG_LEVELS,
+    trackerSourceOptions
+  } from '@shared/constants'
   import {
     backupConfig,
     buildRpcUrl,
@@ -483,9 +488,7 @@
       listenPort,
       logLevel,
       noProxy: convertCommaToLine(noProxy),
-      protocols: {
-        ...protocols
-      },
+      protocols: { ...protocols },
       rpcListenPort,
       rpcSecret,
       trackerSource,
@@ -571,6 +574,12 @@
       }
     },
     methods: {
+      handleLocaleChange (locale) {
+        const lng = getLanguage(locale)
+        getLocaleManager().changeLanguage(lng)
+        this.$electron.ipcRenderer.send('command',
+                                        'application:change-locale', lng)
+      },
       onCheckUpdateClick () {
         this.$electron.ipcRenderer.send('command', 'application:check-for-updates')
         this.$msg.info(this.$t('app.checking-for-updates'))
@@ -703,9 +712,9 @@
           } = data
 
           if ('btAutoDownloadContent' in data) {
-            data.pauseMetadata = !btAutoDownloadContent
-            data.followMetalink = btAutoDownloadContent
             data.followTorrent = btAutoDownloadContent
+            data.followMetalink = btAutoDownloadContent
+            data.pauseMetadata = !btAutoDownloadContent
           }
 
           if (btTracker) {
@@ -769,13 +778,11 @@
             if (response === 0) {
               if (changedConfig.basic.theme !== undefined) {
                 this.$electron.ipcRenderer.send('command',
-                                                'application:change-theme', backupConfig.theme)
+                                                'application:change-theme',
+                                                backupConfig.theme)
               }
               if (changedConfig.basic.locale !== undefined) {
-                const lng = getLanguage(backupConfig.locale)
-                getLocaleManager().changeLanguage(lng)
-                this.$electron.ipcRenderer.send('command',
-                                                'application:change-locale', lng)
+                this.handleLocaleChange(backupConfig.locale)
               }
               changedConfig.basic = {}
               changedConfig.advanced = {}

--- a/src/renderer/components/Preference/Basic.vue
+++ b/src/renderer/components/Preference/Basic.vue
@@ -316,14 +316,18 @@
     diffConfig,
     extractSpeedUnit
   } from '@shared/utils'
-  import { APP_RUN_MODE, ENGINE_MAX_CONCURRENT_DOWNLOADS } from '@shared/constants'
+  import {
+    APP_RUN_MODE,
+    EMPTY_STRING,
+    ENGINE_MAX_CONCURRENT_DOWNLOADS
+  } from '@shared/constants'
   import { reduceTrackerString } from '@shared/utils/tracker'
 
   const initForm = (config) => {
     const {
       autoHideWindow,
-      btSaveMetadata,
       btForceEncryption,
+      btSaveMetadata,
       dir,
       engineMaxConnectionPerServer,
       followMetalink,
@@ -349,11 +353,16 @@
       theme,
       traySpeedometer
     } = config
+
+    const btAutoDownloadContent = followTorrent &&
+      followMetalink &&
+      !pauseMetadata
+
     const result = {
       autoHideWindow,
-      btAutoDownloadContent: !pauseMetadata,
-      btSaveMetadata,
+      btAutoDownloadContent,
       btForceEncryption,
+      btSaveMetadata,
       continue: config.continue,
       dir,
       engineMaxConnectionPerServer,
@@ -370,6 +379,7 @@
       newTaskShowDownloading,
       noConfirmBeforeDeleteTask,
       openAtLogin,
+      pauseMetadata,
       resumeAllWhenAppLaunched,
       runMode,
       seedRatio,
@@ -577,12 +587,18 @@
             ...changedConfig.advanced
           }
 
-          const { btAutoDownloadContent, autoHideWindow, btTracker, noProxy } = data
+          const {
+            btAutoDownloadContent,
+            autoHideWindow,
+            btTracker,
+            noProxy,
+            rpcListenPort
+          } = data
 
           if ('btAutoDownloadContent' in data) {
-            data.pauseMetadata = !btAutoDownloadContent
-            data.followMetalink = btAutoDownloadContent
             data.followTorrent = btAutoDownloadContent
+            data.followMetalink = btAutoDownloadContent
+            data.pauseMetadata = !btAutoDownloadContent
           }
 
           if (btTracker) {
@@ -591,6 +607,10 @@
 
           if (noProxy) {
             data.noProxy = convertLineToComma(noProxy)
+          }
+
+          if (rpcListenPort === EMPTY_STRING) {
+            data.rpcListenPort = this.rpcDefaultPort
           }
 
           console.log('[Motrix] preference changed data:', data)
@@ -644,7 +664,8 @@
             if (response === 0) {
               if (changedConfig.basic.theme !== undefined) {
                 this.$electron.ipcRenderer.send('command',
-                                                'application:change-theme', backupConfig.theme)
+                                                'application:change-theme',
+                                                backupConfig.theme)
               }
               if (changedConfig.basic.locale !== undefined) {
                 this.handleLocaleChange(this.formOriginal.locale)


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
fix: btAutoDownloadContent boolean is inverted

## Related Issues
Close #1471

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?
