### PR TITLE
chore(release): prepare 2.0.0-beta.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
       version: ${{ steps.metadata.outputs.version }}
       prerelease: ${{ steps.metadata.outputs.prerelease }}
       channel: ${{ steps.metadata.outputs.channel }}
+      release_notes_path: ${{ steps.release_notes.outputs.path }}
       container_version: ${{ steps.container.outputs.container_version }}
       container_prerelease: ${{ steps.container.outputs.container_prerelease }}
       container_dockerhub_repository: ${{ steps.container.outputs.container_dockerhub_repository }}
@@ -64,6 +65,26 @@ jobs:
           node scripts/release-metadata.mjs
           --package-json package.json
           --github-output "$GITHUB_OUTPUT"
+
+      - name: Validate release notes
+        id: release_notes
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ steps.metadata.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$RELEASE_VERSION" =~ ^[0-9A-Za-z.+-]+$ ]] ||
+            [[ "$RELEASE_VERSION" == *'..'* ]]; then
+            printf 'Unsafe release version for release-notes path: %s\n' \
+              "$RELEASE_VERSION" >&2
+            exit 1
+          fi
+          release_notes_path="docs/release-notes/${RELEASE_VERSION}.md"
+          if [[ ! -f "$release_notes_path" ]]; then
+            printf 'Missing release notes: %s\n' "$release_notes_path" >&2
+            exit 1
+          fi
+          printf 'path=%s\n' "$release_notes_path" >> "$GITHUB_OUTPUT"
 
       - name: Resolve container release metadata
         id: container
@@ -215,6 +236,7 @@ jobs:
         run: >-
           pnpm exec electron-builder
           ${{ matrix.electron_builder_args }}
+          -c.mac.bundleVersion=${{ github.run_number }}.${{ github.run_attempt }}.0
           --publish never
 
       - name: Electron Builder (Linux)
@@ -747,7 +769,7 @@ jobs:
           EXPECTED_COMMIT: ${{ github.sha }}
           EXPECTED_PLATFORM: ${{ matrix.platform }}
           # Updated only after reviewing the verifier source itself.
-          VERIFIER_SHA256: ef9db8b8e669233c44077791ae7672462fcc5153463fb304287be69411c9a809
+          VERIFIER_SHA256: 948f13ec32c0239a35fd69811a15e2ffa8ab0ba86a6eee95bcef46569c7f68a5
         run: |
           const crypto = require('node:crypto')
           const fs = require('node:fs')
@@ -882,6 +904,7 @@ jobs:
           node node_modules/electron-builder/out/cli/cli.js
           --config electron-builder.signing.json
           ${{ matrix.electron_builder_args }}
+          -c.mac.bundleVersion=${{ github.run_number }}.${{ github.run_attempt }}.0
           --publish never
 
       - name: Electron Builder (Windows signing boundary)
@@ -1044,6 +1067,11 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
       - name: Download validated release
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1053,6 +1081,7 @@ jobs:
       - name: Publish validated GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
+          body_path: ${{ needs.preflight.outputs.release_notes_path }}
           generate_release_notes: true
           fail_on_unmatched_files: true
           prerelease: ${{ needs.preflight.outputs.prerelease }}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ The same core powers two ways to run Motrix:
 - **Desktop app:** Runs on macOS, Windows, and Linux
 - **Headless server:** Runs without a desktop environment, either directly on Node.js or in Docker, and includes a web UI for NAS devices and home servers
 
+## 🧪 Beta testing
+
+Motrix Turbo v2 is currently in beta. Download
+[v2.0.0-beta.1 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.1)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.1.md)
+before installing it.
+
+Back up your existing Motrix data and downloads before testing. Migration from
+Motrix v1 data has not yet been validated, so do not use your only copy of v1
+data with this beta. When practical, test v2 in parallel using a separate OS
+account, machine, or Docker data directory.
+
 ## Screenshots
 
 ### Dashboard
