### PR TITLE
fix: clear Dock Recent Documents when purging task records

### DIFF
--- a/src/renderer/components/Task/TaskActions.vue
+++ b/src/renderer/components/Task/TaskActions.vue
@@ -69,6 +69,7 @@
 </template>
 
 <script>
+  import { ipcRenderer } from 'electron'
   import { mapState } from 'vuex'
 
   import { commands } from '@/components/CommandManager/instance'
@@ -145,6 +146,7 @@
         this.$store.dispatch('task/purgeTaskRecord')
           .then(() => {
             this.$msg.success(this.$t('task.purge-record-success'))
+            ipcRenderer.send('command', 'application:clear-recent-tasks')
           })
           .catch(({ code }) => {
             if (code === 1) {


### PR DESCRIPTION
## Description
Previously, “Purge Record” only cleared in-app/aria2 history but did not clear macOS’s system-level “Recent Documents,” so Dock still showed old downloads.

## Related Issues

Fixed #1776 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?
