### PR TITLE
fix(release): prepare v2.0.0-beta.5 recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -775,7 +775,7 @@ jobs:
           EXPECTED_COMMIT: ${{ github.sha }}
           EXPECTED_PLATFORM: ${{ matrix.platform }}
           # Updated only after reviewing the verifier source itself.
-          VERIFIER_SHA256: 948f13ec32c0239a35fd69811a15e2ffa8ab0ba86a6eee95bcef46569c7f68a5
+          VERIFIER_SHA256: 2f50644532785e07cc9f9769526f1864127bb65f09fadcc410d943e04c87e39c
         run: |
           const crypto = require('node:crypto')
           const fs = require('node:fs')

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. Download
-[v2.0.0-beta.4 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.4)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.4.md)
+[v2.0.0-beta.5 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.5)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.5.md)
 before installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -147,7 +147,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.4'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.5'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。安装前请从 GitHub Releases
-下载 [v2.0.0-beta.4](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.4)，
-并阅读[完整发布说明](./docs/release-notes/2.0.0-beta.4.zh-CN.md)。
+下载 [v2.0.0-beta.5](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.5)，
+并阅读[完整发布说明](./docs/release-notes/2.0.0-beta.5.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -142,7 +142,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.4'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.5'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.4.md
+++ b/docs/release-notes/2.0.0-beta.4.md
@@ -1,31 +1,48 @@
 # Motrix 2.0.0-beta.4
 
-English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.4/docs/release-notes/2.0.0-beta.4.zh-CN.md)
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.5/docs/release-notes/2.0.0-beta.4.zh-CN.md)
 
-Motrix 2.0.0-beta.4 is the next Motrix Turbo beta intended for public
-distribution. It begins public validation of the rebuilt v2 desktop app and
-headless server, shared download core, MDXP integrations, and sandboxed plugin
-system.
+> [!IMPORTANT]
+> This release attempt did not complete. All five desktop build jobs—macOS
+> `arm64`/`x64`, Windows `x64`, and Linux `arm64`/`x64`—succeeded. The Windows
+> LF-pinning fix kept all ten digest-pinned signing control texts in canonical
+> LF form, and their fixed SHA-256 checks passed.
+>
+> Isolated Windows finalization then failed closed before any Authenticode
+> secret was read. The real signing manifest contained 2,434 unique entries in
+> directory-first DFS order, while the verifier required full-path dictionary
+> order for every canonical relative path. The first inversion placed an entry
+> below `js-yaml/lib/schema/…` before its sibling file
+> `js-yaml/lib/schema.js`; the manifest contained no duplicate entries.
+>
+> The macOS signing environments were not approved, and both macOS finalization
+> jobs were canceled. Assemble, GitHub Release, R2 update-feed publishing, and
+> container publishing never ran. Snap successfully built, verified, and
+> uploaded the `arm64` GitHub Actions artifact; its `amd64` build was canceled
+> during the strict Snap build. The Store publish job ended with `steps=[]`, so
+> nested artifact staging, Store credential validation, Store upload,
+> `latest/edge` release, and public verification never ran.
+>
+> Beta.4 therefore created no GitHub Release, R2 feed, Docker Hub or GHCR image,
+> or Snap Store revision: external distribution remained zero. Use
+> [Motrix 2.0.0-beta.5](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.5/docs/release-notes/2.0.0-beta.5.md)
+> instead. The remaining sections are retained as a historical record of the
+> intended beta.4 scope.
 
-The protected `v2.0.0-beta.1`, `v2.0.0-beta.2`, and `v2.0.0-beta.3` attempts
-all stopped before external distribution. They created no GitHub Release, R2
-update feed, Docker Hub or GHCR container image, or Snap Store revision.
-Beta.4 supersedes those attempts; the
-[beta.3 notes](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.4/docs/release-notes/2.0.0-beta.3.md)
-retain the most recent failure record.
+Motrix 2.0.0-beta.4 was intended to begin public validation of the rebuilt v2
+desktop app and headless server, shared download core, MDXP integrations, and
+sandboxed plugin system.
 
-## Release recovery fixes
+## Release recovery fixes included
 
-- Makes all ten digest-pinned isolated signing control texts byte-stable on
-  Windows by declaring each path as `text eol=lf` in `.gitattributes`. Git
-  checkout therefore preserves their canonical LF bytes across platforms. The
-  existing raw-byte fixed SHA-256 verification is unchanged; a CRLF artifact
-  or any other byte change continues to fail closed.
-- Preserves the complete triggering commit metadata in the Windows
+- Declared all ten digest-pinned isolated signing control text paths as
+  `text eol=lf` in `.gitattributes`, preserving canonical LF bytes across
+  Windows checkouts without weakening raw-byte SHA-256 verification.
+- Preserved the complete triggering commit metadata in the Windows
   signing-input handoff before isolated finalization.
-- Hydrates Electron runtime dependencies so the packaged desktop app contains
-  the modules required when it launches.
-- Stages the exact verified `amd64` and `arm64` Snap artifacts before Store
+- Hydrated Electron runtime dependencies so the packaged desktop app contained
+  the modules required when it launched.
+- Staged the exact verified `amd64` and `arm64` Snap artifacts before Store
   publication.
 
 ## Highlights
