### PR TITLE
fix(release): prepare v2.0.0-beta.6 snap recovery

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -256,6 +256,27 @@ jobs:
         timeout-minutes: 10
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Setup pnpm for verification
+        timeout-minutes: 5
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 11.21.0
+          run_install: false
+
+      - name: Setup Node.js for verification
+        timeout-minutes: 5
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install verifier dependencies
+        timeout-minutes: 10
+        run: pnpm install --frozen-lockfile --ignore-scripts
+        env:
+          MOTRIX_SKIP_ELECTRON_REBUILD: '1'
+          MOTRIX_SKIP_ENGINE_FETCH: '1'
+
       - name: Download both architecture artifacts
         timeout-minutes: 10
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. Download
-[v2.0.0-beta.5 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.5)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.5.md)
+[v2.0.0-beta.6 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.6)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.6.md)
 before installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -147,7 +147,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.5'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.6'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。安装前请从 GitHub Releases
-下载 [v2.0.0-beta.5](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.5)，
-并阅读[完整发布说明](./docs/release-notes/2.0.0-beta.5.zh-CN.md)。
+下载 [v2.0.0-beta.6](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.6)，
+并阅读[完整发布说明](./docs/release-notes/2.0.0-beta.6.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -142,7 +142,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.5'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.6'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.5.md
+++ b/docs/release-notes/2.0.0-beta.5.md
@@ -1,20 +1,43 @@
 # Motrix 2.0.0-beta.5
 
-English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.5/docs/release-notes/2.0.0-beta.5.zh-CN.md)
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.6/docs/release-notes/2.0.0-beta.5.zh-CN.md)
 
-Motrix 2.0.0-beta.5 is the next Motrix Turbo beta intended for public
-distribution. It begins public validation of the rebuilt v2 desktop app and
-headless server, shared download core, MDXP integrations, and sandboxed plugin
-system.
+> [!IMPORTANT]
+> This release attempt did not complete. All five desktop build jobs—macOS
+> `arm64`/`x64`, Windows `x64`, and Linux `arm64`/`x64`—succeeded. The macOS
+> signing environments remained pending approval, so neither macOS
+> finalization job ran. The unsigned Windows finalization job was canceled
+> while it was in progress. Assemble, GitHub Release, R2 update-feed
+> publishing, and Docker Hub/GHCR container publishing were canceled before
+> they ran.
+>
+> Snap validated the source and successfully built, verified, and uploaded the
+> internal GitHub Actions artifacts for both `amd64` and `arm64`. The
+> `publish-edge` job downloaded both artifacts, then failed in
+> `Verify complete upload set` because `verify-snap-artifact.mjs` could not
+> resolve its `js-yaml` dependency on the isolated publish runner
+> (`ERR_MODULE_NOT_FOUND`). This happened before Store credential validation,
+> Store upload, exact revision binding, `latest/edge` release, public channel
+> verification, or revision record preservation.
+>
+> Beta.5 therefore created no GitHub Release, R2 feed, Docker Hub or GHCR image,
+> or Snap Store revision: external distribution remained zero. Use
+> [Motrix 2.0.0-beta.6](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.6/docs/release-notes/2.0.0-beta.6.md)
+> instead. The remaining sections are retained as a historical record of the
+> intended beta.5 scope.
+
+Motrix 2.0.0-beta.5 was intended to begin public validation of the rebuilt v2
+desktop app and headless server, shared download core, MDXP integrations, and
+sandboxed plugin system.
 
 The protected `v2.0.0-beta.1`, `v2.0.0-beta.2`, `v2.0.0-beta.3`, and
 `v2.0.0-beta.4` attempts all stopped before external distribution. They created
 no GitHub Release, R2 update feed, Docker Hub or GHCR container image, or Snap
-Store revision. Beta.5 supersedes those attempts; the
+Store revision. Beta.5 was intended to supersede those attempts; the
 [beta.4 notes](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.5/docs/release-notes/2.0.0-beta.4.md)
-retain the most recent failure record.
+retain the preceding failure record.
 
-## Release recovery fixes
+## Release recovery fixes included
 
 - Sorts every Windows signing-input manifest into canonical code-unit order by
   its full relative path before serialization. The creator performs one global
@@ -34,7 +57,7 @@ retain the most recent failure record.
 - Stages the exact verified `amd64` and `arm64` Snap artifacts before Store
   publication.
 
-## Highlights
+## Planned highlights
 
 - A ground-up desktop rebuild with Electron 43, React 19, and TypeScript 7,
   including a customizable Dashboard, dark mode, a cross-platform application
@@ -47,12 +70,12 @@ retain the most recent failure record.
 - A QuickJS plugin sandbox with capability consent, signed builtin plugins,
   and an in-app plugin marketplace.
 - Persistent, multi-architecture Server containers for NAS and home-server
