### PR TITLE
fix(protocol): sanitize mo:// arguments and remove reveal-in-folder command

### DIFF
--- a/src/main/configs/protocol.js
+++ b/src/main/configs/protocol.js
@@ -1,11 +1,40 @@
 /* eslint quote-props: ["error", "always"] */
+
+/**
+ * Map of protocol hosts (e.g. `mo://<host>`) to the internal command
+ * dispatched via `sendCommandToAll`.
+ *
+ * NOTE: Every command listed here can be triggered by any web page that
+ * navigates the user to a `mo:`/`motrix:` URL. Only expose commands whose
+ * side effects are safe when invoked with attacker-controlled arguments.
+ * In particular, do NOT expose commands that read/write the filesystem
+ * or open OS resources based on their arguments (e.g. `reveal-in-folder`,
+ * which would let a remote page invoke `shell.showItemInFolder` with an
+ * arbitrary path).
+ */
 export default {
   'task-list': 'application:task-list',
   'new-task': 'application:new-task',
   'new-bt-task': 'application:new-bt-task',
   'pause-all-task': 'application:pause-all-task',
   'resume-all-task': 'application:resume-all-task',
-  'reveal-in-folder': 'application:reveal-in-folder',
   'preferences': 'application:preferences',
   'about': 'application:about'
+}
+
+/**
+ * Allowlist of query-string keys that may be forwarded as arguments for
+ * each protocol command. Any keys not listed here are dropped before the
+ * command is dispatched. This prevents a crafted `mo:` URL from smuggling
+ * unexpected fields (e.g. arbitrary task options, prototype-polluting
+ * keys, etc.) into internal command handlers.
+ */
+export const protocolArgsAllowlist = {
+  'task-list': ['status'],
+  'new-task': ['uri'],
+  'new-bt-task': [],
+  'pause-all-task': [],
+  'resume-all-task': [],
+  'preferences': [],
+  'about': []
 }

--- a/src/main/core/ProtocolManager.js
+++ b/src/main/core/ProtocolManager.js
@@ -4,8 +4,44 @@ import is from 'electron-is'
 import { parse } from 'querystring'
 
 import logger from './Logger'
-import protocolMap from '../configs/protocol'
+import protocolMap, { protocolArgsAllowlist } from '../configs/protocol'
 import { ADD_TASK_TYPE } from '@shared/constants'
+
+const FORBIDDEN_KEYS = ['__proto__', 'prototype', 'constructor']
+
+/**
+ * Sanitize the query object parsed from an untrusted `mo:`/`motrix:` URL.
+ *
+ * The protocol handler is reachable from any web page (a link click, a
+ * meta refresh, etc.), so query parameters must be treated as attacker
+ * controlled. This helper:
+ *   1. drops keys that could be used for prototype pollution
+ *   2. drops keys that are not on the per-command allowlist
+ *   3. coerces values to plain strings (querystring.parse can return arrays)
+ */
+const sanitizeArgs = (host, rawArgs) => {
+  const allowed = protocolArgsAllowlist[host] || []
+  const safe = Object.create(null)
+
+  for (const key of allowed) {
+    if (FORBIDDEN_KEYS.includes(key)) {
+      continue
+    }
+    if (!Object.prototype.hasOwnProperty.call(rawArgs, key)) {
+      continue
+    }
+    const value = rawArgs[key]
+    if (typeof value === 'string') {
+      safe[key] = value
+    } else if (Array.isArray(value) && typeof value[0] === 'string') {
+      // querystring.parse returns arrays when a key is repeated; only keep
+      // the first occurrence to avoid smuggling multiple values.
+      safe[key] = value[0]
+    }
+  }
+
+  return safe
+}
 
 export default class ProtocolManager extends EventEmitter {
   constructor (options = {}) {
@@ -88,7 +124,8 @@ export default class ProtocolManager extends EventEmitter {
     }
 
     const query = search.startsWith('?') ? search.replace('?', '') : search
-    const args = parse(query)
+    const rawArgs = parse(query)
+    const args = sanitizeArgs(host, rawArgs)
     global.application.sendCommandToAll(command, args)
   }
 }


### PR DESCRIPTION
## Description

This PR hardens the `mo:` / `motrix:` custom protocol handler against malicious URLs served from web pages. Because Motrix registers itself as the OS-wide handler for these schemes, any web page the user visits can hand the app a URL whose querystring is parsed and forwarded to internal command handlers. Today those arguments are neither filtered nor coerced, and one of the exposed commands (`reveal-in-folder`) reaches `shell.showItemInFolder(path)` with a fully attacker-controlled path.

This is a follow-up to #1812, which I closed after two weeks with no maintainer response. Re-opening was not possible via the API, so this is a fresh PR against the same branch with the same fix and a clearer write-up. Happy to squash, rebase, or split further on request.

## Vulnerability summary

- **Component:** `src/main/core/ProtocolManager.js` (command dispatch), `src/main/configs/protocol.js` (command map), sink in `src/main/Application.js` (`application:reveal-in-folder` handler around line 880).
- **Class:** CWE-20 / untrusted input reaching privileged Electron main-process APIs via a custom URL scheme.
- **Trigger:** A web page navigates the browser to `mo://reveal-in-folder?path=/Users/victim/.ssh` (or any other path). The browser prompts once to open Motrix; on confirm, Motrix parses the URL and dispatches:
  ```js
  const args = parse(query)            // { path: '/Users/victim/.ssh' }
  global.application.sendCommandToAll('application:reveal-in-folder', args)
  ```
  which lands in Application.js:
  ```js
  this.on('application:reveal-in-folder', (data) => {
    const { gid, path } = data
    if (path) { showItemInFolder(path) }    // shell.showItemInFolder — arbitrary path
  })
  ```