@@ -41,12 +58,12 @@ retain the most recent failure record.
 - A QuickJS plugin sandbox with capability consent, signed builtin plugins,
   and an in-app plugin marketplace.
 - Persistent, multi-architecture Server containers for NAS and home-server
-  deployments, published to both Docker Hub and GHCR.
+  deployments, with publication planned for Docker Hub and GHCR.
 - A rebuilt release pipeline with isolated macOS signing, explicit unsigned
   Windows finalization, package verification, third-party notices, and an SPDX
   SBOM.
 
-## Before testing
+## Planned testing precautions
 
 This is prerelease software. Back up your existing Motrix application data and
 downloads before installing it. Migration from Motrix v1 data has not yet been
@@ -56,7 +73,7 @@ When practical, test v2 in parallel using a separate OS account, machine, or
 Docker data directory. Please do not rely on this beta for your only copy of
 important downloads.
 
-## What to test
+## Planned testing
 
 - HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
   session recovery
@@ -64,31 +81,32 @@ important downloads.
   plugins
 - Headless Server deployment, persistent storage, and remote pairing
 
-## Available downloads
+## Intended downloads (not published)
 
-| Distribution | Architectures | Published output |
-|--------------|---------------|------------------|
+| Distribution | Architectures | Intended output |
+|--------------|---------------|-----------------|
 | macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
 | Windows | `x64` | NSIS installer (`.exe`) and ZIP |
 | Linux | `x64`, `arm64` | DEB and RPM |
 | Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.4` tag in both registries |
 | Snap Store | `amd64`, `arm64` | `latest/edge` |
 
-Container images are available as
+The planned container image names were
 `docker.io/motrixapp/motrix-server:2.0.0-beta.4` and
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.4`. See the
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.4`; they were not published. See the
 [Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.4/docs/docker-server.md)
 for storage, networking, and upgrade guidance.
 
 ## Known distribution limits
 
-- AppImage is not published for this beta.
-- Flatpak is validated separately and is not published by the release tag.
-- Windows `arm64` and all 32-bit packages are not available.
-- Windows packages are not Authenticode-signed and may trigger a Windows
-  SmartScreen warning. Download them only from this official GitHub release.
-- Beta container tags are immutable and do not update `latest`, `stable`, or
-  other stable floating tags.
+- AppImage was not published for this beta.
+- Flatpak was validated separately and was not published by the release tag.
+- Windows `arm64` and all 32-bit packages were not available.
+- The intended Windows packages would not have been Authenticode-signed and
+  could have triggered a Windows SmartScreen warning. No beta.4 Windows
+  package was published.
+- The planned beta container tags were immutable and would not have updated
+  `latest`, `stable`, or other stable floating tags.
 
 ## Feedback
 

--- a/docs/release-notes/2.0.0-beta.4.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.4.zh-CN.md
@@ -1,23 +1,38 @@
 # Motrix 2.0.0-beta.4
 
-[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.4/docs/release-notes/2.0.0-beta.4.md) | 简体中文
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.5/docs/release-notes/2.0.0-beta.4.md) | 简体中文
 
-Motrix 2.0.0-beta.4 是下一次计划对外发布的 Motrix Turbo beta。
-该版本开始公开验证重新开发的 v2 桌面应用与 Headless server、共用下载内核、
-MDXP 集成和沙箱化插件系统。
+> [!IMPORTANT]
+> 本次发布尝试未完成。5 个桌面构建 job——macOS `arm64`/`x64`、Windows
+> `x64` 和 Linux `arm64`/`x64`——均已成功。Windows 的 LF 固定修复使全部
+> 10 个固定摘要的签名控制文本保持 canonical LF，固定 SHA-256 校验也已通过。
+>
+> 隔离的 Windows finalize 随后在读取任何 Authenticode secret 前 fail closed。
+> 真实签名 manifest 包含 2,434 个无重复条目，采用目录优先的 DFS 顺序；verifier
+> 则要求每个 canonical 相对路径都按全路径字典序排列。首个逆序是
+> `js-yaml/lib/schema/…` 下的条目排在同级文件 `js-yaml/lib/schema.js` 前；
+> manifest 中没有重复条目。
+>
+> macOS 签名环境未获审批，两个 macOS finalize job 均被取消。assemble、
+> GitHub Release、R2 更新数据源发布和 container publish 均未执行。Snap 已成功
+> 构建、验证并上传 `arm64` GitHub Actions artifact；`amd64` 在 strict Snap
+> build 期间取消。Store publish job 以 `steps=[]` 结束，因此 nested artifact
+> staging、Store credential validation、Store upload、`latest/edge` release 和
+> public verification 均未执行。
+>
+> 因此 beta.4 未创建 GitHub Release、R2 数据源、Docker Hub 或 GHCR 镜像及
+> Snap Store revision，外部分发为零。请改用
+> [Motrix 2.0.0-beta.5](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.5/docs/release-notes/2.0.0-beta.5.zh-CN.md)。
+> 下文仅作为 beta.4 原定范围的历史记录保留。
 
-受保护的 `v2.0.0-beta.1`、`v2.0.0-beta.2` 和 `v2.0.0-beta.3` 发布尝试
-均在对外分发前停止，没有创建 GitHub Release，也未发布 R2 更新数据源、
-Docker Hub 或 GHCR 容器镜像及 Snap Store revision。beta.4 取代这些尝试；
-[beta.3 发布说明](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.4/docs/release-notes/2.0.0-beta.3.zh-CN.md)
-保留了最近一次失败记录。
+Motrix 2.0.0-beta.4 原计划开始公开验证重新开发的 v2 桌面应用和 Headless
+server、共用下载内核、MDXP 集成及沙箱化插件系统。
 
-## 发布恢复修复
+## 已包含的发布恢复修复
 
 - 在 `.gitattributes` 中把全部 10 个固定摘要的隔离签名控制文本路径声明为
-  `text eol=lf`，使 Git checkout 在 Windows 及其他平台都保留 canonical LF
-  字节，从而保持字节稳定。原有的原始字节固定 SHA-256 校验完全不变；CRLF
-  产物或任何其他字节变化仍会 fail closed。
+  `text eol=lf`，使 Windows checkout 保留 canonical LF 字节，同时不放宽
+  原始字节 SHA-256 校验。
 - 在进入隔离最终处理前，为 Windows signing-input 交接保留完整的触发 commit
   信息。
 - 补全 Electron runtime 依赖，确保打包后的桌面应用包含启动时所需的 module。
@@ -33,12 +48,12 @@ Docker Hub 或 GHCR 容器镜像及 Snap Store revision。beta.4 取代这些尝
 - 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地安全发现及远程 Server
   的 device-code 配对。
 - 提供带能力授权的 QuickJS 插件沙箱、已签名的内置插件和应用内插件市场。
-- 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器，并同时发布到
+- 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器，原计划同时发布到
   Docker Hub 与 GHCR。
 - 重建发布流水线，隔离 macOS 签名步骤，并明确支持未签名的 Windows
   最终处理，同时加入安装包验证、第三方声明和 SPDX SBOM。
 
-## 测试前须知
+## 原计划的测试须知
 
 这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1
 数据的迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
@@ -46,34 +61,36 @@ Docker Hub 或 GHCR 容器镜像及 Snap Store revision。beta.4 取代这些尝
 条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录与现有环境
 并行测试 v2。请勿让本 beta 成为重要下载文件的唯一存储位置。
 
-## 建议测试项
+## 原计划的测试项
 
 - HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
 - 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
 - Headless Server 部署、数据持久化和远程配对
 
-## 可用下载
+## 原计划下载（未发布）
 
-| 发布方式 | 架构 | 发布产物 |
-|----------|------|----------|
+| 发布方式 | 架构 | 原计划产物 |
+|----------|------|------------|
 | macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
 | Windows | `x64` | NSIS 安装包（`.exe`）和 ZIP |
 | Linux | `x64`、`arm64` | DEB 和 RPM |
 | Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中均发布不可变 tag `2.0.0-beta.4` |
 | Snap Store | `amd64`、`arm64` | `latest/edge` |
 
-容器镜像地址为 `docker.io/motrixapp/motrix-server:2.0.0-beta.4` 和
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.4`。数据持久化、网络和升级方法请参阅
+原计划的容器镜像地址为 `docker.io/motrixapp/motrix-server:2.0.0-beta.4` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.4`，但它们并未发布。数据持久化、
+网络和升级方法请参阅
 [Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.4/docs/docker-server.zh-CN.md)。
 
 ## 已知发布限制
 
-- 本 beta 不发布 AppImage。
-- Flatpak 会单独验证，不会随该版本 tag 发布。
+- 本 beta 未发布 AppImage。
+- Flatpak 已单独验证，未随该版本 tag 发布。
 - 不提供 Windows `arm64` 和任何 32 位安装包。
-- Windows 安装包未进行 Authenticode 签名，可能触发 Windows SmartScreen
-  警告。请仅从此 GitHub 官方 Release 下载。
-- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
+- 原计划的 Windows 安装包不会进行 Authenticode 签名，因而可能触发
+  Windows SmartScreen 警告。beta.4 实际并未发布 Windows 安装包。
+- 原计划的 beta container tag 不可变，不会更新 `latest`、`stable` 或其他
+  稳定版浮动 tag。
 
 ## 反馈
 

--- a/docs/release-notes/2.0.0-beta.5.md
+++ b/docs/release-notes/2.0.0-beta.5.md
@@ -1,0 +1,104 @@
+# Motrix 2.0.0-beta.5
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.5/docs/release-notes/2.0.0-beta.5.zh-CN.md)
+
+Motrix 2.0.0-beta.5 is the next Motrix Turbo beta intended for public
+distribution. It begins public validation of the rebuilt v2 desktop app and
+headless server, shared download core, MDXP integrations, and sandboxed plugin
+system.
+
+The protected `v2.0.0-beta.1`, `v2.0.0-beta.2`, `v2.0.0-beta.3`, and
+`v2.0.0-beta.4` attempts all stopped before external distribution. They created
+no GitHub Release, R2 update feed, Docker Hub or GHCR container image, or Snap
+Store revision. Beta.5 supersedes those attempts; the
+[beta.4 notes](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.5/docs/release-notes/2.0.0-beta.4.md)
+retain the most recent failure record.
+
+## Release recovery fixes
+
+- Sorts every Windows signing-input manifest into canonical code-unit order by
+  its full relative path before serialization. The creator performs one global
+  sort after inventory collection, and the verifier uses the same code-unit
+  comparator. The complete path is the sort key, so the sibling file
+  `js-yaml/lib/schema.js` precedes entries below `js-yaml/lib/schema/…` instead
+  of inheriting directory-first DFS discovery order. Strict path uniqueness,
+  path safety, fixed-digest verification, and fail-closed isolation remain
+  unchanged.
+- Keeps all ten digest-pinned isolated signing control texts byte-stable across
+  Windows checkouts through their `text eol=lf` declarations in
+  `.gitattributes`; raw-byte fixed SHA-256 verification remains strict.
+- Preserves the complete triggering commit metadata in the Windows
+  signing-input handoff before isolated finalization.
+- Hydrates Electron runtime dependencies so the packaged desktop app contains
+  the modules required when it launches.
+- Stages the exact verified `amd64` and `arm64` Snap artifacts before Store
+  publication.
+
+## Highlights
+
+- A ground-up desktop rebuild with Electron 43, React 19, and TypeScript 7,
+  including a customizable Dashboard, dark mode, a cross-platform application
+  menu, and clearer task-inspector feedback.
+- One host-neutral download core for both the desktop app and the new Node/Web
+  Server, with SQLite session recovery, tracker management, UPnP/NAT-PMP, and
+  HTTP, FTP, BitTorrent, and magnet support.
+- MDXP-based integration for the official CLI and browser handoff, including
+  secure local discovery and device-code pairing for remote Server instances.
+- A QuickJS plugin sandbox with capability consent, signed builtin plugins,
+  and an in-app plugin marketplace.
+- Persistent, multi-architecture Server containers for NAS and home-server
+  deployments, published to both Docker Hub and GHCR.
+- A rebuilt release pipeline with isolated macOS signing, explicit unsigned
+  Windows finalization, package verification, third-party notices, and an SPDX
+  SBOM.
+
+## Before testing
+
+This is prerelease software. Back up your existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Please do not rely on this beta for your only copy of
+important downloads.
+
+## What to test
+
+- HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
+  session recovery
+- Desktop integrations, browser and CLI handoff through MDXP, and sandboxed
+  plugins
+- Headless Server deployment, persistent storage, and remote pairing
+
+## Available downloads
+
+| Distribution | Architectures | Published output |
+|--------------|---------------|------------------|
+| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | DEB and RPM |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.5` tag in both registries |
+| Snap Store | `amd64`, `arm64` | `latest/edge` |
+
+Container images are available as
+`docker.io/motrixapp/motrix-server:2.0.0-beta.5` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.5`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.5/docs/docker-server.md)
+for storage, networking, and upgrade guidance.
+
+## Known distribution limits
+
+- AppImage is not published for this beta.
+- Flatpak is validated separately and is not published by the release tag.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are not Authenticode-signed and may trigger a Windows
+  SmartScreen warning. Download them only from this official GitHub release.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.5.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.5.zh-CN.md
@@ -1,0 +1,87 @@
+# Motrix 2.0.0-beta.5
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.5/docs/release-notes/2.0.0-beta.5.md) | 简体中文
+
+Motrix 2.0.0-beta.5 是下一次计划对外发布的 Motrix Turbo beta。
+该版本开始公开验证重新开发的 v2 桌面应用与 Headless server、共用下载内核、
+MDXP 集成和沙箱化插件系统。
+
+受保护的 `v2.0.0-beta.1`、`v2.0.0-beta.2`、`v2.0.0-beta.3` 和
+`v2.0.0-beta.4` 发布尝试均在对外分发前停止，没有创建 GitHub Release，也未发布
+R2 更新数据源、Docker Hub 或 GHCR 容器镜像及 Snap Store revision。beta.5
+取代这些尝试；
+[beta.4 发布说明](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.5/docs/release-notes/2.0.0-beta.4.zh-CN.md)
+保留了最近一次失败记录。
+
+## 发布恢复修复
+
+- 在序列化前，以完整相对路径为 key，把每份 Windows signing-input manifest
+  按 canonical code-unit 顺序排列。
+  creator 会在 inventory 收集完成后进行一次全局排序，verifier 使用同一个
+  code-unit comparator。完整路径排序会让同级文件 `js-yaml/lib/schema.js` 排在
+  `js-yaml/lib/schema/…` 下的条目前，不再沿用目录优先的 DFS 发现顺序。
+  严格的路径唯一性、路径安全、固定摘要验证和 fail-closed 隔离均保持不变。
+- 通过 `.gitattributes` 中的 `text eol=lf` 声明，使全部 10 个固定摘要的隔离
+  签名控制文本在 Windows checkout 间保持字节稳定；原始字节固定 SHA-256 校验
+  仍保持严格。
+- 在进入隔离最终处理前，为 Windows signing-input 交接保留完整的触发 commit
+  信息。
+- 补全 Electron runtime 依赖，确保打包后的桌面应用包含启动时所需的 module。
+- 在发布到 Store 前，暂存经过验证且确定的 `amd64` 和 `arm64` Snap 产物。
+
+## 主要变化
+
+- 使用 Electron 43、React 19 和 TypeScript 7 从头重建桌面应用，提供可自定义
+  Dashboard、深色模式、跨平台应用菜单，以及更清晰的任务检查器反馈。
+- 桌面应用和全新的 Node/Web Server 共用与宿主无关的下载内核，支持 SQLite
+  session 恢复、Tracker 管理、UPnP/NAT-PMP，以及 HTTP、FTP、BitTorrent 和
+  磁力链接下载。
+- 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地安全发现及远程 Server
+  的 device-code 配对。
+- 提供带能力授权的 QuickJS 插件沙箱、已签名的内置插件和应用内插件市场。
+- 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器，并同时发布到
+  Docker Hub 与 GHCR。
+- 重建发布流水线，隔离 macOS 签名步骤，并明确支持未签名的 Windows
+  最终处理，同时加入安装包验证、第三方声明和 SPDX SBOM。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1
+数据的迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
+
+条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录与现有环境
+并行测试 v2。请勿让本 beta 成为重要下载文件的唯一存储位置。
+
+## 建议测试项
+
+- HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
+- 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
+- Headless Server 部署、数据持久化和远程配对
+
+## 可用下载
+
+| 发布方式 | 架构 | 发布产物 |
+|----------|------|----------|
+| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
+| Windows | `x64` | NSIS 安装包（`.exe`）和 ZIP |
+| Linux | `x64`、`arm64` | DEB 和 RPM |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中均发布不可变 tag `2.0.0-beta.5` |
+| Snap Store | `amd64`、`arm64` | `latest/edge` |
+
+容器镜像地址为 `docker.io/motrixapp/motrix-server:2.0.0-beta.5` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.5`。数据持久化、网络和升级方法请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.5/docs/docker-server.zh-CN.md)。
+
+## 已知发布限制
+
+- 本 beta 不发布 AppImage。
+- Flatpak 会单独验证，不会随该版本 tag 发布。
+- 不提供 Windows `arm64` 和任何 32 位安装包。
+- Windows 安装包未进行 Authenticode 签名，可能触发 Windows SmartScreen
+  警告。请仅从此 GitHub 官方 Release 下载。
+- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
+
+## 反馈
+
+请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现的问题，
+并附上操作系统、架构、安装包类型和复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -76,13 +76,23 @@
   <releases>
     <!-- Update this list on every release; Flathub linter requires the most
          recent version listed here to match the manifest's source tag. -->