-  deployments, published to both Docker Hub and GHCR.
+  deployments, with publication planned for Docker Hub and GHCR.
 - A rebuilt release pipeline with isolated macOS signing, explicit unsigned
   Windows finalization, package verification, third-party notices, and an SPDX
   SBOM.
 
-## Before testing
+## Planned testing precautions
 
 This is prerelease software. Back up your existing Motrix application data and
 downloads before installing it. Migration from Motrix v1 data has not yet been
@@ -62,7 +85,7 @@ When practical, test v2 in parallel using a separate OS account, machine, or
 Docker data directory. Please do not rely on this beta for your only copy of
 important downloads.
 
-## What to test
+## Planned testing
 
 - HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
   session recovery
@@ -70,31 +93,32 @@ important downloads.
   plugins
 - Headless Server deployment, persistent storage, and remote pairing
 
-## Available downloads
+## Intended downloads (not published)
 
-| Distribution | Architectures | Published output |
-|--------------|---------------|------------------|
+| Distribution | Architectures | Intended output |
+|--------------|---------------|-----------------|
 | macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
 | Windows | `x64` | NSIS installer (`.exe`) and ZIP |
 | Linux | `x64`, `arm64` | DEB and RPM |
 | Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.5` tag in both registries |
 | Snap Store | `amd64`, `arm64` | `latest/edge` |
 
-Container images are available as
+The planned container image names were
 `docker.io/motrixapp/motrix-server:2.0.0-beta.5` and
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.5`. See the
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.5`; they were not published. See the
 [Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.5/docs/docker-server.md)
 for storage, networking, and upgrade guidance.
 
 ## Known distribution limits
 
-- AppImage is not published for this beta.
-- Flatpak is validated separately and is not published by the release tag.
-- Windows `arm64` and all 32-bit packages are not available.
-- Windows packages are not Authenticode-signed and may trigger a Windows
-  SmartScreen warning. Download them only from this official GitHub release.
-- Beta container tags are immutable and do not update `latest`, `stable`, or
-  other stable floating tags.
+- AppImage was not published for this beta.
+- Flatpak was validated separately and was not published by the release tag.
+- Windows `arm64` and all 32-bit packages were not available.
+- The intended Windows packages would not have been Authenticode-signed and
+  could have triggered a Windows SmartScreen warning. No beta.5 Windows
+  package was published.
+- The planned beta container tags were immutable and would not have updated
+  `latest`, `stable`, or other stable floating tags.
 
 ## Feedback
 

--- a/docs/release-notes/2.0.0-beta.5.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.5.zh-CN.md
@@ -1,19 +1,38 @@
 # Motrix 2.0.0-beta.5
 
-[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.5/docs/release-notes/2.0.0-beta.5.md) | 简体中文
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.6/docs/release-notes/2.0.0-beta.5.md) | 简体中文
 
-Motrix 2.0.0-beta.5 是下一次计划对外发布的 Motrix Turbo beta。
-该版本开始公开验证重新开发的 v2 桌面应用与 Headless server、共用下载内核、
-MDXP 集成和沙箱化插件系统。
+> [!IMPORTANT]
+> 本次发布尝试未完成。5 个桌面构建 job——macOS `arm64`/`x64`、Windows
+> `x64` 和 Linux `arm64`/`x64`——均已成功。macOS 签名环境一直等待审批，
+> 两个 macOS finalize job 均未执行；未签名 Windows
+> finalize job 在运行过程中取消。assemble、GitHub Release、R2 更新数据源
+> 发布以及 Docker Hub/GHCR container publish 均在执行前取消。
+>
+> Snap 已完成 source validation，并成功构建、验证和上传 `amd64`、`arm64`
+> 两个架构的内部 GitHub Actions artifact。`publish-edge` job 下载两个 artifact
+> 后，在 `Verify complete upload set` 失败：隔离 publish runner 上的
+> `verify-snap-artifact.mjs` 无法解析其 `js-yaml` 依赖
+> （`ERR_MODULE_NOT_FOUND`）。失败发生在 Store credential validation、Store
+> upload、精确 revision 绑定、`latest/edge` release、public channel
+> verification 和 revision record preservation 之前。
+>
+> 因此 beta.5 未创建 GitHub Release、R2 数据源、Docker Hub 或 GHCR 镜像及
+> Snap Store revision，外部分发为零。请改用
+> [Motrix 2.0.0-beta.6](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.6/docs/release-notes/2.0.0-beta.6.zh-CN.md)。
+> 下文仅作为 beta.5 原定范围的历史记录保留。
+
+Motrix 2.0.0-beta.5 原计划开始公开验证重新开发的 v2 桌面应用与 Headless
+server、共用下载内核、MDXP 集成和沙箱化插件系统。
 
 受保护的 `v2.0.0-beta.1`、`v2.0.0-beta.2`、`v2.0.0-beta.3` 和
 `v2.0.0-beta.4` 发布尝试均在对外分发前停止，没有创建 GitHub Release，也未发布
 R2 更新数据源、Docker Hub 或 GHCR 容器镜像及 Snap Store revision。beta.5
-取代这些尝试；
+原计划取代这些尝试；
 [beta.4 发布说明](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.5/docs/release-notes/2.0.0-beta.4.zh-CN.md)
-保留了最近一次失败记录。
+保留了前序失败记录。
 
-## 发布恢复修复
+## 已包含的发布恢复修复
 
 - 在序列化前，以完整相对路径为 key，把每份 Windows signing-input manifest
   按 canonical code-unit 顺序排列。
@@ -29,7 +48,7 @@ R2 更新数据源、Docker Hub 或 GHCR 容器镜像及 Snap Store revision。b
 - 补全 Electron runtime 依赖，确保打包后的桌面应用包含启动时所需的 module。
 - 在发布到 Store 前，暂存经过验证且确定的 `amd64` 和 `arm64` Snap 产物。
 
-## 主要变化
+## 原计划主要变化
 
 - 使用 Electron 43、React 19 和 TypeScript 7 从头重建桌面应用，提供可自定义
   Dashboard、深色模式、跨平台应用菜单，以及更清晰的任务检查器反馈。
@@ -39,12 +58,12 @@ R2 更新数据源、Docker Hub 或 GHCR 容器镜像及 Snap Store revision。b
 - 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地安全发现及远程 Server
   的 device-code 配对。
 - 提供带能力授权的 QuickJS 插件沙箱、已签名的内置插件和应用内插件市场。
-- 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器，并同时发布到
+- 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器，原计划同时发布到
   Docker Hub 与 GHCR。
 - 重建发布流水线，隔离 macOS 签名步骤，并明确支持未签名的 Windows
   最终处理，同时加入安装包验证、第三方声明和 SPDX SBOM。
 
-## 测试前须知
+## 原计划的测试须知
 
 这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1
 数据的迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
@@ -52,34 +71,36 @@ R2 更新数据源、Docker Hub 或 GHCR 容器镜像及 Snap Store revision。b
 条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录与现有环境
 并行测试 v2。请勿让本 beta 成为重要下载文件的唯一存储位置。
 
-## 建议测试项
+## 原计划的测试项
 
 - HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
 - 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
 - Headless Server 部署、数据持久化和远程配对
 
-## 可用下载
+## 原计划下载（未发布）
 
-| 发布方式 | 架构 | 发布产物 |
-|----------|------|----------|
+| 发布方式 | 架构 | 原计划产物 |
+|----------|------|------------|
 | macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
 | Windows | `x64` | NSIS 安装包（`.exe`）和 ZIP |
 | Linux | `x64`、`arm64` | DEB 和 RPM |
 | Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中均发布不可变 tag `2.0.0-beta.5` |
 | Snap Store | `amd64`、`arm64` | `latest/edge` |
 
-容器镜像地址为 `docker.io/motrixapp/motrix-server:2.0.0-beta.5` 和
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.5`。数据持久化、网络和升级方法请参阅
+原计划的容器镜像地址为 `docker.io/motrixapp/motrix-server:2.0.0-beta.5` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.5`，但它们并未发布。数据持久化、
+网络和升级方法请参阅
 [Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.5/docs/docker-server.zh-CN.md)。
 
 ## 已知发布限制
 
-- 本 beta 不发布 AppImage。
-- Flatpak 会单独验证，不会随该版本 tag 发布。
+- 本 beta 未发布 AppImage。
+- Flatpak 已单独验证，未随该版本 tag 发布。
 - 不提供 Windows `arm64` 和任何 32 位安装包。
-- Windows 安装包未进行 Authenticode 签名，可能触发 Windows SmartScreen
-  警告。请仅从此 GitHub 官方 Release 下载。
-- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
+- 原计划的 Windows 安装包不会进行 Authenticode 签名，因而可能触发
+  Windows SmartScreen 警告。beta.5 实际并未发布 Windows 安装包。
+- 原计划的 beta container tag 不可变，不会更新 `latest`、`stable` 或其他
+  稳定版浮动 tag。
 
 ## 反馈
 

--- a/docs/release-notes/2.0.0-beta.6.md
+++ b/docs/release-notes/2.0.0-beta.6.md
@@ -1,0 +1,111 @@
+# Motrix 2.0.0-beta.6
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.6/docs/release-notes/2.0.0-beta.6.zh-CN.md)
+
+Motrix 2.0.0-beta.6 is the next Motrix Turbo beta intended for public
+distribution. It begins public validation of the rebuilt v2 desktop app and
+headless server, shared download core, MDXP integrations, and sandboxed plugin
+system.
+
+The protected `v2.0.0-beta.1` through `v2.0.0-beta.5` attempts all stopped
+before external distribution. They created no GitHub Release, R2 update feed,
+Docker Hub or GHCR container image, or Snap Store revision. Beta.6 supersedes
+those attempts; the
+[beta.5 notes](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.6/docs/release-notes/2.0.0-beta.5.md)
+retain the most recent failure record.
+
+## Release recovery fixes
+
+- Prepares the isolated `publish-edge` runner immediately after checkout and
+  before Snap artifact download or verification. SHA-pinned setup actions
+  configure pnpm `11.21.0` and Node.js 24, then
+  `pnpm install --frozen-lockfile --ignore-scripts` installs the complete
+  lockfile-pinned workspace dependency closure, including the `js-yaml`
+  dependency required by `verify-snap-artifact.mjs`.
+- Sets `MOTRIX_SKIP_ELECTRON_REBUILD=1` and
+  `MOTRIX_SKIP_ENGINE_FETCH=1` during that install. Together with
+  `--ignore-scripts`, these controls prevent Electron rebuild, engine fetch,
+  and other lifecycle side effects on the publish runner.
+- Keeps the exact two-architecture artifact count, naming, and content checks
+  ahead of all Store credential access and mutation. Store uploads still do
+  not release automatically; only the exact revisions returned by successful
+  uploads may enter `latest/edge`, followed by rollback handling, public
+  channel verification, and preservation of the trusted revision record.
+  Protected-tag and environment gates remain unchanged, and build jobs still
+  receive no Store secrets.
+- Retains canonical full-relative-path code-unit ordering for Windows
+  signing-input manifests, byte-stable LF control files, strict raw-byte
+  digests, path uniqueness and safety, and fail-closed signing isolation.
+- Preserves the complete triggering commit metadata in the Windows
+  signing-input handoff before isolated finalization.
+- Hydrates Electron runtime dependencies so the packaged desktop app contains
+  the modules required when it launches.
+
+## Highlights
+
+- A ground-up desktop rebuild with Electron 43, React 19, and TypeScript 7,
+  including a customizable Dashboard, dark mode, a cross-platform application
+  menu, and clearer task-inspector feedback.
+- One host-neutral download core for both the desktop app and the new Node/Web
+  Server, with SQLite session recovery, tracker management, UPnP/NAT-PMP, and
+  HTTP, FTP, BitTorrent, and magnet support.
+- MDXP-based integration for the official CLI and browser handoff, including
+  secure local discovery and device-code pairing for remote Server instances.
+- A QuickJS plugin sandbox with capability consent, signed builtin plugins,
+  and an in-app plugin marketplace.
+- Persistent, multi-architecture Server containers for NAS and home-server
+  deployments, published to both Docker Hub and GHCR.
+- A rebuilt release pipeline with isolated macOS signing, explicit unsigned
+  Windows finalization, package verification, third-party notices, and an SPDX
+  SBOM.
+
+## Before testing
+
+This is prerelease software. Back up your existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Please do not rely on this beta for your only copy of
+important downloads.
+
+## What to test
+
+- HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
+  session recovery
+- Desktop integrations, browser and CLI handoff through MDXP, and sandboxed
+  plugins
+- Headless Server deployment, persistent storage, and remote pairing
+
+## Available downloads
+
+| Distribution | Architectures | Published output |
+|--------------|---------------|------------------|
+| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | DEB and RPM |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.6` tag in both registries |
+| Snap Store | `amd64`, `arm64` | `latest/edge` |
+
+Container images are available as
+`docker.io/motrixapp/motrix-server:2.0.0-beta.6` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.6`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.6/docs/docker-server.md)
+for storage, networking, and upgrade guidance.
+
+## Known distribution limits
+
+- AppImage is not published for this beta.
+- Flatpak is validated separately and is not published by the release tag.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are not Authenticode-signed and may trigger a Windows
+  SmartScreen warning. Download them only from this official GitHub release.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.6.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.6.zh-CN.md
@@ -1,0 +1,92 @@
+# Motrix 2.0.0-beta.6
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.6/docs/release-notes/2.0.0-beta.6.md) | 简体中文
+
+Motrix 2.0.0-beta.6 是下一次计划对外发布的 Motrix Turbo beta。
+该版本开始公开验证重新开发的 v2 桌面应用与 Headless server、共用下载内核、
+MDXP 集成和沙箱化插件系统。
+
+受保护的 `v2.0.0-beta.1` 至 `v2.0.0-beta.5` 发布尝试均在对外分发前停止，
+没有创建 GitHub Release，也未发布 R2 更新数据源、Docker Hub 或 GHCR 容器镜像
+及 Snap Store revision。beta.6 取代这些尝试；
+[beta.5 发布说明](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.6/docs/release-notes/2.0.0-beta.5.zh-CN.md)
+保留了最近一次失败记录。
+
+## 发布恢复修复
+
+- 在 checkout 后、下载或验证 Snap artifact 前准备隔离的 `publish-edge` runner。
+  使用固定 SHA 的 setup action 配置 pnpm `11.21.0` 和 Node.js 24，再执行
+  `pnpm install --frozen-lockfile --ignore-scripts`，安装 lockfile 固定的完整
+  workspace dependency closure，其中包括 `verify-snap-artifact.mjs` 所需的
+  `js-yaml` 依赖。
+- 安装时设置 `MOTRIX_SKIP_ELECTRON_REBUILD=1` 和
+  `MOTRIX_SKIP_ENGINE_FETCH=1`。这些控制与 `--ignore-scripts` 一起阻止
+  publish runner 触发 Electron rebuild、engine fetch 或其他 lifecycle 副作用。
+- 继续在任何 Store credential 访问和 mutation 前验证两个架构 artifact 的精确
+  数量、命名和内容。Store upload 仍不会自动 release；只有上传成功后返回的精确
+  revision 才能进入 `latest/edge`，随后执行 rollback 处理、公开 channel 验证，
+  并保存可信 revision record。受保护 tag 和 environment gate 保持不变，build
+  job 仍不会获得 Store secret。
+- 保留 Windows signing-input manifest 的 canonical 完整相对路径 code-unit
+  排序、字节稳定的 LF 控制文件、严格的原始字节摘要、路径唯一性与安全性，以及
+  fail-closed 签名隔离。
+- 在进入隔离最终处理前，为 Windows signing-input 交接保留完整的触发 commit
+  信息。
+- 补全 Electron runtime 依赖，确保打包后的桌面应用包含启动时所需的 module。
+
+## 主要变化
+
+- 使用 Electron 43、React 19 和 TypeScript 7 从头重建桌面应用，提供可自定义
+  Dashboard、深色模式、跨平台应用菜单，以及更清晰的任务检查器反馈。
+- 桌面应用和全新的 Node/Web Server 共用与宿主无关的下载内核，支持 SQLite
+  session 恢复、Tracker 管理、UPnP/NAT-PMP，以及 HTTP、FTP、BitTorrent 和
+  磁力链接下载。
+- 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地安全发现及远程 Server
+  的 device-code 配对。
+- 提供带能力授权的 QuickJS 插件沙箱、已签名的内置插件和应用内插件市场。
+- 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器，并同时发布到
+  Docker Hub 与 GHCR。
+- 重建发布流水线，隔离 macOS 签名步骤，并明确支持未签名的 Windows
+  最终处理，同时加入安装包验证、第三方声明和 SPDX SBOM。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1
+数据的迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
+
+条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录与现有环境
+并行测试 v2。请勿让本 beta 成为重要下载文件的唯一存储位置。
+
+## 建议测试项
+
+- HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
+- 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
+- Headless Server 部署、数据持久化和远程配对
+
+## 可用下载
+
+| 发布方式 | 架构 | 发布产物 |
+|----------|------|----------|
+| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
+| Windows | `x64` | NSIS 安装包（`.exe`）和 ZIP |
+| Linux | `x64`、`arm64` | DEB 和 RPM |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中均发布不可变 tag `2.0.0-beta.6` |
+| Snap Store | `amd64`、`arm64` | `latest/edge` |
+
+容器镜像地址为 `docker.io/motrixapp/motrix-server:2.0.0-beta.6` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.6`。数据持久化、网络和升级方法请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.6/docs/docker-server.zh-CN.md)。
+
+## 已知发布限制
+
+- 本 beta 不发布 AppImage。
+- Flatpak 会单独验证，不会随该版本 tag 发布。
+- 不提供 Windows `arm64` 和任何 32 位安装包。
+- Windows 安装包未进行 Authenticode 签名，可能触发 Windows SmartScreen
+  警告。请仅从此 GitHub 官方 Release 下载。
+- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
+
+## 反馈
+
+请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现的问题，
+并附上操作系统、架构、安装包类型和复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -76,13 +76,23 @@
   <releases>
     <!-- Update this list on every release; Flathub linter requires the most
          recent version listed here to match the manifest's source tag. -->
