### PR TITLE
fix(release): allow unsigned Windows and fix R2 feed

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -48,9 +48,13 @@ them with local publishing steps.
   `v<package-version>` tag whose commit is on `main`. The tag and package
   versions must match; only stable and `beta` channels are supported.
 - A tag push triggers `.github/workflows/release.yml`. Publishing is allowed
-  only after its platform builds, isolated signing jobs, signature/package
-  verification, artifact assembly, and update-artifact validation succeed.
-  Manual dispatch validates the build path but does not sign or publish.
+  only after its platform builds, isolated signing/finalization jobs,
+  required signature checks, package verification, artifact assembly, and
+  update-artifact validation succeed. macOS releases require signing and
+  notarization; Windows releases may be explicitly finalized unsigned when
+  both Authenticode secrets are absent. Disclose unsigned Windows artifacts in
+  the public release notes. Manual dispatch validates the build path but does
+  not sign or publish.
 - Do not manually upload release files, reuse unverified artifacts, bypass
   protected environments, weaken signing-input isolation, or overwrite an
   existing immutable container tag.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,7 +228,8 @@ jobs:
           pnpm run stage:electron -- --platform ${{ matrix.platform }} --arch ${{ matrix.arch }}
 
       # Tagged macOS and Windows outputs are deliberately unsigned here. A
-      # fresh, no-checkout job signs only the verified data artifact below.
+      # fresh, no-checkout job finalizes only the verified data artifact below,
+      # applying platform signing when it is required or configured.
       - name: Electron Builder (macOS)
         if: matrix.platform == 'darwin'
         env:
@@ -454,7 +455,7 @@ jobs:
           retention-days: 7
 
   sign:
-    name: Sign / ${{ matrix.target }}
+    name: Finalize / ${{ matrix.target }}
     needs: [preflight, build]
     if: >-
       github.event_name == 'push' &&
@@ -862,16 +863,30 @@ jobs:
             [[ -n "${!name:-}" ]] || { echo "Missing $name" >&2; exit 1; }
           done
 
-      - name: Validate Windows release credentials
+      - name: Resolve Windows signing mode
+        id: windows-signing
         if: matrix.platform == 'win32'
         shell: pwsh
         env:
           WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
         run: |
-          if ([string]::IsNullOrWhiteSpace($env:WIN_CSC_LINK) -or
-              [string]::IsNullOrWhiteSpace($env:WIN_CSC_KEY_PASSWORD)) {
-            throw 'Missing Windows signing credentials'
+          $linkMissing = [string]::IsNullOrWhiteSpace($env:WIN_CSC_LINK)
+          $passwordMissing = [string]::IsNullOrWhiteSpace(
+            $env:WIN_CSC_KEY_PASSWORD
+          )
+          if ($linkMissing -xor $passwordMissing) {
+            throw 'Configure both Windows signing credentials or neither'
+          }
+          if ($linkMissing) {
+            'enabled=false' | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            @(
+              '### Windows signing'
+              ''
+              'Authenticode credentials are not configured. Publishing the verified Windows release artifacts unsigned.'
+            ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          } else {
+            'enabled=true' | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           }
 
       - name: Prepare Apple API Key
@@ -907,7 +922,7 @@ jobs:
           -c.mac.bundleVersion=${{ github.run_number }}.${{ github.run_attempt }}.0
           --publish never
 
-      - name: Electron Builder (Windows signing boundary)
+      - name: Electron Builder (Windows finalization boundary)
         if: matrix.platform == 'win32'
         working-directory: signing-input
         env:
@@ -934,7 +949,9 @@ jobs:
           xcrun stapler validate "${{ matrix.app_path }}"
 
       - name: Verify Windows signatures
-        if: matrix.platform == 'win32'
+        if: >-
+          matrix.platform == 'win32' &&
+          steps.windows-signing.outputs.enabled == 'true'
         shell: pwsh
         working-directory: signing-input
         run: |
@@ -956,7 +973,7 @@ jobs:
             }
           }
 
-      - name: Verify signed Electron package
+      - name: Verify finalized Electron package
         working-directory: signing-input
         run: >-
           node scripts/verify-electron-package.mjs
@@ -975,7 +992,7 @@ jobs:
             rm -f "$APPLE_API_KEY_PATH"
           fi
 
