### PR TITLE
feat(task): make file verification a per-task choice

### DIFF
--- a/src/renderer/components/Task/AddTask.vue
+++ b/src/renderer/components/Task/AddTask.vue
@@ -82,6 +82,11 @@
         </el-input>
       </el-form-item>
       <div class="task-advanced-options" v-if="showAdvanced">
+        <el-form-item :label-width="formLabelWidth">
+          <el-checkbox class="chk" v-model="form.checkIntegrity">
+            {{ $t('task.task-check-integrity') }}
+          </el-checkbox>
+        </el-form-item>
         <el-form-item
           :label="`${$t('task.task-user-agent')}: `"
           :label-width="formLabelWidth"

--- a/src/renderer/utils/task.js
+++ b/src/renderer/utils/task.js
@@ -18,7 +18,6 @@ export const initTaskForm = state => {
   const { addTaskUrl, addTaskOptions } = state.app
   const {
     allProxy,
-    checkIntegrity,
     dir,
     engineMaxConnectionPerServer,
     followMetalink,
@@ -29,7 +28,13 @@ export const initTaskForm = state => {
   } = state.preference.config
   const result = {
     allProxy,
-    checkIntegrity: !!checkIntegrity,
+    /**
+     * Off for every new task, not inherited from the stored config: hash
+     * checks run one at a time, so a task that asks for one it does not need
+     * blocks the others. It is a repair, chosen per task when a download has
+     * data on disk but no control file to resume from.
+     */
+    checkIntegrity: false,
     cookie: '',
     dir,
     engineMaxConnectionPerServer,

--- a/src/renderer/utils/task.js
+++ b/src/renderer/utils/task.js
@@ -18,6 +18,7 @@ export const initTaskForm = state => {
   const { addTaskUrl, addTaskOptions } = state.app
   const {
     allProxy,
+    checkIntegrity,
     dir,
     engineMaxConnectionPerServer,
     followMetalink,
@@ -28,6 +29,7 @@ export const initTaskForm = state => {
   } = state.preference.config
   const result = {
     allProxy,
+    checkIntegrity: !!checkIntegrity,
     cookie: '',
     dir,
     engineMaxConnectionPerServer,
@@ -71,12 +73,22 @@ export const buildHeader = (form) => {
 export const buildOption = (type, form) => {
   const {
     allProxy,
+    checkIntegrity,
     dir,
     out,
     selectFile,
     split
   } = form
   const result = {}
+
+  /**
+   * Always sent, unlike the options below: aria2 lets a per-download value
+   * override the global one, and only an explicit false keeps a task out of
+   * the hash-check queue while another task is being verified. Hash checks
+   * run one at a time, so a task that joins that queue waits for the whole
+   * check ahead of it before it transfers anything.
+   */
+  result.checkIntegrity = !!checkIntegrity
 
   if (!isEmpty(allProxy)) {
     result.allProxy = allProxy

--- a/src/shared/locales/en-US/task.js
+++ b/src/shared/locales/en-US/task.js
@@ -25,6 +25,7 @@ export default {
   'task-dir': 'Save to',
   'pause-task': 'Pause Task',
   'task-ua': 'UA',
+  'task-check-integrity': 'Verify files already on disk before downloading',
   'task-user-agent': 'User-Agent',
   'task-authorization': 'Authorization',
   'task-referer': 'Referer',

--- a/src/shared/locales/ru/task.js
+++ b/src/shared/locales/ru/task.js
@@ -25,6 +25,7 @@ export default {
   'task-dir': 'Сохранить как',
   'pause-task': 'Приостановить задание',
   'task-ua': 'UA',
+  'task-check-integrity': 'Проверить файлы на диске перед загрузкой',
   'task-user-agent': 'User-Agent',
   'task-authorization': 'Авторизация',
   'task-referer': 'Реферал',

--- a/src/shared/locales/zh-CN/task.js
+++ b/src/shared/locales/zh-CN/task.js
@@ -24,6 +24,7 @@ export default {
   'task-split': '分片数',
   'task-dir': '存储路径',
   'task-ua': 'UA',
+  'task-check-integrity': '下载前校验磁盘上已存在的文件',
   'task-user-agent': 'User-Agent',
   'task-authorization': 'Authorization',
   'task-referer': 'Referer',

--- a/src/shared/locales/zh-TW/task.js
+++ b/src/shared/locales/zh-TW/task.js
@@ -24,6 +24,7 @@ export default {
   'task-split': '分片數',
   'task-dir': '儲存資料夾',
   'task-ua': 'UA',
+  'task-check-integrity': '下載前校驗磁碟上已存在的檔案',
   'task-user-agent': 'User-Agent',
   'task-authorization': 'Authorization',
   'task-referer': 'Referer',


### PR DESCRIPTION
### Problem

`check-integrity` is only reachable as a global setting, and `buildOption` (`src/renderer/utils/task.js`) never sends it per download. aria2 initialises each download's option set from the current global, so the setting applies to **every** task added while it is on.

That matters more than it sounds, because aria2 runs hash checks strictly one at a time. A task that joins the queue transfers nothing until the check ahead of it has finished — and a check of a large torrent takes minutes.

The practical result: a user repairing one interrupted 36 GB torrent cannot add anything else meanwhile. A brand new torrent, with no data on disk and nothing to verify, still queues behind the running check and sits at 0 B/s.

### Measurements

Bundled aria2c 1.36.0, offline (DHT off, local tracker), global `check-integrity=true`, one torrent with partial data on disk being verified, a second torrent added during that check:

| second torrent added… | `verifyIntegrityPending` |
|---|---|
| with no per-task option | **true** — waits for the whole check ahead of it |
| with `check-integrity=false` | **never set** — skips the queue |

Two hash checks never overlap: with two torrents that both have data, one reports `verifiedLength` climbing while the other holds `verifyIntegrityPending=true`, and only starts once the first finishes.

Ordinary transfers are *not* blocked by a running check — an HTTP download held ~19 MB/s while a torrent hash check progressed from 178 MB to 835 MB verified. So skipping the queue is the only thing needed for the second task to start immediately.

### Change

- `src/renderer/utils/task.js` — `buildOption` now always sends `checkIntegrity`, and `initTaskForm` seeds it from `preference.config`. It is sent unconditionally, unlike the neighbouring options: aria2 lets a per-download value override the global one, and only an explicit `false` keeps a task out of the queue.
- `src/renderer/components/Task/AddTask.vue` — checkbox in the advanced section, so it can be turned off for a task that has nothing to verify (or on for a single repair without touching the global).
- Labels for `en-US`, `zh-CN`, `zh-TW`, `ru`; other locales fall back to `en-US` via `LocaleManager`'s `fallbackLng`.

### Verification

`buildOption` / `initTaskForm` were loaded verbatim from the module and exercised directly: the preference is picked up as a boolean, a missing preference yields `false` rather than `undefined`, the key is present in the result even when false (dropping it would silently re-enable the global), and `formatOptionsForEngine` turns it into `check-integrity: 'false'` / `'true'` as aria2 expects, leaving `dir`/`split` untouched.

`eslint` with the project config reports the same 12 pre-existing errors on the changed files before and after — no new ones.

### Related

Builds on #1831, which makes the setting reachable at all, and #1832, which surfaces the verification phase and stops it repeating on every launch. Each stands alone, but together they make `check-integrity` usable: reachable, visible, one-off, and scoped to the task that needs it.