+    <release version="2.0.0-beta.6" date="2026-08-15">
+      <description>
+        <p>
+          Release recovery update that installs the lockfile-pinned workspace
+          dependency closure without lifecycle scripts on the isolated Snap
+          publish runner before artifact verification and Store access.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.5" date="2026-08-15">
       <description>
         <p>
-          Release recovery update that sorts the complete canonical relative
-          paths in the Windows signing manifest by code-unit order, matching
-          the isolated verifier while retaining strict uniqueness and digest
-          validation.
+          Unpublished Motrix Turbo beta attempt. All five desktop builds and
+          both strict Snap builds succeeded, but macOS finalization did not
+          run, unsigned Windows finalization was canceled, and Snap
+          publication could not load js-yaml before Store credential access.
+          No external distribution was published.
         </p>
       </description>
     </release>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1",
   "description": "A full-featured download manager",
   "keywords": [],

--- a/tests/scripts/release-version-contract.test.ts
+++ b/tests/scripts/release-version-contract.test.ts
@@ -90,8 +90,153 @@ describe('release version contract', () => {
       `https://github.com/agalwood/Motrix/blob/${releaseTag}/docs/docker-server.zh-CN.md`
     )
 
-    expect(english).toContain(`motrix-server:${packageVersion}`)
-    expect(chinese).toContain(`motrix-server:${packageVersion}`)
+    for (const source of [english, chinese]) {
+      expect(source).toContain(
+        `docker.io/motrixapp/motrix-server:${packageVersion}`
+      )
+      expect(source).toContain(
+        `ghcr.io/agalwood/motrix-server:${packageVersion}`
+      )
+    }
+  })
+
+  it('preserves beta.6 Snap publish-runner dependency recovery history', () => {
+    const english = read('docs/release-notes/2.0.0-beta.6.md')
+    const chinese = read('docs/release-notes/2.0.0-beta.6.zh-CN.md')
+    const normalizedEnglish = english.replace(/\s+/g, ' ')
+    const normalizedChinese = chinese.replace(/\s+/g, ' ')
+
+    expect(english).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.6/docs/release-notes/2.0.0-beta.5.md'
+    )
+    expect(chinese).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.6/docs/release-notes/2.0.0-beta.5.zh-CN.md'
+    )
+    expect(normalizedEnglish).toContain(
+      'Prepares the isolated `publish-edge` runner immediately after checkout and before Snap artifact download or verification'
+    )
+    expect(normalizedEnglish).toContain('SHA-pinned setup actions')
+    expect(normalizedEnglish).toContain(
+      'installs the complete lockfile-pinned workspace dependency closure'
+    )
+    expect(normalizedEnglish).toContain(
+      'ahead of all Store credential access and mutation'
+    )
+    expect(normalizedEnglish).toContain(
+      'Store uploads still do not release automatically'
+    )
+    expect(normalizedEnglish).toContain(
+      'only the exact revisions returned by successful uploads may enter `latest/edge`, followed by rollback handling, public channel verification, and preservation of the trusted revision record'
+    )
+    expect(normalizedEnglish).toContain(
+      'Protected-tag and environment gates remain unchanged, and build jobs still receive no Store secrets'
+    )
+    expect(normalizedChinese).toContain(
+      '在 checkout 后、下载或验证 Snap artifact 前准备隔离的 `publish-edge` runner'
+    )
+    expect(normalizedChinese).toContain('使用固定 SHA 的 setup action')
+    expect(normalizedChinese).toContain(
+      '安装 lockfile 固定的完整 workspace dependency closure'
+    )
+    expect(normalizedChinese).toContain(
+      '在任何 Store credential 访问和 mutation 前验证两个架构 artifact'
+    )
+    expect(normalizedChinese).toContain('Store upload 仍不会自动 release')
+    expect(normalizedChinese).toContain(
+      '只有上传成功后返回的精确 revision 才能进入 `latest/edge`，随后执行 rollback 处理、公开 channel 验证， 并保存可信 revision record'
+    )
+    expect(normalizedChinese).toContain(
+      '受保护 tag 和 environment gate 保持不变，build job 仍不会获得 Store secret'
+    )
+    for (const source of [english, chinese]) {
+      expect(source).toContain('pnpm `11.21.0`')
+      expect(source).toContain('Node.js 24')
+      expect(source).toContain(
+        'pnpm install --frozen-lockfile --ignore-scripts'
+      )
+      expect(source).toContain('MOTRIX_SKIP_ELECTRON_REBUILD=1')
+      expect(source).toContain('MOTRIX_SKIP_ENGINE_FETCH=1')
+      expect(source).toContain('verify-snap-artifact.mjs')
+      expect(source).toContain('js-yaml')
+      expect(source).toContain('latest/edge')
+      expect(source).toContain('AppImage')
+      expect(source).toContain('Flatpak')
+      expect(source).toContain('Authenticode')
+      expect(source).toContain('SmartScreen')
+    }
+  })
+
+  it('marks beta.5 as an unpublished attempt superseded by beta.6', () => {
+    const english = read('docs/release-notes/2.0.0-beta.5.md')
+    const chinese = read('docs/release-notes/2.0.0-beta.5.zh-CN.md')
+    const normalizedEnglish = english
+      .replace(/^>\s?/gm, '')
+      .replace(/\s+/g, ' ')
+    const normalizedChinese = chinese
+      .replace(/^>\s?/gm, '')
+      .replace(/\s+/g, ' ')
+
+    expect(english).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.6/docs/release-notes/2.0.0-beta.5.zh-CN.md'
+    )
+    expect(chinese).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.6/docs/release-notes/2.0.0-beta.5.md'
+    )
+    expect(english).toContain('This release attempt did not complete')
+    expect(normalizedEnglish).toContain('All five desktop build jobs')
+    expect(normalizedEnglish).toContain(
+      'macOS signing environments remained pending approval'
+    )
+    expect(normalizedEnglish).toContain('neither macOS finalization job ran')
+    expect(normalizedEnglish).toContain(
+      'unsigned Windows finalization job was canceled while it was in progress'
+    )
+    expect(normalizedEnglish).toContain(
+      'Assemble, GitHub Release, R2 update-feed publishing, and Docker Hub/GHCR container publishing were canceled before they ran'
+    )
+    expect(normalizedEnglish).toContain(
+      'successfully built, verified, and uploaded the internal GitHub Actions artifacts for both `amd64` and `arm64`'
+    )
+    expect(normalizedEnglish).toContain(
+      'happened before Store credential validation, Store upload, exact revision binding, `latest/edge` release, public channel verification, or revision record preservation'
+    )
+    expect(normalizedEnglish).toContain('external distribution remained zero')
+    expect(chinese).toContain('本次发布尝试未完成')
+    expect(normalizedChinese).toContain('5 个桌面构建 job')
+    expect(normalizedChinese).toContain('macOS 签名环境一直等待审批')
+    expect(normalizedChinese).toContain('两个 macOS finalize job 均未执行')
+    expect(normalizedChinese).toContain(
+      '未签名 Windows finalize job 在运行过程中取消'
+    )
+    expect(normalizedChinese).toContain(
+      'assemble、GitHub Release、R2 更新数据源 发布以及 Docker Hub/GHCR container publish 均在执行前取消'
+    )
+    expect(normalizedChinese).toContain(
+      '成功构建、验证和上传 `amd64`、`arm64` 两个架构的内部 GitHub Actions artifact'
+    )
+    expect(normalizedChinese).toContain(
+      '失败发生在 Store credential validation、Store upload、精确 revision 绑定、`latest/edge` release、public channel verification 和 revision record preservation 之前'
+    )
+    expect(normalizedChinese).toContain('外部分发为零')
+    for (const source of [english, chinese]) {
+      expect(source).toContain('v2.0.0-beta.6')
+      expect(source).toMatch(/assemble/i)
+      expect(source).toContain('GitHub Release')
+      expect(source).toContain('R2')
+      expect(source).toContain('Docker Hub')
+      expect(source).toContain('GHCR')
+      expect(source).toContain('Snap')
+      expect(source).toContain('publish-edge')
+      expect(source).toContain('Verify complete upload set')
+      expect(source).toContain('ERR_MODULE_NOT_FOUND')
+      expect(source).toContain('js-yaml')
+      expect(source).toContain('AppImage')
+      expect(source).toContain('Flatpak')
+      expect(source).toContain('Authenticode')
+      expect(source).toContain('SmartScreen')
+    }
+    expect(english).toContain('Intended downloads (not published)')
+    expect(chinese).toContain('原计划下载（未发布）')
   })
 
   it('preserves beta.5 canonical manifest-order recovery history', () => {

--- a/tests/scripts/workflow-snap.test.ts
+++ b/tests/scripts/workflow-snap.test.ts
@@ -190,6 +190,83 @@ describe('Snap build workflow contract', () => {
     expect(triggers).toHaveProperty('workflow_dispatch')
   })
 
+  it('installs pinned verifier dependencies before verification and Store mutation', () => {
+    const steps = jobSteps(workflowJob(snapWorkflow, 'publish-edge'))
+    const checkout = steps.find(
+      (step) => step.name === 'Checkout verification tools'
+    )
+    const setupPnpm = steps.find(
+      (step) => step.name === 'Setup pnpm for verification'
+    )
+    const setupNode = steps.find(
+      (step) => step.name === 'Setup Node.js for verification'
+    )
+    const install = steps.find(
+      (step) => step.name === 'Install verifier dependencies'
+    )
+    const download = steps.find(
+      (step) => step.name === 'Download both architecture artifacts'
+    )
+    const completeness = steps.find(
+      (step) => step.name === 'Verify complete upload set'
+    )
+    const credentialValidation = steps.find(
+      (step) => step.name === 'Validate scoped Store credential'
+    )
+
+    expect(stringField(setupPnpm as LooseRecord, 'uses')).toBe(
+      'pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271'
+    )
+    expect(asRecord(setupPnpm?.with, 'pnpm setup inputs')).toEqual({
+      version: '11.21.0',
+      run_install: false,
+    })
+    expect(stringField(setupNode as LooseRecord, 'uses')).toBe(
+      'actions/setup-node@820762786026740c76f36085b0efc47a31fe5020'
+    )
+    expect(asRecord(setupNode?.with, 'Node setup inputs')).toEqual({
+      'node-version': 24,
+      cache: 'pnpm',
+    })
+
+    const installCommand = stringField(install as LooseRecord, 'run')
+    expect(installCommand).toBe(
+      'pnpm install --frozen-lockfile --ignore-scripts'
+    )
+    expect(asRecord(install?.env, 'verifier install environment')).toEqual({
+      MOTRIX_SKIP_ELECTRON_REBUILD: '1',
+      MOTRIX_SKIP_ENGINE_FETCH: '1',
+    })
+
+    expect(steps.indexOf(checkout as LooseRecord)).toBeLessThan(
+      steps.indexOf(setupPnpm as LooseRecord)
+    )
+    expect(steps.indexOf(setupPnpm as LooseRecord)).toBeLessThan(
+      steps.indexOf(setupNode as LooseRecord)
+    )
+    expect(steps.indexOf(setupNode as LooseRecord)).toBeLessThan(
+      steps.indexOf(install as LooseRecord)
+    )
+    expect(steps.indexOf(install as LooseRecord)).toBeLessThan(
+      steps.indexOf(download as LooseRecord)
+    )
+    expect(steps.indexOf(install as LooseRecord)).toBeLessThan(
+      steps.indexOf(completeness as LooseRecord)
+    )
+    expect(steps.indexOf(completeness as LooseRecord)).toBeLessThan(
+      steps.indexOf(credentialValidation as LooseRecord)
+    )
+    for (const mutation of [
+      'Upload complete build set',
+      'Release exact build set to edge',
+    ]) {
+      const mutationStep = steps.find((step) => step.name === mutation)
+      expect(steps.indexOf(completeness as LooseRecord)).toBeLessThan(
+        steps.indexOf(mutationStep as LooseRecord)
+      )
+    }
+  })
+
   it('uploads before releasing only the captured exact edge revisions', () => {
     const steps = jobSteps(workflowJob(snapWorkflow, 'publish-edge'))
     const inspectionTools = steps.find(
@@ -531,6 +608,8 @@ function createSnapUploadFixture(): SnapUploadFixture {
   const root = mkdtempSync(path.join(tmpdir(), 'motrix-snap-workflow-'))
   const binaryDirectory = path.join(root, 'bin')
   const verificationLog = path.join(root, 'verification.log')
+  // Dependency provisioning is covered by the static publish-edge contract;
+  // this stub isolates artifact layout and verifier invocation behavior.
   const nodeStub = path.join(binaryDirectory, 'node')
   mkdirSync(binaryDirectory, { recursive: true })
   mkdirSync(path.join(root, 'release', 'snap-upload'), { recursive: true })


### PR DESCRIPTION
## Summary

- prepare `2.0.0-beta.6` across package metadata, READMEs, AppStream metadata, and bilingual release notes
- provision pinned pnpm and Node.js dependencies on the isolated Snap `publish-edge` runner before artifact verification
- keep verification before Store credential access and every upload/release mutation
- record the accurate beta.5 failure history and its zero external distribution

## Root cause

The beta.5 Snap build jobs produced and verified both architecture artifacts, but the isolated Store publication job checked out only the verifier source. It invoked `verify-snap-artifact.mjs` without installing its lockfile dependency closure, so Node failed to resolve `js-yaml` before Store credential validation or upload.

## Fix

- configure SHA-pinned pnpm 11.21.0 and Node.js 24 immediately after checkout
- run `pnpm install --frozen-lockfile --ignore-scripts` with Electron rebuild and engine fetch disabled
- lock the order checkout → dependency setup → artifact download → verification → Store credential validation → upload/release

## Validation

- complete release script suite: 40 files / 496 tests passed
- TypeScript, Biome, and actionlint passed
- architecture boundaries and file-name checks passed
- Flatpak packaging contract and AppStream XML validation passed
- staged diff whitespace check passed
- independent workflow/security and version/documentation reviews found no remaining P0–P3 issues

## Distribution status

`v2.0.0-beta.5` remains an immutable protected tag, but no GitHub Release, R2 feed, Docker Hub/GHCR image, or Snap Store revision was published. This PR prepares the next complete attempt as `v2.0.0-beta.6`.