-      - name: Upload signed release input
+      - name: Upload finalized release input
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-input-${{ matrix.target }}
@@ -1440,6 +1457,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: auto
       AWS_EC2_METADATA_DISABLED: 'true'
+      RELEASE_CHANNEL: ${{ needs.preflight.outputs.channel }}
       R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
       R2_BUCKET: ${{ secrets.R2_BUCKET }}
     steps:
@@ -1468,10 +1486,18 @@ jobs:
             echo "Missing required app-update-feed secrets: ${missing[*]}" >&2
             exit 1
           fi
+          if [[ ! "$R2_ACCOUNT_ID" =~ ^[0-9a-f]{32}$ ]]; then
+            echo 'R2_ACCOUNT_ID must be a 32-character lowercase hexadecimal account ID' >&2
+            exit 1
+          fi
+          if [[ "$R2_BUCKET" != 'motrix-releases' ]]; then
+            echo 'R2_BUCKET must match the dl Worker RELEASES binding: motrix-releases' >&2
+            exit 1
+          fi
           aws --version
 
       # The generic provider cannot publish itself. GitHub Release is the
-      # archive; this R2 prefix is the sole feed embedded in app-update.yml.
+      # archive; the R2 bucket root is the sole feed embedded in app-update.yml.
       # Upload versioned assets first and mutable channel manifests last so a
       # manifest never references an asset that is not already available.
       - name: Upload versioned update assets
@@ -1479,7 +1505,7 @@ jobs:
         run: |
           set -euo pipefail
           endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
-          aws s3 cp release "s3://${R2_BUCKET}/releases/" \
+          aws s3 cp release "s3://${R2_BUCKET}/" \
             --recursive \
             --exclude '*.yml' \
             --cache-control 'public,max-age=31536000,immutable' \
@@ -1490,7 +1516,7 @@ jobs:
         run: |
           set -euo pipefail
           endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
-          aws s3 cp release "s3://${R2_BUCKET}/releases/" \
+          aws s3 cp release "s3://${R2_BUCKET}/" \
             --recursive \
             --exclude '*' \
             --include 'latest*.yml' \
@@ -1498,3 +1524,55 @@ jobs:
             --content-type 'application/yaml' \
             --cache-control 'no-cache, no-store, must-revalidate' \
             --endpoint-url "$endpoint"
