### PR TITLE
chore: upgrade ws dependency from 8.13.0 to 8.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "node-fetch": "^2.6.1",
-    "ws": "^8.13.0"
+    "ws": "^8.21.0"
   },
   "devDependencies": {
     "@babel/core": "^7.21.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7883,6 +7883,11 @@ ws@^8.13.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
   integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
 
+ws@^8.21.0:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
+
 xml-name-validator@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"


### PR DESCRIPTION
## Changes

Upgrade the `ws` (WebSocket) dependency from `^8.13.0` to `^8.21.0`.

### Files Changed
- `package.json` — Updated `ws` version
- `yarn.lock` — Updated lockfile
