### PR TITLE
fix(protocol): validate commands and sanitize URIs in protocol handler

### DIFF
--- a/src/main/core/ProtocolManager.js
+++ b/src/main/core/ProtocolManager.js
@@ -7,6 +7,37 @@ import logger from './Logger'
 import protocolMap from '../configs/protocol'
 import { ADD_TASK_TYPE } from '@shared/constants'
 
+// Commands that are safe to invoke via protocol URL without arguments
+const SAFE_COMMANDS = new Set([
+  'application:task-list',
+  'application:pause-all-task',
+  'application:resume-all-task',
+  'application:preferences',
+  'application:about'
+])
+
+// Commands that accept arguments but need validation
+const ARGS_ALLOWED_COMMANDS = new Set([
+  'application:new-task',
+  'application:new-bt-task'
+])
+
+function sanitizeNewTaskArgs (args) {
+  const sanitized = {}
+  if (args.uri && typeof args.uri === 'string') {
+    // Only allow http(s), ftp, magnet, thunder URIs
+    const uri = args.uri.trim()
+    if (/^(https?|ftp|magnet|thunder):/i.test(uri)) {
+      sanitized.uri = uri
+      sanitized.type = ADD_TASK_TYPE.URI
+    } else {
+      logger.warn('[Motrix] protocol handler rejected uri:', uri)
+      return null
+    }
+  }
+  return sanitized
+}
+
 export default class ProtocolManager extends EventEmitter {
   constructor (options = {}) {
     super()
@@ -87,8 +118,31 @@ export default class ProtocolManager extends EventEmitter {
       return
     }
 
+    // Safe commands can be invoked without arguments
+    if (SAFE_COMMANDS.has(command)) {
+      global.application.sendCommandToAll(command, {})
+      return
+    }
+
+    // Commands that accept arguments require validation
+    if (!ARGS_ALLOWED_COMMANDS.has(command)) {
+      logger.warn('[Motrix] protocol handler blocked command:', command)
+      return
+    }
+
     const query = search.startsWith('?') ? search.replace('?', '') : search
     const args = parse(query)
-    global.application.sendCommandToAll(command, args)
+
+    let sanitizedArgs = null
+    if (command === 'application:new-task' || command === 'application:new-bt-task') {
+      sanitizedArgs = sanitizeNewTaskArgs(args)
+    }
+
+    if (!sanitizedArgs) {
+      logger.warn('[Motrix] protocol handler rejected args for command:', command, args)
+      return
+    }
+
+    global.application.sendCommandToAll(command, sanitizedArgs)
   }
 }


### PR DESCRIPTION
## Description

This PR fixes an injection vulnerability (CWE-79 / CWE-77) in `ProtocolManager.js` where crafted `mo://` or `motrix://` protocol URLs can pass arbitrary, unsanitized arguments to application commands — including injecting `javascript:` URIs into the renderer's "new task" dialog, leading to XSS, or invoking `reveal-in-folder` with arbitrary file paths.

The root cause is that `handleUrl()` parses the URL pathname as a command name from `protocolMap` and passes the raw query string as arguments to `sendCommandToAll()` with no validation. Since `protocolMap` includes commands like `new-task` (which renders a URI in the UI) and `reveal-in-folder` (which opens paths on disk), an attacker can craft a link like:

```
mo://new-task?uri=javascript:alert(document.cookie)
```

If the victim clicks this link (e.g., in a browser, email, or chat), Motrix opens and the malicious URI is injected directly into the renderer context.

## Vulnerability Details

- **CWE**: CWE-79 (Cross-site Scripting via protocol handler), CWE-77 (Command Injection)
- **Severity**: High — single-click exploitation, no authentication
- **Affected file**: `src/main/core/ProtocolManager.js`, `handleUrl()` method
- **Data flow**: External URL → `handleUrl(url)` → `parse(query)` → `sendCommandToAll(command, args)` → renderer processes unsanitized `args.uri`

## Proof of Concept

On macOS (after Motrix registers as protocol handler):

```bash
open "mo://new-task?uri=javascript:alert(document.cookie)"
```

On Linux:

```bash
xdg-open "mo://new-task?uri=javascript:alert(document.cookie)"
```

This opens Motrix's "new task" dialog with the `javascript:` URI pre-filled. When the renderer processes this value, it executes in the Electron context.

Similarly, path traversal via `reveal-in-folder`:

```bash
open "mo://reveal-in-folder?path=/etc/passwd"
```

## Fix Description

The fix introduces:

1. **Command allowlisting** — only explicitly listed safe commands (`SAFE_COMMANDS`) can be invoked without arguments; only `ARGS_ALLOWED_COMMANDS` can receive parameters.
2. **URI scheme validation** — for `new-task` / `new-bt-task`, only `http:`, `https:`, `ftp:`, `magnet:`, and `thunder:` schemes are permitted. All other schemes (including `javascript:`, `file:`, `data:`) are rejected.
3. **Argument sanitization** — only the `uri` field is passed through; other arbitrary query parameters are dropped.

Commands like `reveal-in-folder` are deliberately excluded from the allowed set since there's no safe way to validate arbitrary file paths from an external URL.

## Testing

- Verified that `mo://new-task?uri=https://example.com/file.zip` still works correctly (valid URI passes validation).
- Verified that `mo://new-task?uri=javascript:alert(1)` is rejected and logged as a warning.
- Verified that `mo://task-list` (no-arg safe command) still works.
- Verified that `mo://reveal-in-folder?path=/tmp` is now blocked.
- Linted with project ESLint config — no new warnings.

## Adversarial Review

Before submitting, we considered whether existing mitigations prevent exploitation. Electron's `webSecurity` and CSP settings don't help here because the `javascript:` URI is injected as a value into the application's own task-creation flow, not loaded as a navigation target. The protocol handler has no existing validation — `parse(query)` feeds raw input directly to `sendCommandToAll`. The only precondition is the victim clicking a crafted link, which is trivially achievable via phishing.

## Related Issues

None found — this has not been previously reported.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?