+
+      - name: Verify channel manifests through dl.motrix.app
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+          manifests=(release/latest*.yml release/beta*.yml)
+          case "$RELEASE_CHANNEL" in
+            beta) expected_count=4 ;;
+            stable) expected_count=8 ;;
+            *)
+              echo "Unsupported release channel: ${RELEASE_CHANNEL}" >&2
+              exit 1
+              ;;
+          esac
+          if (( ${#manifests[@]} != expected_count )); then
+            echo "Expected ${expected_count} ${RELEASE_CHANNEL} update manifests, found ${#manifests[@]}" >&2
+            exit 1
+          fi
+          for manifest in "${manifests[@]}"; do
+            name="$(basename "$manifest")"
+            aws s3api head-object \
+              --bucket "$R2_BUCKET" \
+              --key "$name" \
+              --endpoint-url "$endpoint" \
+              > /dev/null
+            expected="$(sha256sum "$manifest" | cut -d ' ' -f 1)"
+            downloaded="${RUNNER_TEMP}/${name}"
+            matched='false'
+            for attempt in {1..12}; do
+              if curl \
+                --fail \
+                --location \
+                --silent \
+                --show-error \
+                "https://dl.motrix.app/releases/${name}?release=${GITHUB_SHA}&attempt=${attempt}" \
+                --output "$downloaded"
+              then
+                actual="$(sha256sum "$downloaded" | cut -d ' ' -f 1)"
+                if [[ "$actual" == "$expected" ]]; then
+                  matched='true'
+                  break
+                fi
+              fi
+              sleep 5
+            done
+            if [[ "$matched" != 'true' ]]; then
+              echo "Published manifest did not converge at dl.motrix.app: ${name}" >&2
+              exit 1
+            fi
+          done

--- a/docs/release-notes/2.0.0-beta.1.md
+++ b/docs/release-notes/2.0.0-beta.1.md
@@ -20,8 +20,9 @@ download core, MDXP integrations, and sandboxed plugin system.
   and an in-app plugin marketplace.
 - Persistent, multi-architecture Server containers for NAS and home-server
   deployments, published to both Docker Hub and GHCR.
-- A rebuilt release pipeline with isolated macOS and Windows signing, package
-  verification, third-party notices, and an SPDX SBOM.
+- A rebuilt release pipeline with isolated macOS signing, optional Windows
+  Authenticode signing, package verification, third-party notices, and an SPDX
+  SBOM.
 
 ## Before testing
 
@@ -62,6 +63,9 @@ for storage, networking, and upgrade guidance.
 - AppImage is not published for this beta.
 - Flatpak is validated separately and is not published by the release tag.
 - Windows `arm64` and all 32-bit packages are not available.
+- Windows packages in this beta are not Authenticode-signed and may trigger a
+  Windows SmartScreen warning. Download them only from this official GitHub
+  release.
 - Beta container tags are immutable and do not update `latest`, `stable`, or
   other stable floating tags.
 

--- a/docs/release-notes/2.0.0-beta.1.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.1.zh-CN.md
@@ -18,8 +18,8 @@ Motrix 2.0.0-beta.1 是 Motrix Turbo 的首个公开 beta，包含重新开发�
 - 提供带能力授权的 QuickJS 插件沙箱、已签名的内置插件和应用内插件市场。
 - 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器，并同时发布到
   Docker Hub 与 GHCR。
-- 重建发布流水线，隔离 macOS 与 Windows 签名步骤，并加入安装包验证、
-  第三方声明和 SPDX SBOM。
+- 重建发布流水线，隔离 macOS 签名步骤、支持可选的 Windows Authenticode
+  签名，并加入安装包验证、第三方声明和 SPDX SBOM。
 
 ## 测试前须知
 
@@ -54,6 +54,8 @@ Motrix 2.0.0-beta.1 是 Motrix Turbo 的首个公开 beta，包含重新开发�
 - 本 beta 不发布 AppImage。
 - Flatpak 会单独验证，不会随该版本 tag 发布。
 - 不提供 Windows `arm64` 和任何 32 位安装包。
+- 本 beta 的 Windows 安装包未进行 Authenticode 签名，可能触发 Windows
+  SmartScreen 警告。请仅从此 GitHub 官方 Release 下载。
 - Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
 
 ## 反馈

--- a/tests/scripts/workflow-release-matrix.test.ts
+++ b/tests/scripts/workflow-release-matrix.test.ts
@@ -859,6 +859,9 @@ describe('release workflow publication contract', () => {
     ] as const) {
       expect(stringField(environment, name)).toContain(`secrets.${secret}`)
     }
+    expect(stringField(environment, 'RELEASE_CHANNEL')).toContain(
+      'needs.preflight.outputs.channel'
+    )
 
     const steps = jobSteps(feedJob)
     const assetsIndex = steps.findIndex(
@@ -872,15 +875,34 @@ describe('release workflow publication contract', () => {
 
     const assetsCommand = stringField(steps[assetsIndex] as LooseRecord, 'run')
     expect(assetsCommand).toContain("--exclude '*.yml'")
-    expect(assetsCommand).toContain('/releases/')
+    expect(assetsCommand).toContain(`s3://\${R2_BUCKET}/`)
+    expect(assetsCommand).not.toContain('/releases/')
     const manifestsCommand = stringField(
       steps[manifestsIndex] as LooseRecord,
       'run'
     )
+    expect(manifestsCommand).toContain(`s3://\${R2_BUCKET}/`)
+    expect(manifestsCommand).not.toContain('/releases/')
     expect(manifestsCommand).toContain("--include 'latest*.yml'")
     expect(manifestsCommand).toContain("--include 'beta*.yml'")
     expect(manifestsCommand).toContain("--exclude '*'")
     expect(manifestsCommand).toContain('no-cache')
+
+    const validation = steps.find(
+      (step) => step.name === 'Validate update feed credentials'
+    )
+    const validationCommand = stringField(validation as LooseRecord, 'run')
+    expect(validationCommand).toContain("R2_BUCKET\" != 'motrix-releases'")
+
+    const verification = steps.find(
+      (step) => step.name === 'Verify channel manifests through dl.motrix.app'
+    )
+    const verificationCommand = stringField(verification as LooseRecord, 'run')
+    expect(verificationCommand).toContain('aws s3api head-object')
+    expect(verificationCommand).toContain('https://dl.motrix.app/releases/')
+    expect(verificationCommand).toContain('sha256sum')
+    expect(verificationCommand).toContain('beta) expected_count=4')
+    expect(verificationCommand).toContain('stable) expected_count=8')
   })
 
   it('uploads only stable and beta metadata from target builds', () => {
@@ -1047,7 +1069,47 @@ describe('release workflow publication contract', () => {
     expect(stringField(windowsEnv, 'CSC_KEY_PASSWORD')).toContain(
       'secrets.WIN_CSC_KEY_PASSWORD'
     )
+    expect(stringField(windowsEnv, 'CSC_IDENTITY_AUTO_DISCOVERY')).toBe('false')
     expect(JSON.stringify(windowsEnv)).not.toContain('MAC_CERTS')
+    expect(stringField(windowsStep, 'if')).toBe("matrix.platform == 'win32'")
+
+    const windowsMode = steps.find(
+      (step) => step.name === 'Resolve Windows signing mode'
+    )
+    expect(windowsMode).toBeDefined()
+    expect(stringField(windowsMode as LooseRecord, 'id')).toBe(
+      'windows-signing'
+    )
+    const windowsModeCommand = stringField(windowsMode as LooseRecord, 'run')
+    expect(windowsModeCommand).toContain("'enabled=false'")
+    expect(windowsModeCommand).toContain("'enabled=true'")
+    expect(windowsModeCommand).toContain('-xor')
+    expect(windowsModeCommand).toContain('GITHUB_STEP_SUMMARY')
+    expect(windowsModeCommand).toContain('unsigned')
+    expect(JSON.stringify(windowsMode)).not.toContain(
+      'needs.preflight.outputs.prerelease'
+    )
+    expect(JSON.stringify(windowsMode)).not.toContain(
+      'needs.preflight.outputs.channel'
+    )
+
+    const windowsVerification = steps.find(
+      (step) => step.name === 'Verify Windows signatures'
+    )
+    expect(stringField(windowsVerification as LooseRecord, 'if')).toContain(
+      "steps.windows-signing.outputs.enabled == 'true'"
+    )
+
+    const packageVerification = steps.find(
+      (step) => step.name === 'Verify finalized Electron package'
+    )
+    const finalizedUpload = steps.find(
+      (step) => step.name === 'Upload finalized release input'
+    )
+    expect(packageVerification).toBeDefined()
+    expect(finalizedUpload).toBeDefined()
+    expect(stringField(packageVerification as LooseRecord, 'if', '')).toBe('')
+    expect(stringField(finalizedUpload as LooseRecord, 'if', '')).toBe('')
 
     expect(releaseSource).toContain('APPLE_API_ISSUER')
     expect(releaseSource).not.toContain('secrets.TEAM_ID')
@@ -1066,7 +1128,7 @@ describe('release workflow publication contract', () => {
     expect(command).toContain('xcrun stapler validate')
   })
 
-  it('keeps manual assembly unsigned and tag assembly signing-gated', () => {
+  it('keeps manual assembly unsigned and tag assembly finalization-gated', () => {
     const jobs = workflowJobs(releaseWorkflow)
     const build = asRecord(jobs.build, 'build job')
     const upload = jobSteps(build).find(


### PR DESCRIPTION
## What changed

- allow Windows beta and stable releases to finalize without Authenticode credentials
- keep Windows signing and timestamp verification when both `WIN_CSC` secrets are configured
- fail on partially configured Windows credentials
- publish release assets and updater manifests at the R2 bucket root expected by the dl Worker
- validate the R2 account/bucket contract and verify published manifests through `dl.motrix.app`
- disclose that `v2.0.0-beta.1` Windows artifacts are unsigned

## Why

Motrix v1 Windows releases were unsigned, so missing `WIN_CSC` credentials must not block v2 releases. The update workflow also wrote objects under a `releases/` key prefix while the website Worker reads flat keys from the bucket root, which would make beta updater manifests unavailable.

## Impact

The `v2.0.0-beta.1` release can publish verified unsigned Windows artifacts. R2 publication now matches the existing `motrix-website` Worker without a Worker redeploy, and both beta (4 manifests) and stable (8 manifests) feeds are checked after upload.

## Validation

- 147 release-related Vitest tests
- actionlint
- Biome over the workflow contract test and all `src/`
- TypeScript type-check
- architecture boundary checks
- file-name check
- staged diff checks
