### PR TITLE
bt-prioritize-piece=head,tail

### DIFF
--- a/extra/darwin/arm64/engine/aria2.conf
+++ b/extra/darwin/arm64/engine/aria2.conf
@@ -66,7 +66,7 @@ bt-hash-check-seed=true
 # Specify the maximum number of peers per torrent.
 bt-max-peers=128
 # Try to download first and last pieces of each file first. This is useful for previewing files.
-bt-prioritize-piece=head
+bt-prioritize-piece=head,tail
 # Removes the unselected files when download is completed in BitTorrent.
 bt-remove-unselected-file=true
 # Seed previously downloaded files without verifying piece hashes.

--- a/extra/darwin/x64/engine/aria2.conf
+++ b/extra/darwin/x64/engine/aria2.conf
@@ -66,7 +66,7 @@ bt-hash-check-seed=true
 # Specify the maximum number of peers per torrent.
 bt-max-peers=128
 # Try to download first and last pieces of each file first. This is useful for previewing files.
-bt-prioritize-piece=head
+bt-prioritize-piece=head,tail
 # Removes the unselected files when download is completed in BitTorrent.
 bt-remove-unselected-file=true
 # Seed previously downloaded files without verifying piece hashes.

--- a/extra/linux/arm64/engine/aria2.conf
+++ b/extra/linux/arm64/engine/aria2.conf
@@ -66,7 +66,7 @@ bt-hash-check-seed=true
 # Specify the maximum number of peers per torrent.
 bt-max-peers=128
 # Try to download first and last pieces of each file first. This is useful for previewing files.
-bt-prioritize-piece=head
+bt-prioritize-piece=head,tail
 # Removes the unselected files when download is completed in BitTorrent.
 bt-remove-unselected-file=true
 # Seed previously downloaded files without verifying piece hashes.

--- a/extra/linux/armv7l/engine/aria2.conf
+++ b/extra/linux/armv7l/engine/aria2.conf
@@ -66,7 +66,7 @@ bt-hash-check-seed=true
 # Specify the maximum number of peers per torrent.
 bt-max-peers=128
 # Try to download first and last pieces of each file first. This is useful for previewing files.
-bt-prioritize-piece=head
+bt-prioritize-piece=head,tail
 # Removes the unselected files when download is completed in BitTorrent.
 bt-remove-unselected-file=true
 # Seed previously downloaded files without verifying piece hashes.

--- a/extra/linux/x64/engine/aria2.conf
+++ b/extra/linux/x64/engine/aria2.conf
@@ -66,7 +66,7 @@ bt-hash-check-seed=true
 # Specify the maximum number of peers per torrent.
 bt-max-peers=128
 # Try to download first and last pieces of each file first. This is useful for previewing files.
-bt-prioritize-piece=head
+bt-prioritize-piece=head,tail
 # Removes the unselected files when download is completed in BitTorrent.
 bt-remove-unselected-file=true
 # Seed previously downloaded files without verifying piece hashes.

--- a/extra/win32/ia32/engine/aria2.conf
+++ b/extra/win32/ia32/engine/aria2.conf
@@ -66,7 +66,7 @@ bt-hash-check-seed=true
 # Specify the maximum number of peers per torrent.
 bt-max-peers=128
 # Try to download first and last pieces of each file first. This is useful for previewing files.
-bt-prioritize-piece=head
+bt-prioritize-piece=head,tail
 # Removes the unselected files when download is completed in BitTorrent.
 bt-remove-unselected-file=true
 # Seed previously downloaded files without verifying piece hashes.

--- a/extra/win32/x64/engine/aria2.conf
+++ b/extra/win32/x64/engine/aria2.conf
@@ -66,7 +66,7 @@ bt-hash-check-seed=true
 # Specify the maximum number of peers per torrent.
 bt-max-peers=128
 # Try to download first and last pieces of each file first. This is useful for previewing files.
-bt-prioritize-piece=head
+bt-prioritize-piece=head,tail
 # Removes the unselected files when download is completed in BitTorrent.
 bt-remove-unselected-file=true
 # Seed previously downloaded files without verifying piece hashes.


### PR DESCRIPTION
## Description
Improved the "stream while downloading" feature by prioritizing the download of the first and last pieces of each file (`bt-prioritize-piece=head,tail`) to enable quicker file previews.

## Related Issues
None

### Checklist:

* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?  
* [x] Have you linted your code locally prior to submission?  
* [ ] Have you successfully run the app with your changes locally?  