@@ -102,13 +114,19 @@ Plugins run inside a QuickJS sandbox. Each plugin declares the host capabilities
 
 Download Motrix from [motrix.app](https://motrix.app) and choose the package for your operating system. Most Mac users should choose the Apple Silicon build; Intel builds are available for older Macs with Intel processors.
 
-Available package formats:
+The current beta desktop packages are distributed through the GitHub
+prerelease linked above, with Snap available from its edge channel. Choose the
+package that matches your operating system and architecture:
 
-| Platform | Formats | Recommendation |
-|----------|---------|----------------|
-| macOS | `.dmg` / `.zip` | The Apple Silicon `.dmg` is recommended; use the Intel build only on an Intel-based Mac |
-| Windows | `.exe` (NSIS installer) / `.zip` | The `.exe` installer is the best choice for most users; use `.zip` for a manually extracted copy |
-| Linux | `.AppImage` / `.deb` / `.rpm`, plus Flatpak and Snap | Use `.deb` on Debian or Ubuntu, `.rpm` on Fedora or openSUSE, or `.AppImage` to run Motrix without installing it |
+| Platform | Architectures | Packages / channel | Recommendation |
+|----------|---------------|--------------------|----------------|
+| macOS 12+ | `arm64` (Apple Silicon), `x64` (Intel) | `.dmg` / `.zip` | Use the `.dmg` matching your Mac; choose `x64` only for an Intel-based Mac |
+| Windows | `x64` | `.exe` (NSIS installer) / `.zip` | Use the `.exe` installer for a normal installation or `.zip` for a manually extracted copy |
+| Linux | `x64`, `arm64` | `.deb` / `.rpm`; Snap `latest/edge` | Use `.deb` on Debian or Ubuntu, `.rpm` on Fedora or openSUSE, or the edge Snap for beta testing |
+
+This beta does not publish an AppImage. Flatpak is validated separately and is
+not published by the release tag. Windows `arm64` and all 32-bit packages are
+not available.
 
 ### Command-line client
 
@@ -121,12 +139,14 @@ You can also install it from Settings → Integration → Command-line tools in 
 ### Headless server with Docker
 
 Tagged releases publish a multi-architecture Server image to Docker Hub and
-GHCR. The included `compose.yaml` pulls Docker Hub by default and keeps Server
-state separate from downloaded resources:
+GHCR. Beta releases publish only the immutable version tag and do not update
+`latest`; the included `compose.yaml` keeps Server state separate from
+downloaded resources:
 
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.1'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait
@@ -161,8 +181,8 @@ diagnostics, and backup/upgrade instructions.
 Development requires Node.js 22 or later and pnpm. Use the pnpm version specified by the `packageManager` field in `package.json`.
 
 ```bash
-git clone https://gitlab.com/agalwood/motrix-turbo.git
-cd motrix-turbo
+git clone https://github.com/agalwood/Motrix.git
+cd Motrix
 
 pnpm install     # Install dependencies, download aria2 for your platform, and rebuild native modules
 pnpm start       # Start the Electron app in development mode with Vite HMR in the renderer

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,6 +19,16 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 - **桌面应用**：可在 macOS、Windows 和 Linux 上运行；
 - **Headless server**：无需桌面环境，可直接使用 Node.js 运行或通过 Docker 部署，并提供 Web 界面，适合安装在 NAS 和家庭服务器上。
 
+## 🧪 Beta 测试
+
+Motrix Turbo v2 目前仍处于 beta 阶段。安装前请从 GitHub Releases
+下载 [v2.0.0-beta.1](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.1)，
+并阅读[完整发布说明](./docs/release-notes/2.0.0-beta.1.zh-CN.md)。
+
+测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
+验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
+账户、设备或 Docker 数据目录与现有环境并行测试 v2。
+
 ## 应用截图
 
 ### 仪表盘
@@ -102,13 +112,17 @@ pnpm create motrix-plugin my-plugin
 
 访问 Motrix 官网 [motrix.app](https://motrix.app)，选择对应操作系统的安装包。macOS 用户通常下载 Apple Silicon 版本即可；如果使用较早的 Intel 芯片 Mac，请选择 Intel 版本。
 
-各平台提供以下安装格式：
+当前 beta 桌面安装包通过上方链接的 GitHub 预发布版提供，Snap 则通过
+edge 通道提供。请根据操作系统和架构选择安装包：
 
-| 平台 | 可用格式 | 选择建议 |
-|------|----------|----------|
-| macOS | `.dmg` / `.zip` | 推荐下载 Apple Silicon 版的 `.dmg`；Intel 版只适用于旧款 Intel Mac |
-| Windows | `.exe`（NSIS 安装包）/ `.zip` | 大多数用户可直接使用 `.exe` 安装包；`.zip` 可解压后使用 |
-| Linux | `.AppImage` / `.deb` / `.rpm`，另提供 Flatpak 与 Snap | Debian、Ubuntu 等发行版使用 `.deb`，Fedora、openSUSE 等发行版使用 `.rpm`；`.AppImage` 无需安装即可运行 |
+| 平台 | 架构 | 安装包 / 通道 | 选择建议 |
+|------|------|---------------|----------|
+| macOS 12+ | `arm64`（Apple Silicon）、`x64`（Intel） | `.dmg` / `.zip` | 选择与 Mac 架构匹配的 `.dmg`；仅 Intel Mac 使用 `x64` |
+| Windows | `x64` | `.exe`（NSIS 安装包）/ `.zip` | 常规安装使用 `.exe`；`.zip` 可解压后手动运行 |
+| Linux | `x64`、`arm64` | `.deb` / `.rpm`；Snap `latest/edge` | Debian 或 Ubuntu 使用 `.deb`，Fedora 或 openSUSE 使用 `.rpm`；beta 测试也可使用 edge Snap |
+
+本 beta 不发布 AppImage。Flatpak 会单独验证，不会随该版本 tag 发布。
+同时不提供 Windows `arm64` 和任何 32 位安装包。
 
 ### 命令行客户端
 
@@ -120,13 +134,14 @@ npm install -g @motrix/cli
 
 ### Headless server（Docker）
 
-带 tag 的正式版本会把多架构 Server 镜像发布到 Docker Hub 和 GHCR。仓库的
-`compose.yaml` 默认从 Docker Hub 拉取，并分别持久化 Server 状态与用户下载
-资源：
+带 tag 的版本会把多架构 Server 镜像发布到 Docker Hub 和 GHCR。
+Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compose.yaml`
+会分别持久化 Server 状态与用户下载资源：
 
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.1'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait
@@ -158,8 +173,8 @@ DSM 7 和飞牛 fnOS 安装、目录所有权、端口、诊断与备份/升级�
 开发前请先安装 Node.js 22+ 和 pnpm。pnpm 版本以 `package.json` 中的 `packageManager` 字段为准。
 
 ```bash
-git clone https://gitlab.com/agalwood/motrix-turbo.git
-cd motrix-turbo
+git clone https://github.com/agalwood/Motrix.git
+cd Motrix
 
 pnpm install     # 安装依赖（postinstall 自动下载适用于本机系统的 aria2，并重建原生模块）
 pnpm start       # 启动 Electron 开发模式（renderer 使用 Vite HMR）

--- a/docs/release-notes/2.0.0-beta.1.md
+++ b/docs/release-notes/2.0.0-beta.1.md
@@ -1,0 +1,73 @@
+# Motrix 2.0.0-beta.1
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.1/docs/release-notes/2.0.0-beta.1.zh-CN.md)
+
+Motrix 2.0.0-beta.1 is the first public beta of Motrix Turbo, the rebuilt v2
+desktop app and headless server. It starts public validation of the shared
+download core, MDXP integrations, and sandboxed plugin system.
+
+## Highlights
+
+- A ground-up desktop rebuild with Electron 43, React 19, and TypeScript 7,
+  including a customizable Dashboard, dark mode, a cross-platform application
+  menu, and clearer task-inspector feedback.
+- One host-neutral download core for both the desktop app and the new Node/Web
+  Server, with SQLite session recovery, tracker management, UPnP/NAT-PMP, and
+  HTTP, FTP, BitTorrent, and magnet support.
+- MDXP-based integration for the official CLI and browser handoff, including
+  secure local discovery and device-code pairing for remote Server instances.
+- A QuickJS plugin sandbox with capability consent, signed builtin plugins,
+  and an in-app plugin marketplace.
+- Persistent, multi-architecture Server containers for NAS and home-server
+  deployments, published to both Docker Hub and GHCR.
+- A rebuilt release pipeline with isolated macOS and Windows signing, package
+  verification, third-party notices, and an SPDX SBOM.
+
+## Before testing
+
+This is prerelease software. Back up your existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Please do not rely on this beta for your only copy of
+important downloads.
+
+## What to test
+
+- HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
+  session recovery
+- Desktop integrations, browser and CLI handoff through MDXP, and sandboxed
+  plugins
+- Headless Server deployment, persistent storage, and remote pairing
+
+## Available downloads
+
+| Distribution | Architectures | Published output |
+|--------------|---------------|------------------|
+| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | DEB and RPM |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.1` tag in both registries |
+| Snap Store | `amd64`, `arm64` | `latest/edge` |
+
+Container images are available as
+`docker.io/motrixapp/motrix-server:2.0.0-beta.1` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.1`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.1/docs/docker-server.md)
+for storage, networking, and upgrade guidance.
+
+## Known distribution limits
+
+- AppImage is not published for this beta.
+- Flatpak is validated separately and is not published by the release tag.
+- Windows `arm64` and all 32-bit packages are not available.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.1.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.1.zh-CN.md
@@ -1,0 +1,62 @@
+# Motrix 2.0.0-beta.1
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.1/docs/release-notes/2.0.0-beta.1.md) | 简体中文
+
+Motrix 2.0.0-beta.1 是 Motrix Turbo 的首个公开 beta，包含重新开发的 v2
+桌面应用和 Headless server。该版本开始公开验证共用下载内核、MDXP 集成和
+沙箱化插件系统。
+
+## 主要变化
+
+- 使用 Electron 43、React 19 和 TypeScript 7 从头重建桌面应用，提供可自定义
+  Dashboard、深色模式、跨平台应用菜单，以及更清晰的任务检查器反馈。
+- 桌面应用和全新的 Node/Web Server 共用与宿主无关的下载内核，支持 SQLite
+  session 恢复、Tracker 管理、UPnP/NAT-PMP，以及 HTTP、FTP、BitTorrent 和
+  磁力链接下载。
+- 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地安全发现及远程 Server
+  的 device-code 配对。
+- 提供带能力授权的 QuickJS 插件沙箱、已签名的内置插件和应用内插件市场。
+- 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器，并同时发布到
+  Docker Hub 与 GHCR。
+- 重建发布流水线，隔离 macOS 与 Windows 签名步骤，并加入安装包验证、
+  第三方声明和 SPDX SBOM。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1
+数据的迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
+
+条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录与现有环境
+并行测试 v2。请勿让本 beta 成为重要下载文件的唯一存储位置。
+
+## 建议测试项
+
+- HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
+- 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
+- Headless Server 部署、数据持久化和远程配对
+
+## 可用下载
+
+| 发布方式 | 架构 | 发布产物 |
+|----------|------|----------|
+| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
+| Windows | `x64` | NSIS 安装包（`.exe`）和 ZIP |
+| Linux | `x64`、`arm64` | DEB 和 RPM |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中均发布不可变 tag `2.0.0-beta.1` |
+| Snap Store | `amd64`、`arm64` | `latest/edge` |
+
+容器镜像地址为 `docker.io/motrixapp/motrix-server:2.0.0-beta.1` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.1`。数据持久化、网络和升级方法请参阅
+[Docker Server 部署指南](../docker-server.zh-CN.md)。
+
+## 已知发布限制
+
+- 本 beta 不发布 AppImage。
+- Flatpak 会单独验证，不会随该版本 tag 发布。
+- 不提供 Windows `arm64` 和任何 32 位安装包。
+- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
+
+## 反馈
+
+请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现的问题，
+并附上操作系统、架构、安装包类型和复现步骤。

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -95,6 +95,8 @@
     "category": "public.app-category.utilities",
     "type": "distribution",
     "artifactName": "${productName}-${version}-${arch}.${ext}",
+    "bundleShortVersion": "2.0.0",
+    "bundleVersion": "2.0.1",
     "minimumSystemVersion": "12.0",
     "hardenedRuntime": true,
     "gatekeeperAssess": false,

--- a/electron-builder.signing.json
+++ b/electron-builder.signing.json
@@ -96,6 +96,8 @@
     "category": "public.app-category.utilities",
     "type": "distribution",
     "artifactName": "${productName}-${version}-${arch}.${ext}",
+    "bundleShortVersion": "2.0.0",
+    "bundleVersion": "2.0.1",
     "minimumSystemVersion": "12.0",
     "hardenedRuntime": true,
     "gatekeeperAssess": false,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0",
+  "version": "2.0.0-beta.1",
   "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1",
   "description": "A full-featured download manager",
   "keywords": [],

--- a/scripts/release-signing-input.mjs
+++ b/scripts/release-signing-input.mjs
@@ -35,7 +35,7 @@ export const SIGNING_ARCHIVE_LIMITS = Object.freeze({
 
 const TRUSTED_INPUT_SHA256 = Object.freeze({
   'electron-builder.signing.json':
-    '38edb9d207e1ad8f13d0b93b94ff664f742a3a8e64f789d036fa2dd0661dc68c',
+    '05baea577e4c0e18599e6a56213a467bd35c6c6a1a0fba68b1bbd3739768450f',
   'signing-build-resources/256x256.png':
     '044d3b64a14aa512ca41469372d1ad630557daaeb2cb4e709d34f2d3c57d4c3b',
   'signing-build-resources/background.tiff':

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -100,6 +100,7 @@ import type { AppSettings } from '@shared/types/settings'
 import type { DownloadTask } from '@shared/types/task'
 import { TaskType } from '@shared/types/task'
 import pino from 'pino'
+import packageJson from '../../package.json' with { type: 'json' }
 import {
   bootstrapBridgeForServer,
   type ServerBridgeRuntime,
@@ -152,6 +153,7 @@ async function main() {
 
   // ─── Platform ─────────────────────────────────────────────────
   const platform = createNodePlatformServices()
+  const appVersion = process.env.MOTRIX_APP_VERSION ?? packageJson.version
   const runtimeDirectories = await prepareServerRuntimeDirectories({
     dataDir: platform.userDataDir,
     tempDirValue: process.env.MOTRIX_TEMP_DIR,
@@ -428,7 +430,7 @@ async function main() {
     pluginsDir,
     builtinDir,
     stateStore: pluginStateStore,
-    hostVersion: process.env.MOTRIX_APP_VERSION ?? '2.0.0',
+    hostVersion: appVersion,
     hostLanguage,
     devPath,
     communityDirectoryPolicy: createServerCommunityPluginPolicy({
@@ -440,7 +442,7 @@ async function main() {
   await pluginRegistry.discover()
   if (!shellAsyncWork.isAccepting()) return
   const pluginCapHost = await createServerCapabilityHost({
-    appVersion: process.env.MOTRIX_APP_VERSION ?? '2.0.0',
+    appVersion,
     hostLanguage,
     db: db.database,
     userDataDir: platform.userDataDir,
@@ -475,7 +477,7 @@ async function main() {
       serverDir,
       '../core/plugin/host/quick-js-worker.cjs'
     ),
-    appVersion: process.env.MOTRIX_APP_VERSION ?? '2.0.0',
+    appVersion,
     runtime: 'server',
     hostLanguage,
     pluginGrants,
@@ -501,7 +503,7 @@ async function main() {
     pluginsDir,
   })
 
-  const hostVersion = process.env.MOTRIX_APP_VERSION ?? '2.0.0'
+  const hostVersion = appVersion
   const registryClient = new RegistryClient({
     cachePath: path.join(platform.userDataDir, REGISTRY_CACHE_FILENAME),
   })
@@ -1023,7 +1025,7 @@ async function main() {
           devPath,
           pluginRegistry,
           pluginHost,
-          process.env.MOTRIX_APP_VERSION ?? '2.0.0'
+          appVersion
         )
         if (!shellAsyncWork.isAccepting()) {
           await handle.close()
@@ -1413,7 +1415,7 @@ async function main() {
         userDataDir: platform.userDataDir,
         host: mdxpHost,
         port: mdxpPort,
-        motrixVersion: process.env.MOTRIX_APP_VERSION ?? '2.0.0',
+        motrixVersion: appVersion,
         eventBus,
         // The web approval UI is a separate (Fastify) service; the operator points
         // device-code clients at it via MOTRIX_PUBLIC_URL. Unset → no URL printed.

--- a/tests/scripts/electron-package-contract.test.ts
+++ b/tests/scripts/electron-package-contract.test.ts
@@ -94,6 +94,25 @@ describe('Electron package contracts', () => {
     expect(manifest.scripts?.['build:electron']).not.toContain('stage:electron')
   })
 
+  it('keeps macOS bundle versions numeric while the app version stays SemVer', async () => {
+    const manifest = (await readJson('package.json')) as { version?: string }
+    const version = manifest.version ?? ''
+    const match = /^(\d+)\.(\d+)\.(\d+)(?:-beta\.\d+)?$/.exec(version)
+
+    expect(match).not.toBeNull()
+    const bundleShortVersion = match?.slice(1, 4).join('.')
+    for (const configPath of [
+      'electron-builder.json',
+      'electron-builder.signing.json',
+    ]) {
+      const config = (await readJson(configPath)) as {
+        mac?: { bundleShortVersion?: string; bundleVersion?: string }
+      }
+      expect(config.mac?.bundleShortVersion).toBe(bundleShortVersion)
+      expect(config.mac?.bundleVersion).toMatch(/^\d+(?:\.\d+){0,2}$/)
+    }
+  })
+
   it('declares the exact supported runtime roots and targets', async () => {
     const contract = validateRuntimeDependencyContract(
       await readJson('scripts/electron-runtime-dependencies.json')

--- a/tests/scripts/workflow-release-matrix.test.ts
+++ b/tests/scripts/workflow-release-matrix.test.ts
@@ -555,6 +555,75 @@ describe('general CI native-host split contract', () => {
 })
 
 describe('release workflow publication contract', () => {
+  it('derives the GitHub Release body from validated version metadata', () => {
+    const jobs = workflowJobs(releaseWorkflow)
+    const preflightJob = asRecord(jobs.preflight, 'preflight job')
+    const preflightOutputs = asRecord(
+      preflightJob.outputs,
+      'preflight job outputs'
+    )
+    const preflightSteps = jobSteps(preflightJob)
+    const metadataIndex = preflightSteps.findIndex(
+      (step) => step.id === 'metadata'
+    )
+    const releaseNotesIndex = preflightSteps.findIndex(
+      (step) => step.id === 'release_notes'
+    )
+
+    expect(metadataIndex).toBeGreaterThanOrEqual(0)
+    expect(releaseNotesIndex).toBeGreaterThan(metadataIndex)
+    expect(stringField(preflightOutputs, 'release_notes_path')).toBe(
+      `\${{ steps.release_notes.outputs.path }}`
+    )
+
+    const releaseNotesStep = preflightSteps[releaseNotesIndex] as LooseRecord
+    const releaseNotesEnvironment = asRecord(
+      releaseNotesStep.env,
+      'release notes environment'
+    )
+    expect(releaseNotesEnvironment).toEqual({
+      RELEASE_VERSION: `\${{ steps.metadata.outputs.version }}`,
+    })
+
+    const releaseNotesCommand = stringField(releaseNotesStep, 'run')
+    expect(releaseNotesCommand).toContain(
+      '[[ ! "$RELEASE_VERSION" =~ ^[0-9A-Za-z.+-]+$ ]]'
+    )
+    expect(releaseNotesCommand).toContain(`[[ "$RELEASE_VERSION" == *'..'* ]]`)
+    expect(releaseNotesCommand).toContain(
+      `release_notes_path="docs/release-notes/\${RELEASE_VERSION}.md"`
+    )
+    expect(releaseNotesCommand).toContain('[[ ! -f "$release_notes_path" ]]')
+    expect(releaseNotesCommand).toContain(
+      `printf 'path=%s\\n' "$release_notes_path" >> "$GITHUB_OUTPUT"`
+    )
+    expect(releaseNotesCommand).not.toMatch(/github\.(?:ref|ref_name)/)
+
+    const publishSteps = jobSteps(asRecord(jobs.publish, 'publish job'))
+    const checkoutIndex = publishSteps.findIndex((step) =>
+      stringField(step, 'uses', '').startsWith('actions/checkout@')
+    )
+    const releaseIndex = publishSteps.findIndex((step) =>
+      stringField(step, 'uses', '').startsWith('softprops/action-gh-release@')
+    )
+    expect(checkoutIndex).toBeGreaterThanOrEqual(0)
+    expect(releaseIndex).toBeGreaterThan(checkoutIndex)
+    const checkoutInputs = asRecord(
+      publishSteps[checkoutIndex]?.with,
+      'publish checkout inputs'
+    )
+    expect(checkoutInputs['persist-credentials']).toBe(false)
+
+    const publishInputs = asRecord(
+      publishSteps[releaseIndex]?.with,
+      'GitHub Release action inputs'
+    )
+    expect(stringField(publishInputs, 'body_path')).toBe(
+      `\${{ needs.preflight.outputs.release_notes_path }}`
+    )
+    expect(publishInputs.generate_release_notes).toBe(true)
+  })
+
   it('gates every build and publication on validated release metadata', () => {
     const jobs = workflowJobs(releaseWorkflow)
     const preflightJob = asRecord(jobs.preflight, 'preflight job')
@@ -1135,6 +1204,27 @@ describe('release workflow publication contract', () => {
       expect(stringField(env, 'MACOSX_DEPLOYMENT_TARGET')).toContain('12.0')
     }
   })
+
+  it('assigns an increasing numeric macOS bundle build to unsigned and signed packages', () => {
+    const bundleVersionArgument = `-c.mac.bundleVersion=\${{ github.run_number }}.\${{ github.run_attempt }}.0`
+
+    const jobs = workflowJobs(releaseWorkflow)
+    const buildMac = jobSteps(asRecord(jobs.build, 'build job')).find(
+      (step) => step.name === 'Electron Builder (macOS)'
+    )
+    const signMac = jobSteps(asRecord(jobs.sign, 'sign job')).find(
+      (step) => step.name === 'Electron Builder (macOS signing boundary)'
+    )
+
+    expect(buildMac).toBeDefined()
+    expect(signMac).toBeDefined()
+    expect(stringField(buildMac as LooseRecord, 'run')).toContain(
+      bundleVersionArgument
+    )
+    expect(stringField(signMac as LooseRecord, 'run')).toContain(
+      bundleVersionArgument
+    )
+  })
 })
 
 describe('workflow action supply-chain contract', () => {
@@ -1202,9 +1292,7 @@ describe('workflow action supply-chain contract', () => {
 
     const dockerfile = readFileSync(path.join(ROOT, 'Dockerfile'), 'utf8')
     expect(
-      dockerfile.match(
-        new RegExp(`corepack prepare pnpm@${PNPM_VERSION}`, 'g')
-      )
+      dockerfile.match(new RegExp(`corepack prepare pnpm@${PNPM_VERSION}`, 'g'))
     ).toHaveLength(2)
     expect(dockerfile).not.toMatch(/pnpm@(?:latest|9(?:\D|$))/)
 


### PR DESCRIPTION
## Summary

- set the root release version to `2.0.0-beta.1` and keep the Server runtime version aligned
- add English and Simplified Chinese beta release notes plus README download, risk, and rollback guidance
- require version-matched release notes in the protected tag workflow while retaining generated GitHub notes
- use Apple-compatible numeric macOS bundle versions without changing the application SemVer
- keep AppImage out of this beta; Linux GitHub assets remain DEB/RPM and Snap stays on its separate edge workflow

## Why

This prepares the first Motrix v2 beta for publication through the protected `v2.0.0-beta.1` tag workflow. AppImage remains excluded because its transient mount cannot yet provide a persistent Browser Native Messaging host path after the app exits.

This PR does not create the release tag or publish a GitHub Release.

## Validation

- script and packaging test suite: 39 files / 463 tests
- final release workflow contract: 31 tests
- TypeScript typecheck
- architecture boundary checks
- Biome, actionlint, file-name validation, and `git diff --check`
- Server build, staged-package verification, and runtime smoke
- macOS arm64 package build, ad-hoc signing, and runtime smoke
