### PR TITLE
fix(windows): disable GPU sandbox to prevent startup crash

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -23,4 +23,8 @@ if (is.windows()) {
   app.setAppUserModelId(appId)
 }
 
+if (is.windows()) {
+  app.commandLine.appendSwitch('disable-gpu-sandbox')
+}
+
 global.launcher = new Launcher()


### PR DESCRIPTION
## Summary

Fixes a startup crash on Windows 11 build 26200 where the GPU process repeatedly fails during initialization and Motrix exits before the UI becomes usable.

Issue: #1814

## Problem

When launching Motrix normally on Windows 11 build 26200:

```text
GPU process exited unexpectedly: exit_code=-1073741515
FATAL: GPU process isn't usable. Goodbye.
```

The application exits immediately.

Testing showed:

* `--disable-gpu` → still crashes
* `--disable-gpu-sandbox` → application starts successfully

## Solution

Apply the equivalent of the working command-line workaround on Windows:

```js
if (is.windows()) {
  app.commandLine.appendSwitch('disable-gpu-sandbox')
}
```

This change is Windows-only and leaves other platforms unchanged.

## Testing

Environment:

* Windows 11 build 26200
* NVIDIA RTX 3050 Laptop GPU
* Motrix 1.8.19

Results:

* Application launches successfully
* Main window loads correctly
* Aria2 engine starts normally
* Downloads function normally
* Clean shutdown works

## Notes

The exact underlying cause inside Chromium/Electron has not been identified. However, disabling only the GPU sandbox consistently resolves the startup failure.

Closes #1814
