### PR TITLE
fix(release): prepare v2.0.0-beta.4 recovery

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,16 @@
 # scripts/generate-third-party-notices.mjs). Disable line-ending conversion so
 # Windows checkouts (autocrlf) stay byte-identical to the committed blobs.
 THIRD_PARTY_LICENSES/** -text
+
+# Isolated signing control files are hash-pinned byte-for-byte. Keep their
+# checkout representation identical on Windows, macOS, and Linux.
+electron-builder.signing.json text eol=lf
+build/entitlements.mac.plist text eol=lf
+build/installer.nsh text eol=lf
+scripts/release-signing-tool/package.json text eol=lf
+scripts/release-signing-tool/package-lock.json text eol=lf
+scripts/electron-package-size-budgets.json text eol=lf
+scripts/electron-package-utils.mjs text eol=lf
+scripts/native-binary-target.mjs text eol=lf
+scripts/release-signing-input.mjs text eol=lf
+scripts/verify-electron-package.mjs text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
           tests/scripts/native-binary-target.test.ts
           tests/scripts/obsidian-docs.test.ts
           tests/scripts/release-metadata.test.ts
+          tests/scripts/release-signing-input.test.ts
           tests/scripts/release-version-contract.test.ts
           tests/scripts/snap-artifact.test.ts
           tests/scripts/snap-build-set-release.test.ts

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. Download
-[v2.0.0-beta.3 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.3)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.3.md)
+[v2.0.0-beta.4 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.4)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.4.md)
 before installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -126,7 +126,8 @@ package that matches your operating system and architecture:
 
 This beta does not publish an AppImage. Flatpak is validated separately and is
 not published by the release tag. Windows `arm64` and all 32-bit packages are
-not available.
+not available. Windows `x64` packages are not Authenticode-signed and may
+trigger a Windows SmartScreen warning.
 
 ### Command-line client
 
@@ -146,7 +147,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.3'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.4'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。安装前请从 GitHub Releases
-下载 [v2.0.0-beta.3](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.3)，
-并阅读[完整发布说明](./docs/release-notes/2.0.0-beta.3.zh-CN.md)。
+下载 [v2.0.0-beta.4](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.4)，
+并阅读[完整发布说明](./docs/release-notes/2.0.0-beta.4.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -122,7 +122,8 @@ edge 通道提供。请根据操作系统和架构选择安装包：
 | Linux | `x64`、`arm64` | `.deb` / `.rpm`；Snap `latest/edge` | Debian 或 Ubuntu 使用 `.deb`，Fedora 或 openSUSE 使用 `.rpm`；beta 测试也可使用 edge Snap |
 
 本 beta 不发布 AppImage。Flatpak 会单独验证，不会随该版本 tag 发布。
-同时不提供 Windows `arm64` 和任何 32 位安装包。
+同时不提供 Windows `arm64` 和任何 32 位安装包。Windows `x64` 安装包不进行
+Authenticode 签名，可能触发 Windows SmartScreen 警告。
 
 ### 命令行客户端
 
@@ -141,7 +142,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.3'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.4'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.3.md
+++ b/docs/release-notes/2.0.0-beta.3.md
@@ -1,24 +1,39 @@
 # Motrix 2.0.0-beta.3
 
-English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.3/docs/release-notes/2.0.0-beta.3.zh-CN.md)
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.4/docs/release-notes/2.0.0-beta.3.zh-CN.md)
 
-Motrix 2.0.0-beta.3 is the first Motrix Turbo beta intended for public
-distribution. It begins public validation of the rebuilt v2 desktop app and
-headless server, shared download core, MDXP integrations, and sandboxed plugin
-system.
+> [!IMPORTANT]
+> This release attempt did not complete. The four non-Windows desktop build
+> targets (macOS `arm64`/`x64` and Linux `arm64`/`x64`) succeeded. The corrected
+> signing-input handoff delivered the complete triggering commit to Windows,
+> but Git checkout converted fixed-digest UTF-8 control files from LF to CRLF.
+> `electron-builder.signing.json` was the first fixed SHA-256 mismatch; the
+> audit found the same byte conversion in other digest-pinned control text and
+> the embedded verifier. Signing-input creation failed closed before a Windows
+> signing input was uploaded.
+>
+> Windows finalization, both macOS finalize jobs, assemble, GitHub Release, R2
+> update-feed publishing, and container publishing never ran. Snap completed
+> and staged verified `amd64` and `arm64` artifacts, but its Store publish job
+> was canceled with `steps=[]` before credential validation. It performed no
+> Store upload, `latest/edge` release, or public verification. Beta.3 therefore
+> created no GitHub Release, R2 feed, Docker Hub or GHCR image, or Snap Store
+> revision: external distribution remained zero. Use
+> [Motrix 2.0.0-beta.4](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.4/docs/release-notes/2.0.0-beta.4.md)
+> instead. The remaining sections are retained as a historical record of the
+> intended beta.3 scope.
 
-The protected `v2.0.0-beta.1` and `v2.0.0-beta.2` release attempts both
-stopped before external distribution. Neither version created a GitHub
-Release, R2 update feed, Docker Hub or GHCR container image, or Snap Store
-revision. This beta.3 release supersedes both attempts.
+Motrix 2.0.0-beta.3 was intended to be the first publicly distributed Motrix
+Turbo beta. Its planned scope covered the rebuilt v2 desktop app and headless
+server, shared download core, MDXP integrations, and sandboxed plugin system.
 
-## Release recovery fixes
+## Release recovery fixes included
 
-- Corrected the Windows signing-input handoff to record the triggering commit
-  with a cross-platform workflow expression before isolated finalization.
+- Corrected the Windows signing-input handoff so the complete triggering
+  commit metadata reached isolated finalization.
 - Corrected Electron runtime dependency hydration so the packaged desktop app
   contains the runtime modules required when it launches.
-- Corrected Snap artifact staging so the tag pipeline can verify and publish
+- Corrected Snap artifact staging so the tag pipeline could verify and stage
   the exact `amd64` and `arm64` build outputs.
 
 ## Highlights
@@ -34,12 +49,12 @@ revision. This beta.3 release supersedes both attempts.
 - A QuickJS plugin sandbox with capability consent, signed builtin plugins,
   and an in-app plugin marketplace.
 - Persistent, multi-architecture Server containers for NAS and home-server
-  deployments, published to both Docker Hub and GHCR.
+  deployments, with publication planned for Docker Hub and GHCR.
 - A rebuilt release pipeline with isolated macOS signing, explicit unsigned
   Windows finalization, package verification, third-party notices, and an SPDX
   SBOM.
 
-## Before testing
+## Planned testing precautions
 
 This is prerelease software. Back up your existing Motrix application data and
 downloads before installing it. Migration from Motrix v1 data has not yet been
@@ -49,7 +64,7 @@ When practical, test v2 in parallel using a separate OS account, machine, or
 Docker data directory. Please do not rely on this beta for your only copy of
 important downloads.
 
-## What to test
+## Planned testing
 
 - HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
   session recovery
@@ -57,31 +72,32 @@ important downloads.
   plugins
 - Headless Server deployment, persistent storage, and remote pairing
 
-## Available downloads
+## Intended downloads (not published)
 
-| Distribution | Architectures | Published output |
-|--------------|---------------|------------------|
+| Distribution | Architectures | Intended output |
+|--------------|---------------|-----------------|
 | macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
 | Windows | `x64` | NSIS installer (`.exe`) and ZIP |
 | Linux | `x64`, `arm64` | DEB and RPM |
 | Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.3` tag in both registries |
 | Snap Store | `amd64`, `arm64` | `latest/edge` |
 
-Container images are available as
+The planned container image names were
 `docker.io/motrixapp/motrix-server:2.0.0-beta.3` and
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.3`. See the
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.3`; they were not published. See the
 [Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.3/docs/docker-server.md)
 for storage, networking, and upgrade guidance.
 
 ## Known distribution limits
 
-- AppImage is not published for this beta.
-- Flatpak is validated separately and is not published by the release tag.
+- AppImage was not published for this beta.
+- Flatpak was validated separately and was not published by the release tag.
 - Windows `arm64` and all 32-bit packages are not available.
-- Windows packages are not Authenticode-signed and may trigger a Windows
-  SmartScreen warning. Download them only from this official GitHub release.
-- Beta container tags are immutable and do not update `latest`, `stable`, or
-  other stable floating tags.
+- The intended Windows packages would not have been Authenticode-signed and
+  could have triggered a Windows SmartScreen warning. No beta.3 Windows
+  package was published.
+- The planned beta container tags were immutable and would not have updated
+  `latest`, `stable`, or other stable floating tags.
 
 ## Feedback
 

--- a/docs/release-notes/2.0.0-beta.3.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.3.zh-CN.md
@@ -1,23 +1,35 @@
 # Motrix 2.0.0-beta.3
 
-[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.3/docs/release-notes/2.0.0-beta.3.md) | 简体中文
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.4/docs/release-notes/2.0.0-beta.3.md) | 简体中文
 
-Motrix 2.0.0-beta.3 是首个计划对外发布的 Motrix Turbo beta。
-该版本开始公开验证重新开发的 v2 桌面应用与 Headless server、共用下载
-内核、MDXP 集成和沙箱化插件系统。
+> [!IMPORTANT]
+> 本次发布尝试未完成。4 个非 Windows 桌面构建目标（macOS `arm64`/`x64`
+> 和 Linux `arm64`/`x64`）均已成功。修正后的 signing-input 交接已把完整的
+> 触发 commit 信息传到 Windows，但 Git checkout 将固定摘要的 UTF-8 控制文件
+> 从 LF 转为 CRLF。`electron-builder.signing.json` 首先触发固定 SHA-256
+> 不匹配；审计确认其他受摘要保护的控制文本和内嵌 verifier 也发生了相同的
+> 字节转换。signing-input 创建流程在上传 Windows 签名输入前 fail closed。
+>
+> Windows finalize、两个 macOS finalize job、assemble、GitHub Release、R2
+> 更新数据源发布和 container publish 均未执行。Snap 完成并暂存了经过验证的
+> `amd64` 和 `arm64` 产物，但 Store publish job 在 credential validation 前以
+> `steps=[]` 状态取消，没有执行 Store upload、`latest/edge` release 或 public
+> verification。因此 beta.3 未创建 GitHub Release、R2 数据源、Docker Hub 或
+> GHCR 镜像及 Snap Store revision，外部分发为零。请改用
+> [Motrix 2.0.0-beta.4](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.4/docs/release-notes/2.0.0-beta.4.zh-CN.md)。
+> 下文仅作为 beta.3 原定范围的历史记录保留。
 
-受保护的 `v2.0.0-beta.1` 和 `v2.0.0-beta.2` 发布尝试均在对外分发前
-停止。两个版本都未创建 GitHub Release，也未发布 R2 更新数据源、
-Docker Hub 或 GHCR 容器镜像及 Snap Store revision。本 beta.3 版本
-取代前两次尝试。
+Motrix 2.0.0-beta.3 原计划作为首个对外分发的 Motrix Turbo beta。
+其原定范围包含重新开发的 v2 桌面应用和 Headless server、共用下载内核、
+MDXP 集成和沙箱化插件系统。
 
-## 发布恢复修复
+## 已包含的发布恢复修复
 
-- 修正 Windows 签名输入的交接流程，在隔离的最终处理前通过跨平台
-  workflow 表达式记录触发本次发布的 commit。
+- 修正 Windows signing-input 的交接流程，使完整的触发 commit 信息能够到达
+  隔离的最终处理阶段。
 - 修正 Electron runtime 依赖的补全流程，确保打包后的桌面应用包含启动时所需
   的 runtime module。
-- 修正 Snap 产物的 staging 流程，使 tag 流水线能够验证并发布确定的
+- 修正 Snap 产物的 staging 流程，使 tag 流水线能够验证并暂存确定的
   `amd64` 和 `arm64` 构建产物。
 
 ## 主要变化
@@ -30,12 +42,12 @@ Docker Hub 或 GHCR 容器镜像及 Snap Store revision。本 beta.3 版本
 - 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地安全发现及远程 Server
   的 device-code 配对。
 - 提供带能力授权的 QuickJS 插件沙箱、已签名的内置插件和应用内插件市场。
-- 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器，并同时发布到
+- 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器，原计划同时发布到
   Docker Hub 与 GHCR。
 - 重建发布流水线，隔离 macOS 签名步骤，并明确支持未签名的 Windows
   最终处理，同时加入安装包验证、第三方声明和 SPDX SBOM。
 
-## 测试前须知
+## 原计划的测试须知
 
 这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1
 数据的迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
@@ -43,34 +55,35 @@ Docker Hub 或 GHCR 容器镜像及 Snap Store revision。本 beta.3 版本
 条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录与现有环境
 并行测试 v2。请勿让本 beta 成为重要下载文件的唯一存储位置。
 
-## 建议测试项
+## 原计划的测试项
 
 - HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
 - 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
 - Headless Server 部署、数据持久化和远程配对
 
-## 可用下载
+## 原计划下载（未发布）
 
-| 发布方式 | 架构 | 发布产物 |
-|----------|------|----------|
+| 发布方式 | 架构 | 原计划产物 |
+|----------|------|------------|
 | macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
 | Windows | `x64` | NSIS 安装包（`.exe`）和 ZIP |
 | Linux | `x64`、`arm64` | DEB 和 RPM |
 | Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中均发布不可变 tag `2.0.0-beta.3` |
 | Snap Store | `amd64`、`arm64` | `latest/edge` |
 
-容器镜像地址为 `docker.io/motrixapp/motrix-server:2.0.0-beta.3` 和
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.3`。数据持久化、网络和升级方法请参阅
+原计划的容器镜像地址为 `docker.io/motrixapp/motrix-server:2.0.0-beta.3` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.3`，但它们并未发布。数据持久化、网络和升级方法请参阅
 [Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.3/docs/docker-server.zh-CN.md)。
 
 ## 已知发布限制
 
-- 本 beta 不发布 AppImage。
-- Flatpak 会单独验证，不会随该版本 tag 发布。
+- 本 beta 未发布 AppImage。
+- Flatpak 已单独验证，未随该版本 tag 发布。
 - 不提供 Windows `arm64` 和任何 32 位安装包。
-- Windows 安装包未进行 Authenticode 签名，可能触发 Windows SmartScreen
-  警告。请仅从此 GitHub 官方 Release 下载。
-- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
+- 原计划的 Windows 安装包不会进行 Authenticode 签名，因而可能触发
+  Windows SmartScreen 警告。beta.3 实际并未发布 Windows 安装包。
+- 原计划的 beta container tag 不可变，不会更新 `latest`、`stable` 或其他
+  稳定版浮动 tag。
 
 ## 反馈
 

--- a/docs/release-notes/2.0.0-beta.4.md
+++ b/docs/release-notes/2.0.0-beta.4.md
@@ -1,0 +1,98 @@
+# Motrix 2.0.0-beta.4
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.4/docs/release-notes/2.0.0-beta.4.zh-CN.md)
+
+Motrix 2.0.0-beta.4 is the next Motrix Turbo beta intended for public
+distribution. It begins public validation of the rebuilt v2 desktop app and
+headless server, shared download core, MDXP integrations, and sandboxed plugin
+system.
+
+The protected `v2.0.0-beta.1`, `v2.0.0-beta.2`, and `v2.0.0-beta.3` attempts
+all stopped before external distribution. They created no GitHub Release, R2
+update feed, Docker Hub or GHCR container image, or Snap Store revision.
+Beta.4 supersedes those attempts; the
+[beta.3 notes](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.4/docs/release-notes/2.0.0-beta.3.md)
+retain the most recent failure record.
+
+## Release recovery fixes
+
+- Makes all ten digest-pinned isolated signing control texts byte-stable on
+  Windows by declaring each path as `text eol=lf` in `.gitattributes`. Git
+  checkout therefore preserves their canonical LF bytes across platforms. The
+  existing raw-byte fixed SHA-256 verification is unchanged; a CRLF artifact
+  or any other byte change continues to fail closed.
+- Preserves the complete triggering commit metadata in the Windows
+  signing-input handoff before isolated finalization.
+- Hydrates Electron runtime dependencies so the packaged desktop app contains
+  the modules required when it launches.
+- Stages the exact verified `amd64` and `arm64` Snap artifacts before Store
+  publication.
+
+## Highlights
+
+- A ground-up desktop rebuild with Electron 43, React 19, and TypeScript 7,
+  including a customizable Dashboard, dark mode, a cross-platform application
+  menu, and clearer task-inspector feedback.
+- One host-neutral download core for both the desktop app and the new Node/Web
+  Server, with SQLite session recovery, tracker management, UPnP/NAT-PMP, and
+  HTTP, FTP, BitTorrent, and magnet support.
+- MDXP-based integration for the official CLI and browser handoff, including
+  secure local discovery and device-code pairing for remote Server instances.
+- A QuickJS plugin sandbox with capability consent, signed builtin plugins,
+  and an in-app plugin marketplace.
+- Persistent, multi-architecture Server containers for NAS and home-server
+  deployments, published to both Docker Hub and GHCR.
+- A rebuilt release pipeline with isolated macOS signing, explicit unsigned
+  Windows finalization, package verification, third-party notices, and an SPDX
+  SBOM.
+
+## Before testing
+
+This is prerelease software. Back up your existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Please do not rely on this beta for your only copy of
+important downloads.
+
+## What to test
+
+- HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
+  session recovery
+- Desktop integrations, browser and CLI handoff through MDXP, and sandboxed
+  plugins
+- Headless Server deployment, persistent storage, and remote pairing
+
+## Available downloads
+
+| Distribution | Architectures | Published output |
+|--------------|---------------|------------------|
+| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | DEB and RPM |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.4` tag in both registries |
+| Snap Store | `amd64`, `arm64` | `latest/edge` |
+
+Container images are available as
+`docker.io/motrixapp/motrix-server:2.0.0-beta.4` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.4`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.4/docs/docker-server.md)
+for storage, networking, and upgrade guidance.
+
+## Known distribution limits
+
+- AppImage is not published for this beta.
+- Flatpak is validated separately and is not published by the release tag.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are not Authenticode-signed and may trigger a Windows
+  SmartScreen warning. Download them only from this official GitHub release.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.4.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.4.zh-CN.md
@@ -1,0 +1,81 @@
+# Motrix 2.0.0-beta.4
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.4/docs/release-notes/2.0.0-beta.4.md) | 简体中文
+
+Motrix 2.0.0-beta.4 是下一次计划对外发布的 Motrix Turbo beta。
+该版本开始公开验证重新开发的 v2 桌面应用与 Headless server、共用下载内核、
+MDXP 集成和沙箱化插件系统。
+
+受保护的 `v2.0.0-beta.1`、`v2.0.0-beta.2` 和 `v2.0.0-beta.3` 发布尝试
+均在对外分发前停止，没有创建 GitHub Release，也未发布 R2 更新数据源、
+Docker Hub 或 GHCR 容器镜像及 Snap Store revision。beta.4 取代这些尝试；
+[beta.3 发布说明](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.4/docs/release-notes/2.0.0-beta.3.zh-CN.md)
+保留了最近一次失败记录。
+
+## 发布恢复修复
+
+- 在 `.gitattributes` 中把全部 10 个固定摘要的隔离签名控制文本路径声明为
+  `text eol=lf`，使 Git checkout 在 Windows 及其他平台都保留 canonical LF
+  字节，从而保持字节稳定。原有的原始字节固定 SHA-256 校验完全不变；CRLF
+  产物或任何其他字节变化仍会 fail closed。
+- 在进入隔离最终处理前，为 Windows signing-input 交接保留完整的触发 commit
+  信息。
+- 补全 Electron runtime 依赖，确保打包后的桌面应用包含启动时所需的 module。
+- 在发布到 Store 前，暂存经过验证且确定的 `amd64` 和 `arm64` Snap 产物。
+
+## 主要变化
+
+- 使用 Electron 43、React 19 和 TypeScript 7 从头重建桌面应用，提供可自定义
+  Dashboard、深色模式、跨平台应用菜单，以及更清晰的任务检查器反馈。
+- 桌面应用和全新的 Node/Web Server 共用与宿主无关的下载内核，支持 SQLite
+  session 恢复、Tracker 管理、UPnP/NAT-PMP，以及 HTTP、FTP、BitTorrent 和
+  磁力链接下载。
+- 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地安全发现及远程 Server
+  的 device-code 配对。
+- 提供带能力授权的 QuickJS 插件沙箱、已签名的内置插件和应用内插件市场。
+- 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器，并同时发布到
+  Docker Hub 与 GHCR。
+- 重建发布流水线，隔离 macOS 签名步骤，并明确支持未签名的 Windows
+  最终处理，同时加入安装包验证、第三方声明和 SPDX SBOM。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1
+数据的迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
+
+条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录与现有环境
+并行测试 v2。请勿让本 beta 成为重要下载文件的唯一存储位置。
+
+## 建议测试项
+
+- HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
+- 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
+- Headless Server 部署、数据持久化和远程配对
+
+## 可用下载
+
+| 发布方式 | 架构 | 发布产物 |
+|----------|------|----------|
+| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
+| Windows | `x64` | NSIS 安装包（`.exe`）和 ZIP |
+| Linux | `x64`、`arm64` | DEB 和 RPM |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中均发布不可变 tag `2.0.0-beta.4` |
+| Snap Store | `amd64`、`arm64` | `latest/edge` |
+
+容器镜像地址为 `docker.io/motrixapp/motrix-server:2.0.0-beta.4` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.4`。数据持久化、网络和升级方法请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.4/docs/docker-server.zh-CN.md)。
+
+## 已知发布限制
+
+- 本 beta 不发布 AppImage。
+- Flatpak 会单独验证，不会随该版本 tag 发布。
+- 不提供 Windows `arm64` 和任何 32 位安装包。
+- Windows 安装包未进行 Authenticode 签名，可能触发 Windows SmartScreen
+  警告。请仅从此 GitHub 官方 Release 下载。
+- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
+
+## 反馈
+
+请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现的问题，
+并附上操作系统、架构、安装包类型和复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -76,13 +76,23 @@
   <releases>
     <!-- Update this list on every release; Flathub linter requires the most
          recent version listed here to match the manifest's source tag. -->
+    <release version="2.0.0-beta.4" date="2026-08-15">
+      <description>
+        <p>
+          Release recovery update that declares all ten fixed-digest signing
+          control text paths as text eol=lf, preserving canonical LF bytes
+          across Windows checkouts while leaving raw-byte SHA-256 verification
+          unchanged.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.3" date="2026-08-15">
       <description>
         <p>
-          First Motrix Turbo beta intended for public distribution. Rewritten
-          on Electron 43, Vite 8, React 19, TypeScript 7 and Zod 4, with
-          corrected cross-platform release finalization, Electron runtime
-          dependency hydration and Snap artifact staging.
+          Unpublished Motrix Turbo beta attempt. Four non-Windows builds and
+          both Snap architectures succeeded; Windows signing-input creation
+          failed closed after CRLF checkout conversion changed digest-pinned
+          control bytes. No external distribution was published.
         </p>
       </description>
     </release>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1",
   "description": "A full-featured download manager",
   "keywords": [],

--- a/tests/scripts/release-signing-input.test.ts
+++ b/tests/scripts/release-signing-input.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import {
   cp,
@@ -23,6 +24,18 @@ import {
 const ROOT = process.cwd()
 const COMMIT = 'a'.repeat(40)
 const temporaryDirectories: string[] = []
+const HASH_PINNED_TEXT_SOURCES = [
+  'electron-builder.signing.json',
+  'build/entitlements.mac.plist',
+  'build/installer.nsh',
+  'scripts/release-signing-tool/package.json',
+  'scripts/release-signing-tool/package-lock.json',
+  'scripts/electron-package-size-budgets.json',
+  'scripts/electron-package-utils.mjs',
+  'scripts/native-binary-target.mjs',
+  'scripts/release-signing-input.mjs',
+  'scripts/verify-electron-package.mjs',
+] as const
 const TRUSTED_FIXTURES = [
   ['electron-builder.signing.json', 'electron-builder.signing.json'],
   ['build/256x256.png', 'signing-build-resources/256x256.png'],
@@ -63,6 +76,71 @@ afterEach(async () => {
 })
 
 describe('isolated release signing input', () => {
+  it('forces every hash-pinned text source to canonical LF checkouts', () => {
+    const fields = gitOutput([
+      'check-attr',
+      '-z',
+      'text',
+      'eol',
+      '--',
+      ...HASH_PINNED_TEXT_SOURCES,
+    ])
+      .toString('utf8')
+      .split('\0')
+    fields.pop()
+
+    const attributes = new Map<string, Map<string, string>>()
+    for (let index = 0; index < fields.length; index += 3) {
+      const source = fields[index]
+      const attribute = fields[index + 1]
+      const value = fields[index + 2]
+      if (source && attribute && value) {
+        const sourceAttributes = attributes.get(source) ?? new Map()
+        sourceAttributes.set(attribute, value)
+        attributes.set(source, sourceAttributes)
+      }
+    }
+
+    expect(fields).toHaveLength(HASH_PINNED_TEXT_SOURCES.length * 6)
+    for (const source of HASH_PINNED_TEXT_SOURCES) {
+      expect(attributes.get(source), source).toEqual(
+        new Map([
+          ['text', 'set'],
+          ['eol', 'lf'],
+        ])
+      )
+    }
+  })
+
+  it('keeps hash-pinned inputs byte-identical in a Windows-style checkout', async () => {
+    const directory = await temporaryDirectory('motrix-windows-checkout-')
+    const controlPath = 'package.json'
+    gitOutput([
+      '-c',
+      'core.autocrlf=true',
+      '-c',
+      'core.eol=crlf',
+      'checkout-index',
+      '--force',
+      `--prefix=${directory}${path.sep}`,
+      '--',
+      ...HASH_PINNED_TEXT_SOURCES,
+      controlPath,
+    ])
+
+    for (const source of HASH_PINNED_TEXT_SOURCES) {
+      const blob = gitOutput(['show', `:${source}`])
+      const checkout = await readFile(path.join(directory, source))
+      expect(checkout.equals(blob), source).toBe(true)
+      expect(checkout.includes(Buffer.from('\r\n')), source).toBe(false)
+    }
+
+    const controlBlob = gitOutput(['show', `:${controlPath}`])
+    const controlCheckout = await readFile(path.join(directory, controlPath))
+    expect(controlCheckout.equals(controlBlob)).toBe(false)
+    expect(controlCheckout.includes(Buffer.from('\r\n'))).toBe(true)
+  })
+
   it('accepts a digest-complete data-only fixture', async () => {
     const directory = await createFixture()
 
@@ -119,6 +197,18 @@ describe('isolated release signing input', () => {
         config.beforePack = './untrusted.mjs'
       },
     })
+
+    await expect(verify(directory)).rejects.toThrow(
+      /trusted signing input digest mismatch/
+    )
+  })
+
+  it('rejects CRLF trusted controls at the verification boundary', async () => {
+    const directory = await createFixture()
+    const configPath = path.join(directory, 'electron-builder.signing.json')
+    const config = await readFile(configPath, 'utf8')
+    await writeFile(configPath, config.replace(/\n/gu, '\r\n'))
+    await refreshManifest(directory)
 
     await expect(verify(directory)).rejects.toThrow(
       /trusted signing input digest mismatch/
@@ -194,6 +284,17 @@ async function verify(directory: string) {
     arch: 'x64',
     commit: COMMIT,
   })
+}
+
+function gitOutput(arguments_: string[]): Buffer {
+  const result = spawnSync('git', arguments_, { cwd: ROOT })
+  if (result.error) throw result.error
+  if (result.status !== 0) {
+    throw new Error(
+      `git ${arguments_[0] ?? '<unknown>'} failed: ${result.stderr.toString('utf8')}`
+    )
+  }
+  return result.stdout
 }
 
 async function temporaryDirectory(prefix: string): Promise<string> {

--- a/tests/scripts/release-version-contract.test.ts
+++ b/tests/scripts/release-version-contract.test.ts
@@ -53,6 +53,13 @@ describe('release version contract', () => {
       expect(source).toContain(
         `docker.io/motrixapp/motrix-server:${packageVersion}`
       )
+      const advertisedReleaseTags = Array.from(
+        source.matchAll(
+          /https:\/\/github\.com\/agalwood\/Motrix\/releases\/tag\/([^\s)]+)/g
+        ),
+        (match) => match[1]
+      )
+      expect(new Set(advertisedReleaseTags)).toEqual(new Set([releaseTag]))
     }
   })
 
@@ -87,23 +94,86 @@ describe('release version contract', () => {
       expect(source).toContain(`motrix-server:${packageVersion}`)
       expect(source).toContain('Snap')
       expect(source).toContain('AppImage')
+      expect(source).toContain('Flatpak')
       expect(source).toContain('Authenticode')
       expect(source).toContain('SmartScreen')
     }
   })
 
-  it('preserves beta.3 recovery history', () => {
+  it('preserves beta.4 Git-enforced LF signing-control history', () => {
+    const english = read('docs/release-notes/2.0.0-beta.4.md')
+    const chinese = read('docs/release-notes/2.0.0-beta.4.zh-CN.md')
+
+    expect(english).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.4/docs/release-notes/2.0.0-beta.3.md'
+    )
+    expect(chinese).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.4/docs/release-notes/2.0.0-beta.3.zh-CN.md'
+    )
+    expect(english).toContain('byte-stable')
+    expect(english).toContain('all ten digest-pinned')
+    expect(english).toContain('CRLF artifact')
+    expect(english).toContain('raw-byte')
+    expect(chinese).toContain('字节稳定')
+    expect(chinese).toContain('全部 10 个固定摘要')
+    expect(chinese.replace(/\s+/g, ' ')).toContain('CRLF 产物')
+    expect(chinese).toContain('原始字节')
+    for (const source of [english, chinese]) {
+      expect(source).toContain('.gitattributes')
+      expect(source).toContain('text eol=lf')
+      expect(source).toContain('CRLF')
+      expect(source).toContain('canonical LF')
+      expect(source).toContain('SHA-256')
+      expect(source).toContain('fail closed')
+      expect(source).toContain('latest/edge')
+    }
+  })
+
+  it('marks beta.3 as an unpublished attempt superseded by beta.4', () => {
     const english = read('docs/release-notes/2.0.0-beta.3.md')
     const chinese = read('docs/release-notes/2.0.0-beta.3.zh-CN.md')
+    const normalizedEnglish = english
+      .replace(/^>\s?/gm, '')
+      .replace(/\s+/g, ' ')
 
+    expect(english).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.4/docs/release-notes/2.0.0-beta.3.zh-CN.md'
+    )
+    expect(chinese).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.4/docs/release-notes/2.0.0-beta.3.md'
+    )
+    expect(english).toContain('This release attempt did not complete')
+    expect(normalizedEnglish).toContain(
+      'four non-Windows desktop build targets'
+    )
+    expect(english).toContain('Intended downloads (not published)')
+    expect(english).toContain('external distribution remained zero')
+    expect(english).toContain('failed closed')
+    expect(chinese).toContain('本次发布尝试未完成')
+    expect(chinese).toContain('4 个非 Windows 桌面构建目标')
+    expect(chinese).toContain('原计划下载（未发布）')
+    expect(chinese).toContain('外部分发为零')
+    expect(chinese).toContain('fail closed')
     for (const source of [english, chinese]) {
-      expect(source).toContain('v2.0.0-beta.1')
-      expect(source).toContain('v2.0.0-beta.2')
-      expect(source).toMatch(/GitHub\s+Release/)
-      expect(source).toContain('R2')
-      expect(source).toContain('Snap')
-      expect(source).toContain('workflow')
+      expect(source).toContain('v2.0.0-beta.4')
+      expect(source).toContain('electron-builder.signing.json')
       expect(source).toContain('commit')
+      expect(source).toContain('CRLF')
+      expect(source).toContain('SHA-256')
+      expect(source).toContain('macOS')
+      expect(source).toContain('finalize')
+      expect(source).toContain('assemble')
+      expect(source).toContain('GitHub Release')
+      expect(source).toContain('R2')
+      expect(source).toContain('container')
+      expect(source).toContain('Snap')
+      expect(source).toContain('steps=[]')
+      expect(source).toContain('latest/edge')
+      expect(source).toContain('Docker Hub')
+      expect(source).toContain('GHCR')
+      expect(source).toContain('AppImage')
+      expect(source).toContain('Authenticode')
+      expect(source).toContain('SmartScreen')
     }
   })
 

--- a/tests/scripts/workflow-release-matrix.test.ts
+++ b/tests/scripts/workflow-release-matrix.test.ts
@@ -508,6 +508,7 @@ describe('general CI native-host split contract', () => {
     for (const test of [
       'tests/scripts/electron-package-contract.test.ts',
       'tests/scripts/native-binary-target.test.ts',
+      'tests/scripts/release-signing-input.test.ts',
       'tests/scripts/stage-electron-app.test.ts',
       'tests/scripts/verify-electron-package.test.ts',
     ]) {


### PR DESCRIPTION
## Summary

- keep all ten digest-pinned signing control text files in canonical LF form across Windows, macOS, and Linux checkouts
- add Windows-style checkout and CRLF fail-closed coverage, and run the signing-input contract in the blocking release/packaging CI gate
- bump the release candidate to `2.0.0-beta.4`, add paired release notes, and record beta.3 as an immutable tag with zero external distribution

## Root cause

The beta.3 Windows build received the correct triggering commit, but Git checkout converted digest-pinned control text from LF to CRLF. The first mismatch was `electron-builder.signing.json`; the other pinned control texts and embedded verifier had the same exposure. Signing-input creation failed closed before finalization or publication.

The four non-Windows builds succeeded. Assemble, GitHub Release, R2, and container publishing never ran. The Snap Store publish job was cancelled before executing any steps, so beta.3 produced no external release.

## Verification

- focused release/signing/version workflow tests: 79 passed
- complete `tests/scripts` suite: 491 passed
- TypeScript type-check
- Biome over changed tests and `src/`
- architecture boundary checks
- actionlint for CI and release workflows
- AppStream XML validation
- staged diff and whitespace checks
- two independent final reviews: no P0-P3 findings
