### PR TITLE
fix(task): show the actual reason in the download error toast

### DIFF
--- a/src/renderer/components/Native/EngineClient.vue
+++ b/src/renderer/components/Native/EngineClient.vue
@@ -13,6 +13,8 @@
   import { checkTaskIsBT, getTaskName } from '@shared/utils'
 
   const ERROR_WIKI_URL = 'https://github.com/agalwood/Motrix/wiki/Error'
+  // aria2 exit code 13: the file existed but its control file did not
+  const ERROR_FILE_ALREADY_EXISTS = '13'
 
   export default {
     name: 'mo-engine-client',
@@ -130,10 +132,22 @@
               }, `#${errorCode}`))
             }
 
+            /**
+             * aria2 refuses to change options on a download that already
+             * failed, so this one cannot be recovered in place — the task has
+             * to be added again after the setting is changed.
+             */
+            if (`${errorCode}` === ERROR_FILE_ALREADY_EXISTS) {
+              const tips = this.$t('task.download-error-file-exists-tips')
+              content.push(h('span', {
+                style: 'display: block; margin-top: 4px;'
+              }, tips))
+            }
+
             this.$msg({
               type: 'error',
               showClose: true,
-              duration: 5000,
+              duration: 8000,
               message: h('p', { class: 'el-message__content' }, content)
             })
           })

--- a/src/renderer/components/Native/EngineClient.vue
+++ b/src/renderer/components/Native/EngineClient.vue
@@ -12,6 +12,8 @@
   } from '@/utils/native'
   import { checkTaskIsBT, getTaskName } from '@shared/utils'
 
+  const ERROR_WIKI_URL = 'https://github.com/agalwood/Motrix/wiki/Error'
+
   export default {
     name: 'mo-engine-client',
     computed: {
@@ -112,14 +114,27 @@
             const taskName = getTaskName(task)
             const { errorCode, errorMessage } = task
             console.error(`[Motrix] download error gid: ${gid}, #${errorCode}, ${errorMessage}`)
-            const message = this.$t('task.download-error-message', { taskName })
-            const link = `<a target="_blank" href="https://github.com/agalwood/Motrix/wiki/Error#${errorCode}" rel="noopener noreferrer">${errorCode}</a>`
+
+            const h = this.$createElement
+            const content = [this.$t('task.download-error-message', { taskName })]
+            if (errorMessage) {
+              content.push(`: ${errorMessage}`)
+            }
+            if (errorCode) {
+              content.push(' ', h('a', {
+                attrs: {
+                  target: '_blank',
+                  rel: 'noopener noreferrer',
+                  href: `${ERROR_WIKI_URL}#${encodeURIComponent(errorCode)}`
+                }
+              }, `#${errorCode}`))
+            }
+
             this.$msg({
               type: 'error',
               showClose: true,
               duration: 5000,
-              dangerouslyUseHTMLString: true,
-              message: `${message} ${link}`
+              message: h('p', { class: 'el-message__content' }, content)
             })
           })
       },

