### PR TITLE
Reduce default max-connection-per-server

### DIFF
--- a/src/main/core/ConfigManager.js
+++ b/src/main/core/ConfigManager.js
@@ -67,7 +67,7 @@ export default class ConfigManager {
         'follow-torrent': true,
         'listen-port': 21301,
         'max-concurrent-downloads': 5,
-        'max-connection-per-server': getMaxConnectionPerServer(),
+        'max-connection-per-server': 8,
         'max-download-limit': 0,
         'max-overall-download-limit': 0,
         'max-overall-upload-limit': 0,

--- a/src/main/core/ConfigManager.js
+++ b/src/main/core/ConfigManager.js
@@ -78,7 +78,7 @@ export default class ConfigManager {
         'rpc-secret': EMPTY_STRING,
         'seed-ratio': 2,
         'seed-time': 2880,
-        'split': getMaxConnectionPerServer(),
+        'split': 8,
         'user-agent': CHROME_UA
       }
       /* eslint-enable quote-props */


### PR DESCRIPTION
## Description
The maximum connections per server, if not set, currently defaults to the maximum the engine will support, 64. This seems very high for the average user. The user can always set their own value later. Reduced to a more sane default.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* N/A Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?