+    <release version="2.0.0-beta.5" date="2026-08-15">
+      <description>
+        <p>
+          Release recovery update that sorts the complete canonical relative
+          paths in the Windows signing manifest by code-unit order, matching
+          the isolated verifier while retaining strict uniqueness and digest
+          validation.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.4" date="2026-08-15">
       <description>
         <p>
-          Release recovery update that declares all ten fixed-digest signing
-          control text paths as text eol=lf, preserving canonical LF bytes
-          across Windows checkouts while leaving raw-byte SHA-256 verification
-          unchanged.
+          Unpublished Motrix Turbo beta attempt. All five desktop builds
+          succeeded and the Windows LF digest fix held, but finalization
+          rejected a unique 2,434-entry DFS manifest that was not in full-path
+          dictionary order. No external distribution was published.
         </p>
       </description>
     </release>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1",
   "description": "A full-featured download manager",
   "keywords": [],

--- a/scripts/release-signing-input.mjs
+++ b/scripts/release-signing-input.mjs
@@ -125,9 +125,9 @@ function portable(relativePath) {
   return relativePath.split(path.sep).join('/')
 }
 
-function compareNames(left, right) {
-  if (left.name < right.name) return -1
-  if (left.name > right.name) return 1
+function compareCodeUnits(left, right) {
+  if (left < right) return -1
+  if (left > right) return 1
   return 0
 }
 
@@ -342,7 +342,7 @@ async function inventory(root, options = {}) {
   let totalBytes = 0
   async function visit(current, relative) {
     const entries = await readdir(current, { withFileTypes: true })
-    entries.sort(compareNames)
+    entries.sort((left, right) => compareCodeUnits(left.name, right.name))
     for (const entry of entries) {
       const absolute = path.join(current, entry.name)
       const relativePath = relative
@@ -386,7 +386,7 @@ async function inventory(root, options = {}) {
     }
   }
   await visit(root, '')
-  return files
+  return files.sort((left, right) => compareCodeUnits(left.path, right.path))
 }
 
 function tarString(buffer, offset, length, value) {
@@ -747,7 +747,7 @@ export async function verifySigningInput(options) {
   const expectedPaths = manifest.files.map((entry) => entry.path)
   if (
     JSON.stringify(expectedPaths) !==
-    JSON.stringify([...new Set(expectedPaths)].sort())
+    JSON.stringify([...new Set(expectedPaths)].sort(compareCodeUnits))
   ) {
     throw new Error('signing input file inventory must be sorted and unique')
   }

--- a/tests/scripts/release-signing-input.test.ts
+++ b/tests/scripts/release-signing-input.test.ts
@@ -7,6 +7,7 @@ import {
   mkdtemp,
   readdir,
   readFile,
+  realpath,
   rm,
   truncate,
   writeFile,
@@ -150,6 +151,62 @@ describe('isolated release signing input', () => {
       tools: { electronBuilder: '26.15.7', electron: '43.4.0' },
       limits: SIGNING_ARCHIVE_LIMITS,
     })
+  })
+
+  it('creates and verifies a canonical manifest for prefix-colliding paths', async () => {
+    const schemaFile = 'dist/electron-app/node_modules/js-yaml/lib/schema.js'
+    const schemaChild =
+      'dist/electron-app/node_modules/js-yaml/lib/schema/core.js'
+    const libsodiumFile =
+      'dist/electron-app/node_modules/libsodium/dist/libsodium.js'
+    const libsodiumWrappersFile =
+      'dist/electron-app/node_modules/libsodium-wrappers/dist/libsodium-wrappers.js'
+    const directory = await createGeneratedSigningInput([
+      [schemaChild, 'schema child'],
+      [schemaFile, 'schema module'],
+      [libsodiumFile, 'libsodium'],
+      [libsodiumWrappersFile, 'libsodium wrappers'],
+    ])
+    const manifestPath = path.join(directory, 'signing-input-manifest.json')
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as {
+      files: Array<{
+        path: string
+        bytes: number
+        mode: number
+        sha256: string
+      }>
+    }
+    const paths = manifest.files.map((entry) => entry.path)
+
+    expect(paths).toEqual([...paths].sort(compareCodeUnits))
+    expect(paths.indexOf(schemaFile)).toBeLessThan(paths.indexOf(schemaChild))
+    expect(paths.indexOf(libsodiumWrappersFile)).toBeLessThan(
+      paths.indexOf(libsodiumFile)
+    )
+    await expect(verify(directory)).resolves.toMatchObject({
+      target: { key: 'win32-x64' },
+    })
+
+    const schemaFileIndex = manifest.files.findIndex(
+      (entry) => entry.path === schemaFile
+    )
+    const schemaChildIndex = manifest.files.findIndex(
+      (entry) => entry.path === schemaChild
+    )
+    ;[manifest.files[schemaFileIndex], manifest.files[schemaChildIndex]] = [
+      manifest.files[schemaChildIndex]!,
+      manifest.files[schemaFileIndex]!,
+    ]
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+    await expect(verify(directory)).rejects.toThrow(/sorted and unique/)
+
+    ;[manifest.files[schemaFileIndex], manifest.files[schemaChildIndex]] = [
+      manifest.files[schemaChildIndex]!,
+      manifest.files[schemaFileIndex]!,
+    ]
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+    await writeFile(path.join(directory, libsodiumFile), 'tampered!')
+    await expect(verify(directory)).rejects.toThrow(/inventory or digest/)
   })
 
   it.each([
@@ -344,6 +401,67 @@ async function createFixture(
   return directory
 }
 
+async function createGeneratedSigningInput(
+  files: Array<[string, string]>
+): Promise<string> {
+  const sourceRoot = await realpath(
+    await temporaryDirectory('motrix-signing-source-')
+  )
+  for (const [source] of TRUSTED_FIXTURES) {
+    const target = path.join(sourceRoot, source)
+    await mkdir(path.dirname(target), { recursive: true })
+    await cp(path.join(ROOT, source), target)
+  }
+  for (const [relativePath, content] of [
+    ['THIRD_PARTY_LICENSES/LICENSE.txt', 'license'],
+    ['THIRD_PARTY_NOTICES.md', 'notices'],
+    ['THIRD_PARTY_NOTICES.zh-CN.md', 'notices'],
+    ['build/legal/LICENSE.txt', 'legal'],
+    ['dist/builtin-plugins/plugin.json', '{}'],
+    ['extra/aria2.conf', ''],
+    ['extra/tray/icon.png', 'tray'],
+    ['extra/win32/x64/aria2c.exe', 'aria2'],
+    [
+      'packages/native-host/dist/win32-x64/motrix-native-host.exe',
+      'native host',
+    ],
+    ['release/size-reports/win32-x64.json', '{}'],
+    ...files,
+  ] as Array<[string, string]>) {
+    await writeFixtureFile(sourceRoot, relativePath, content)
+  }
+
+  const generatedRoot = await temporaryDirectory('motrix-signing-generated-')
+  const directory = path.join(generatedRoot, 'signing-input')
+  const archive = path.join(generatedRoot, 'signing-input.tar')
+  const result = spawnSync(
+    process.execPath,
+    [
+      path.join(sourceRoot, 'scripts/release-signing-input.mjs'),
+      '--mode',
+      'create',
+      '--directory',
+      directory,
+      '--platform',
+      'win32',
+      '--arch',
+      'x64',
+      '--commit',
+      COMMIT,
+      '--archive',
+      archive,
+    ],
+    { cwd: sourceRoot, encoding: 'utf8' }
+  )
+  if (result.error) throw result.error
+  if (result.status !== 0) {
+    throw new Error(
+      `signing input create failed: ${result.stderr || result.stdout}`
+    )
+  }
+  return directory
+}
+
 async function refreshManifest(directory: string) {
   const manifestPath = path.join(directory, 'signing-input-manifest.json')
   await rm(manifestPath, { force: true })
@@ -400,5 +518,11 @@ async function inventory(root: string) {
     }
   }
   await walk(root)
-  return files
+  return files.sort((left, right) => compareCodeUnits(left.path, right.path))
+}
+
+function compareCodeUnits(left: string, right: string): number {
+  if (left < right) return -1
+  if (left > right) return 1
+  return 0
 }

--- a/tests/scripts/release-version-contract.test.ts
+++ b/tests/scripts/release-version-contract.test.ts
@@ -79,7 +79,7 @@ describe('release version contract', () => {
     )
   })
 
-  it('preserves current distribution disclosures', () => {
+  it('preserves current release references', () => {
     const english = read(`docs/release-notes/${packageVersion}.md`)
     const chinese = read(`docs/release-notes/${packageVersion}.zh-CN.md`)
 
@@ -90,9 +90,51 @@ describe('release version contract', () => {
       `https://github.com/agalwood/Motrix/blob/${releaseTag}/docs/docker-server.zh-CN.md`
     )
 
+    expect(english).toContain(`motrix-server:${packageVersion}`)
+    expect(chinese).toContain(`motrix-server:${packageVersion}`)
+  })
+
+  it('preserves beta.5 canonical manifest-order recovery history', () => {
+    const english = read('docs/release-notes/2.0.0-beta.5.md')
+    const chinese = read('docs/release-notes/2.0.0-beta.5.zh-CN.md')
+    const normalizedEnglish = english.replace(/\s+/g, ' ')
+    const normalizedChinese = chinese.replace(/\s+/g, ' ')
+
+    expect(english).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.5/docs/release-notes/2.0.0-beta.4.md'
+    )
+    expect(chinese).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.5/docs/release-notes/2.0.0-beta.4.zh-CN.md'
+    )
+    expect(normalizedEnglish).toContain(
+      'canonical code-unit order by its full relative path'
+    )
+    expect(normalizedEnglish).toContain(
+      'instead of inheriting directory-first DFS discovery order'
+    )
+    expect(normalizedEnglish).toContain(
+      'one global sort after inventory collection, and the verifier uses the same code-unit comparator'
+    )
+    expect(english).toContain('Strict path uniqueness')
+    expect(english).toContain('fixed-digest')
+    expect(normalizedChinese).toContain(
+      '完整相对路径为 key，把每份 Windows signing-input manifest 按 canonical code-unit 顺序排列'
+    )
+    expect(normalizedChinese).toContain(
+      'inventory 收集完成后进行一次全局排序，verifier 使用同一个 code-unit comparator'
+    )
+    expect(normalizedChinese).toContain('不再沿用目录优先的 DFS 发现顺序')
+    expect(chinese).toContain('严格的路径唯一性')
+    expect(chinese).toContain('固定摘要验证')
     for (const source of [english, chinese]) {
-      expect(source).toContain(`motrix-server:${packageVersion}`)
-      expect(source).toContain('Snap')
+      expect(source).toContain('v2.0.0-beta.4')
+      expect(source).toContain('js-yaml/lib/schema.js')
+      expect(source).toContain('js-yaml/lib/schema/…')
+      expect(source).toContain('fail-closed')
+      expect(source).toContain('.gitattributes')
+      expect(source).toContain('text eol=lf')
+      expect(source).toContain('SHA-256')
+      expect(source).toContain('latest/edge')
       expect(source).toContain('AppImage')
       expect(source).toContain('Flatpak')
       expect(source).toContain('Authenticode')
@@ -100,32 +142,68 @@ describe('release version contract', () => {
     }
   })
 
-  it('preserves beta.4 Git-enforced LF signing-control history', () => {
+  it('marks beta.4 as an unpublished attempt superseded by beta.5', () => {
     const english = read('docs/release-notes/2.0.0-beta.4.md')
     const chinese = read('docs/release-notes/2.0.0-beta.4.zh-CN.md')
+    const normalizedEnglish = english
+      .replace(/^>\s?/gm, '')
+      .replace(/\s+/g, ' ')
+    const normalizedChinese = chinese
+      .replace(/^>\s?/gm, '')
+      .replace(/\s+/g, ' ')
 
     expect(english).toContain(
-      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.4/docs/release-notes/2.0.0-beta.3.md'
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.5/docs/release-notes/2.0.0-beta.4.zh-CN.md'
     )
     expect(chinese).toContain(
-      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.4/docs/release-notes/2.0.0-beta.3.zh-CN.md'
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.5/docs/release-notes/2.0.0-beta.4.md'
     )
-    expect(english).toContain('byte-stable')
-    expect(english).toContain('all ten digest-pinned')
-    expect(english).toContain('CRLF artifact')
-    expect(english).toContain('raw-byte')
-    expect(chinese).toContain('字节稳定')
-    expect(chinese).toContain('全部 10 个固定摘要')
-    expect(chinese.replace(/\s+/g, ' ')).toContain('CRLF 产物')
-    expect(chinese).toContain('原始字节')
+    expect(english).toContain('This release attempt did not complete')
+    expect(normalizedEnglish).toContain('All five desktop build jobs')
+    expect(normalizedEnglish).toContain('fixed SHA-256 checks passed')
+    expect(normalizedEnglish).toContain('2,434 unique entries')
+    expect(normalizedEnglish).toContain('full-path dictionary order')
+    expect(normalizedEnglish).toContain('no duplicate entries')
+    expect(normalizedEnglish).toContain(
+      'before any Authenticode secret was read'
+    )
+    expect(normalizedEnglish).toContain('were not approved')
+    expect(chinese).toContain('本次发布尝试未完成')
+    expect(normalizedChinese).toContain('5 个桌面构建 job')
+    expect(normalizedChinese).toContain('固定 SHA-256 校验也已通过')
+    expect(normalizedChinese).toContain('2,434 个无重复条目')
+    expect(normalizedChinese).toContain('全路径字典序')
+    expect(normalizedChinese).toContain('manifest 中没有重复条目')
+    expect(normalizedChinese).toContain('读取任何 Authenticode secret 前')
+    expect(normalizedChinese).toContain('macOS 签名环境未获审批')
     for (const source of [english, chinese]) {
-      expect(source).toContain('.gitattributes')
-      expect(source).toContain('text eol=lf')
-      expect(source).toContain('CRLF')
-      expect(source).toContain('canonical LF')
+      const normalized = source.replace(/^>\s?/gm, '').replace(/\s+/g, ' ')
+      expect(source).toContain('v2.0.0-beta.5')
+      expect(source).toContain('js-yaml/lib/schema/…')
+      expect(source).toContain('js-yaml/lib/schema.js')
+      expect(source).toContain('DFS')
       expect(source).toContain('SHA-256')
-      expect(source).toContain('fail closed')
+      expect(source).toMatch(/finaliz/)
+      expect(source).toMatch(/assemble/i)
+      expect(source).toContain('GitHub Release')
+      expect(source).toContain('R2')
+      expect(source).toContain('container')
+      expect(source).toContain('Snap')
+      expect(source).toContain('arm64')
+      expect(source).toContain('amd64')
+      expect(normalized).toContain('strict Snap')
+      expect(source).toContain('steps=[]')
+      expect(normalized).toContain('nested artifact staging')
+      expect(normalized).toContain('Store credential validation')
+      expect(normalized).toContain('Store upload')
+      expect(normalized).toContain('public verification')
       expect(source).toContain('latest/edge')
+      expect(source).toContain('Docker Hub')
+      expect(source).toContain('GHCR')
+      expect(source).toContain('AppImage')
+      expect(source).toContain('Flatpak')
+      expect(source).toContain('Authenticode')
+      expect(source).toContain('SmartScreen')
     }
   })
 

--- a/tests/scripts/workflow-release-matrix.test.ts
+++ b/tests/scripts/workflow-release-matrix.test.ts
@@ -1240,7 +1240,14 @@ describe('release workflow publication contract', () => {
     expect(source).toContain('tar contains trailing bytes')
     expect(source).toContain('unsupported tar entry type')
 
-    expect(releaseSource).toContain(
+    const verification = jobSteps(sign).find(
+      (step) => step.name === 'Verify signing input before secrets'
+    )
+    const verifierEnvironment = asRecord(
+      verification?.env,
+      'signing input verifier environment'
+    )
+    expect(stringField(verifierEnvironment, 'VERIFIER_SHA256')).toBe(
       createHash('sha256').update(signingInputSource).digest('hex')
     )
   })


### PR DESCRIPTION
## Summary

- prepare `2.0.0-beta.5` across package metadata, READMEs, AppStream metadata, and bilingual release notes
- make signing-input manifests canonical by globally sorting complete portable paths with the same code-unit comparator in the creator and verifier
- preserve strict uniqueness, path safety, fixed SHA-256 digests, and fail-closed verification
- record the accurate beta.4 failure history and its zero external distribution

## Root cause

The beta.4 creator emitted signing-input inventory in directory-first DFS order, while isolated finalization required a globally sorted full-path inventory. The real 2,434-entry manifest was unique and digest-valid but contained nine ordering inversions, such as `js-yaml/lib/schema/core.js` appearing before sibling `js-yaml/lib/schema.js`.

## Validation

- 81 focused Vitest tests passed
- TypeScript check passed
- Biome passed across the changed release files and `src/`
- `actionlint` passed for the release workflow
- architecture boundary checks passed
- AppStream XML validation passed
- staged diff whitespace check passed
- independent workflow/security and version/documentation reviews found no blocking issues

## Distribution status

`v2.0.0-beta.4` remains an immutable protected tag, but its GitHub Release, R2 feed, container publication, and Snap Store publication never ran. This PR prepares the next public attempt as `v2.0.0-beta.5`.