- **Secondary issue:** the other protocol commands (`new-task`, `task-list`, etc.) receive the *entire* parsed querystring with no key filtering. That means a remote page can smuggle arbitrary fields into internal command handlers, and because `querystring.parse` returns arrays for repeated keys and preserves `__proto__` as a real key, downstream code that does `Object.assign(options, args)` or similar is exposed to prototype pollution and type-confusion.

## Fix

Two small, surgical changes:

1. **`src/main/configs/protocol.js`** — remove `reveal-in-folder` from the protocol command map entirely. There is no legitimate reason for a web page to be able to point Motrix at arbitrary filesystem paths; the in-app "reveal in folder" affordance (task list context menu) is unaffected because it dispatches the command directly, not via the URL scheme.
2. **`src/main/core/ProtocolManager.js`** — add `sanitizeArgs(host, rawArgs)`:
   - drops keys not on a per-command allowlist (`new-task` → `['uri']`, `task-list` → `['status']`, others → `[]`),
   - drops `__proto__`, `prototype`, `constructor` defensively,
   - coerces values to plain strings (collapsing repeated-key arrays to their first element),
   - returns an object created with `Object.create(null)` so downstream prototype lookups can't be poisoned.

Total diff: **+69 / −3** across two files. No behavioural change for legitimate `mo://new-task?uri=...` flows, which remain the primary public use of the scheme.

## Testing

- Built and ran locally on macOS. Legitimate `mo://new-task?uri=https://example.com/file.iso` still opens the new-task dialog as before.
- `mo://reveal-in-folder?path=/etc` now hits the "protocol command not found" branch and produces no filesystem access — verified by adding a temporary `console.log` in the `reveal-in-folder` handler and confirming it is never entered.
- `mo://new-task?uri=https://example.com&__proto__[polluted]=1&extra=x` results in `args === { uri: 'https://example.com' }` — extra and `__proto__` keys are dropped; `({}).polluted` remains `undefined`.
- `mo://new-task?uri=a&uri=b` yields `{ uri: 'a' }` (first value wins, no array smuggling).
- Lint on the two changed files is clean.

## Security analysis

The finding is exploitable in the default configuration of a shipped Motrix install:

- Motrix registers `mo:` / `motrix:` as OS protocol handlers on install (see `protocols` in `package.json` and the `setup protocols client` log line in Application.js).
- Any web page can trigger `window.location = 'mo://reveal-in-folder?path=...'`. Modern browsers show a single "Open Motrix?" confirmation; there is no additional per-URL prompt and no origin check.
- `showItemInFolder` opens the containing directory in Finder/Explorer with the target selected. While this is not by itself RCE, it is a strong information-disclosure primitive (attacker learns which paths exist and forces the victim's file manager to render them, which has historically been an attack surface — Windows shell LNK/URL parsing bugs are the canonical example), and removing it also removes a useful gadget for future chains.
- The argument-sanitization portion is defence-in-depth: none of the currently-mapped commands are known to be exploitable through querystring smuggling today, but the dispatcher was previously handing raw `querystring.parse` output — including array-valued and `__proto__` keys — to every internal handler, which is a fragile invariant to rely on.

### Adversarial review

Before submitting I tried to disprove the finding. Considered:

- **"Doesn't the browser prompt gate this?"** It does, but the prompt says only "Open Motrix?" — a user who has ever clicked a legitimate `mo:` link has likely checked "always allow", and even without that the prompt is a single click. Similar single-prompt custom-scheme handlers have been the basis for a long line of CVEs.
- **"Is `reveal-in-folder` gated by a task check?"** No — the handler runs `showItemInFolder(path)` whenever `path` is truthy, with no lookup against the app's own task list.
- **"Is there a parallel unfixed path?"** Grepped for other call sites that dispatch based on parsed protocol URLs; `handleProtocol` in `ProtocolManager.js` is the sole entry point.
- **"Does removing `reveal-in-folder` from the URL map break the in-app menu?"** No — the context-menu action emits `application:reveal-in-folder` directly on the app event bus; only the URL-scheme surface is removed.

## Proof of concept

Save as `poc.html`, open in a browser on a machine with Motrix installed, and click each button. Confirm the "Open Motrix?" prompt when it appears.

```html
<!doctype html>
<meta charset="utf-8">
<title>Motrix mo:// PoC</title>
<button onclick="location='mo://reveal-in-folder?path=/etc'">
  1. Reveal /etc in Finder (pre-fix: opens Finder; post-fix: no-op)
</button>
<button onclick="location='mo://new-task?uri=https://example.com/x.iso&__proto__[polluted]=1&secret=y'">
  2. new-task with extra + __proto__ keys (pre-fix: all forwarded; post-fix: only uri)
</button>
```

To observe the argument object on the main-process side, temporarily add `logger.info('args', args)` at the end of `handleProtocol` in `ProtocolManager.js` and watch `~/Library/Logs/Motrix/main.log` (macOS) or the equivalent on your platform.

## Related Issues

Supersedes #1812 (closed for inactivity, could not be reopened via the API).

### Checklist

- [x] Checked existing PRs — this supersedes #1812; no other open PR touches these files.
- [x] Linted the changed files locally.
- [x] Built and ran the app locally with the changes on macOS.