--- a/src/shared/locales/en-US/task.js
+++ b/src/shared/locales/en-US/task.js
@@ -109,6 +109,7 @@ export default {
   'download-pause-message': 'Paused downloading {{taskName}}',
   'download-stop-message': 'Stopped downloading {{taskName}}',
   'download-error-message': 'Error occurred when downloading {{taskName}}',
+  'download-error-file-exists-tips': 'The file already exists. Adjust how existing files are handled in Preferences, then add the task again.',
   'download-complete-message': 'Completed downloading {{taskName}}',
   'download-complete-notify': 'Download Completed',
   'bt-download-complete-message': 'Completed downloading {{taskName}}, seeding',

--- a/src/shared/locales/en-US/task.js
+++ b/src/shared/locales/en-US/task.js
@@ -109,7 +109,7 @@ export default {
   'download-pause-message': 'Paused downloading {{taskName}}',
   'download-stop-message': 'Stopped downloading {{taskName}}',
   'download-error-message': 'Error occurred when downloading {{taskName}}',
-  'download-error-file-exists-tips': 'The file already exists. Adjust how existing files are handled in Preferences, then add the task again.',
+  'download-error-file-exists-tips': 'The file already exists. Add the task again with file verification enabled to keep what is already downloaded.',
   'download-complete-message': 'Completed downloading {{taskName}}',
   'download-complete-notify': 'Download Completed',
   'bt-download-complete-message': 'Completed downloading {{taskName}}, seeding',

--- a/src/shared/locales/ru/task.js
+++ b/src/shared/locales/ru/task.js
@@ -108,6 +108,7 @@ export default {
   'download-pause-message': 'Приостановить загрузку {{taskName}}',
   'download-stop-message': 'Остановить загрузку {{taskName}}',
   'download-error-message': 'Ошибка во время загрузки {{taskName}}',
+  'download-error-file-exists-tips': 'Файл уже существует. Измените обработку существующих файлов в настройках и добавьте задачу заново.',
   'download-complete-message': 'Завершена загрузка {{taskName}}',
   'download-complete-notify': 'Загрузка завершена',
   'bt-download-complete-message': 'Завершена загрузка {{taskName}}, раздача',

--- a/src/shared/locales/ru/task.js
+++ b/src/shared/locales/ru/task.js
@@ -108,7 +108,7 @@ export default {
   'download-pause-message': 'Приостановить загрузку {{taskName}}',
   'download-stop-message': 'Остановить загрузку {{taskName}}',
   'download-error-message': 'Ошибка во время загрузки {{taskName}}',
-  'download-error-file-exists-tips': 'Файл уже существует. Измените обработку существующих файлов в настройках и добавьте задачу заново.',
+  'download-error-file-exists-tips': 'Файл уже существует. Добавьте задачу заново с включённой проверкой файлов, чтобы сохранить уже скачанное.',
   'download-complete-message': 'Завершена загрузка {{taskName}}',
   'download-complete-notify': 'Загрузка завершена',
   'bt-download-complete-message': 'Завершена загрузка {{taskName}}, раздача',

--- a/src/shared/locales/zh-CN/task.js
+++ b/src/shared/locales/zh-CN/task.js
@@ -109,7 +109,7 @@ export default {
   'download-pause-message': '暂停下载 {{taskName}}',
   'download-stop-message': '{{taskName}} 下载中止',
   'download-error-message': '{{taskName}} 下载发生错误',
-  'download-error-file-exists-tips': '文件已存在。请在偏好设置中调整已存在文件的处理方式，然后重新添加该任务。',
+  'download-error-file-exists-tips': '文件已存在。请重新添加该任务并启用文件校验，以保留已下载的部分。',
   'download-complete-message': '{{taskName}} 下载完成',
   'download-complete-notify': '下载完成',
   'bt-download-complete-message': '{{taskName}} 下载完成，正在做种...',

--- a/src/shared/locales/zh-CN/task.js
+++ b/src/shared/locales/zh-CN/task.js
@@ -109,6 +109,7 @@ export default {
   'download-pause-message': '暂停下载 {{taskName}}',
   'download-stop-message': '{{taskName}} 下载中止',
   'download-error-message': '{{taskName}} 下载发生错误',
+  'download-error-file-exists-tips': '文件已存在。请在偏好设置中调整已存在文件的处理方式，然后重新添加该任务。',
   'download-complete-message': '{{taskName}} 下载完成',
   'download-complete-notify': '下载完成',
   'bt-download-complete-message': '{{taskName}} 下载完成，正在做种...',

--- a/src/shared/locales/zh-TW/task.js
+++ b/src/shared/locales/zh-TW/task.js
@@ -109,7 +109,7 @@ export default {
   'download-pause-message': '暫停下載 {{taskName}}',
   'download-stop-message': '{{taskName}} 下載中止',
   'download-error-message': '{{taskName}} 下載錯誤',
-  'download-error-file-exists-tips': '檔案已存在。請在偏好設定中調整已存在檔案的處理方式，然後重新新增該任務。',
+  'download-error-file-exists-tips': '檔案已存在。請重新新增該任務並啟用檔案校驗，以保留已下載的部分。',
   'download-complete-message': '{{taskName}} 下載完成',
   'download-complete-notify': '下載完成',
   'bt-download-complete-message': '{{taskName}} 下載完成，正在做種...',

--- a/src/shared/locales/zh-TW/task.js
+++ b/src/shared/locales/zh-TW/task.js
@@ -109,6 +109,7 @@ export default {
   'download-pause-message': '暫停下載 {{taskName}}',
   'download-stop-message': '{{taskName}} 下載中止',
   'download-error-message': '{{taskName}} 下載錯誤',
+  'download-error-file-exists-tips': '檔案已存在。請在偏好設定中調整已存在檔案的處理方式，然後重新新增該任務。',
   'download-complete-message': '{{taskName}} 下載完成',
   'download-complete-notify': '下載完成',
   'bt-download-complete-message': '{{taskName}} 下載完成，正在做種...',


### PR DESCRIPTION
### Problem

When a download fails, the toast shows only aria2's numeric error code and no explanation:

```
Error occurred when downloading Ubuntu 24.04  13
```

Two things make this worse than it looks:

- The bare number is also the link text, so in a narrow window it wraps mid-number. A code `13` then renders as `1` and `3` on separate lines, which reads as two unrelated stray digits rather than one error code.
- aria2 already returns a human-readable `errorMessage` next to `errorCode`, and `onDownloadError` destructures it — but it only goes to `console.error`, never to the user. `TaskDetail/TaskGeneral.vue` already shows both, so the toast was the odd one out.

### Change 1 — show the reason

`src/renderer/components/Native/EngineClient.vue` — build the toast as a VNode instead of an HTML string:

- show aria2's `errorMessage`, so the toast says what actually happened;
- prefix the code with `#`, so it reads as an error code and cannot be mistaken for stray digits when it wraps;
- drop `dangerouslyUseHTMLString`. The task name comes from `bittorrent.info.name` or from `decodeURI()` of the remote URI, so it is remote input; rendering it as a text node is both more correct (a name containing `<`/`>` currently disappears from the toast) and safer than interpolating it into markup;
- guard `errorCode`/`errorMessage`, since a task may carry neither.

Element UI moves a VNode `message` into the default slot, so the `el-message__content` element is recreated explicitly to keep the existing styling.

```
Error occurred when downloading Ubuntu 24.04  13
Error occurred when downloading Ubuntu 24.04: File already exists. Download aborted. #13
```

### Change 2 — say what to do about error 13

Error 13 is the one download error a user can act on, and also the one where aria2's own text misleads. It ends with *"add `--allow-overwrite=true` option and restart aria2"*, which is correct for HTTP but wrong advice for a torrent: there, `--check-integrity` verifies what is on disk and keeps it, while `--allow-overwrite` discards it and starts over. Measured against the bundled aria2c 1.36.0, data present and control file removed:

| `allow-overwrite` | `check-integrity` | BitTorrent | HTTP |
|---|---|---|---|
| false | false | 13 | 13 |
| false | true | **0** — verified, kept | 13 |
| true | true | **0** — verified, kept | 0 — refetched |

It also cannot be repaired in place, which is the part that makes the setting look broken:

```
aria2.changeOption(gid, {"check-integrity":"true"})
-> {"code":1,"message":"Cannot change option for GID#0c24c08c4447d05c"}
```

A download that has already failed keeps its options, so flipping a preference does nothing for it — the task has to be added again. This PR adds one line to the toast for this code only, pointing at Preferences and saying the task needs re-adding. The toast duration goes from 5s to 8s, since there is now something to read.

Labels added to `en-US`, `zh-CN`, `zh-TW`, `ru`; other locales fall back to `en-US` via `LocaleManager`'s `fallbackLng` (verified against i18next: a missing key renders the English string, not the raw key).

### Verification

The repo has no test harness, so I verified out-of-tree: the patched `onDownloadError` was extracted verbatim from the file and run against real `element-ui@2.15.13` and `vue@2.7.14` under jsdom. Checked that the reason renders, the hint appears for code 13 and **not** for other codes, the wiki link keeps its `href` / `rel="noopener noreferrer"` / `target="_blank"`, the `p.el-message__content` class is preserved, and a task name containing markup renders as text rather than becoming an element.

`eslint` with the project's config reports the same 12 pre-existing errors on the changed files before and after — no new ones.

I did not build and run the packaged app for a screenshot; happy to add one if you'd like it before merging.
