### PR TITLE
fix(release): prepare beta.7 finalizer recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -910,6 +910,7 @@ jobs:
 
       - name: Electron Builder (macOS signing boundary)
         if: matrix.platform == 'darwin'
+        shell: bash
         working-directory: signing-input
         env:
           ELECTRON_BUILDER_CACHE: ${{ runner.temp }}/motrix-signing-cache
@@ -920,15 +921,21 @@ jobs:
           APPLE_API_KEY: ${{ steps.apple-api-key.outputs.path }}
           APPLE_API_KEY_ID: ${{ secrets.API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.API_KEY_ISSUER_ID }}
-        run: >-
-          node node_modules/electron-builder/out/cli/cli.js
-          --config electron-builder.signing.json
-          ${{ matrix.electron_builder_args }}
-          -c.mac.bundleVersion=${{ github.run_number }}.${{ github.run_attempt }}.0
-          --publish never
+        run: |
+          set -euo pipefail
+          unset ELECTRON_BUILDER_BINARIES_CUSTOM_DIR
+          unset NPM_CONFIG_ELECTRON_BUILDER_BINARIES_CUSTOM_DIR
+          unset npm_config_electron_builder_binaries_custom_dir
+          unset npm_package_config_electron_builder_binaries_custom_dir
+          node node_modules/electron-builder/out/cli/cli.js \
+            --config electron-builder.signing.json \
+            ${{ matrix.electron_builder_args }} \
+            -c.mac.bundleVersion=${{ github.run_number }}.${{ github.run_attempt }}.0 \
+            --publish never
 
       - name: Electron Builder (Windows finalization boundary)
         if: matrix.platform == 'win32'
+        shell: pwsh
         working-directory: signing-input
         env:
           ELECTRON_BUILDER_CACHE: ${{ runner.temp }}/motrix-signing-cache
@@ -936,11 +943,15 @@ jobs:
           CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
           CSC_IDENTITY_AUTO_DISCOVERY: 'false'
-        run: >-
-          node node_modules/electron-builder/out/cli/cli.js
-          --config electron-builder.signing.json
-          ${{ matrix.electron_builder_args }}
-          --publish never
+        run: |
+          Remove-Item Env:\ELECTRON_BUILDER_BINARIES_CUSTOM_DIR -ErrorAction SilentlyContinue
+          Remove-Item Env:\NPM_CONFIG_ELECTRON_BUILDER_BINARIES_CUSTOM_DIR -ErrorAction SilentlyContinue
+          Remove-Item Env:\npm_config_electron_builder_binaries_custom_dir -ErrorAction SilentlyContinue
+          Remove-Item Env:\npm_package_config_electron_builder_binaries_custom_dir -ErrorAction SilentlyContinue
+          node node_modules/electron-builder/out/cli/cli.js `
+            --config electron-builder.signing.json `
+            ${{ matrix.electron_builder_args }} `
+            --publish never
 
       - name: Verify macOS signatures
         if: matrix.platform == 'darwin'

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. Download
-[v2.0.0-beta.6 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.6)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.6.md)
+[v2.0.0-beta.7 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.7)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.7.md)
 before installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -147,7 +147,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.6'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.7'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。安装前请从 GitHub Releases
-下载 [v2.0.0-beta.6](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.6)，
-并阅读[完整发布说明](./docs/release-notes/2.0.0-beta.6.zh-CN.md)。
+下载 [v2.0.0-beta.7](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.7)，
+并阅读[完整发布说明](./docs/release-notes/2.0.0-beta.7.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -142,7 +142,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.6'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.7'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.6.md
+++ b/docs/release-notes/2.0.0-beta.6.md
@@ -1,20 +1,53 @@
 # Motrix 2.0.0-beta.6
 
-English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.6/docs/release-notes/2.0.0-beta.6.zh-CN.md)
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.7/docs/release-notes/2.0.0-beta.6.zh-CN.md)
 
-Motrix 2.0.0-beta.6 is the next Motrix Turbo beta intended for public
-distribution. It begins public validation of the rebuilt v2 desktop app and
-headless server, shared download core, MDXP integrations, and sandboxed plugin
-system.
+> [!IMPORTANT]
+> This release attempt did not complete. All five desktop build jobs—macOS
+> `arm64`/`x64`, Windows `x64`, and Linux `arm64`/`x64`—succeeded. The macOS
+> signing environment was not approved, and both macOS finalization jobs were
+> canceled without running. Windows signing-input verification, installation
+> of the fixed dependency closure, the digest-pinned Electron download, and
+> unsigned Windows mode selection all succeeded. `Electron Builder (Windows
+> finalization boundary)` then failed while downloading the NSIS tool: empty
+> binary custom-directory configuration made the pinned Electron Builder
+> 26.15.7 request `.../releases/download//nsis-3.0.4.1.7z`, which returned
+> HTTP 404. The failure was unrelated to absent Authenticode credentials.
+>
+> Assemble, GitHub Release, R2 update-feed publishing, and Docker Hub/GHCR
+> container publishing were canceled without running. Snap validated the
+> source and successfully built, verified, and uploaded the internal GitHub
+> Actions artifacts for both `amd64` and `arm64`. The isolated `publish-edge`
+> runner installed its verifier dependencies, verified the complete
+> `amd64`/`arm64` set, and validated the scoped Store credential. During the
+> sequential Store upload, the amd64 transfer completed and entered Store
+> processing before the job was canceled; no exact revision was returned or
+> recorded, and the arm64 Store upload never started. Exact-revision release,
+> `latest/edge` mutation, public channel verification, and trusted revision
+> record preservation did not run. Public `latest/edge` remained on amd64
+> Motrix 1.8.19 revision 49. At most one unchannelled internal amd64 revision
+> may have completed processing after cancellation; no beta.6 Snap revision
+> was released to a channel.
+>
+> Beta.6 therefore created no GitHub Release, R2 feed, Docker Hub or GHCR
+> image, or public Snap distribution: external distribution remained zero.
+> Use
+> [Motrix 2.0.0-beta.7](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.7/docs/release-notes/2.0.0-beta.7.md)
+> instead. The remaining sections are retained as a historical record of the
+> intended beta.6 scope.
+
+Motrix 2.0.0-beta.6 was intended to begin public validation of the rebuilt v2
+desktop app and headless server, shared download core, MDXP integrations, and
+sandboxed plugin system.
 
 The protected `v2.0.0-beta.1` through `v2.0.0-beta.5` attempts all stopped
 before external distribution. They created no GitHub Release, R2 update feed,
-Docker Hub or GHCR container image, or Snap Store revision. Beta.6 supersedes
-those attempts; the
+Docker Hub or GHCR container image, or Snap Store revision. Beta.6 was intended
+to supersede those attempts; the
 [beta.5 notes](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.6/docs/release-notes/2.0.0-beta.5.md)
-retain the most recent failure record.
+retain the preceding failure record.
 
-## Release recovery fixes
+## Release recovery fixes included
 
 - Prepares the isolated `publish-edge` runner immediately after checkout and
   before Snap artifact download or verification. SHA-pinned setup actions
@@ -41,7 +74,7 @@ retain the most recent failure record.
 - Hydrates Electron runtime dependencies so the packaged desktop app contains
   the modules required when it launches.
 
-## Highlights
+## Planned highlights
 
 - A ground-up desktop rebuild with Electron 43, React 19, and TypeScript 7,
   including a customizable Dashboard, dark mode, a cross-platform application
@@ -54,12 +87,12 @@ retain the most recent failure record.
 - A QuickJS plugin sandbox with capability consent, signed builtin plugins,
   and an in-app plugin marketplace.
 - Persistent, multi-architecture Server containers for NAS and home-server
-  deployments, published to both Docker Hub and GHCR.
+  deployments, with publication planned for Docker Hub and GHCR.
 - A rebuilt release pipeline with isolated macOS signing, explicit unsigned
   Windows finalization, package verification, third-party notices, and an SPDX
   SBOM.
 
-## Before testing
+## Planned testing precautions
 
 This is prerelease software. Back up your existing Motrix application data and
 downloads before installing it. Migration from Motrix v1 data has not yet been
@@ -69,7 +102,7 @@ When practical, test v2 in parallel using a separate OS account, machine, or
 Docker data directory. Please do not rely on this beta for your only copy of
 important downloads.
 
-## What to test
+## Planned testing
 
 - HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
   session recovery
@@ -77,31 +110,33 @@ important downloads.
   plugins
 - Headless Server deployment, persistent storage, and remote pairing
 
-## Available downloads
+## Intended downloads (not published)
 
-| Distribution | Architectures | Published output |
-|--------------|---------------|------------------|
+| Distribution | Architectures | Intended output |
+|--------------|---------------|-----------------|
 | macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
 | Windows | `x64` | NSIS installer (`.exe`) and ZIP |
 | Linux | `x64`, `arm64` | DEB and RPM |
 | Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.6` tag in both registries |
 | Snap Store | `amd64`, `arm64` | `latest/edge` |
 
-Container images are available as
+The planned container image names were
 `docker.io/motrixapp/motrix-server:2.0.0-beta.6` and
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.6`. See the
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.6`; they were not published. See the
 [Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.6/docs/docker-server.md)
 for storage, networking, and upgrade guidance.
 
 ## Known distribution limits
 
-- AppImage is not published for this beta.
-- Flatpak is validated separately and is not published by the release tag.
-- Windows `arm64` and all 32-bit packages are not available.
-- Windows packages are not Authenticode-signed and may trigger a Windows
-  SmartScreen warning. Download them only from this official GitHub release.
-- Beta container tags are immutable and do not update `latest`, `stable`, or
-  other stable floating tags.
+- AppImage was not published for this beta.
+- Flatpak validation remained separate, and Flatpak was not published by the
+  release tag.
+- Windows `arm64` and all 32-bit packages were not available.
+- The intended Windows packages would not have been Authenticode-signed and
+  could have triggered a Windows SmartScreen warning. No beta.6 Windows
+  package was published.
+- The planned beta container tags were immutable and would not have updated
+  `latest`, `stable`, or other stable floating tags.
 
 ## Feedback
 

--- a/docs/release-notes/2.0.0-beta.6.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.6.zh-CN.md
@@ -1,18 +1,45 @@
 # Motrix 2.0.0-beta.6
 
-[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.6/docs/release-notes/2.0.0-beta.6.md) | 简体中文
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.7/docs/release-notes/2.0.0-beta.6.md) | 简体中文
 
-Motrix 2.0.0-beta.6 是下一次计划对外发布的 Motrix Turbo beta。
-该版本开始公开验证重新开发的 v2 桌面应用与 Headless server、共用下载内核、
-MDXP 集成和沙箱化插件系统。
+> [!IMPORTANT]
+> 本次发布尝试未完成。5 个桌面构建 job——macOS `arm64`/`x64`、Windows
+> `x64` 和 Linux `arm64`/`x64`——均已成功。macOS 签名环境未获审批，两个
+> macOS finalize job 均未执行而被取消。Windows signing-input 验证、
+> 固定 dependency closure 安装、固定摘要的 Electron 下载以及未签名
+> Windows 模式选择均已成功。随后 `Electron Builder (Windows
+> finalization boundary)` 在下载 NSIS 工具时失败：空的 binary
+> custom-directory 配置使固定的 Electron Builder 26.15.7 请求
+> `.../releases/download//nsis-3.0.4.1.7z`，并收到 HTTP 404。该失败与缺少
+> Authenticode credential 无关。
+>
+> assemble、GitHub Release、R2 更新数据源发布以及 Docker Hub/GHCR
+> container publish 均未执行而被取消。Snap 已验证 source，
+> 并成功构建、验证和上传 `amd64`、`arm64` 两个架构的内部 GitHub Actions
+> artifact。隔离的 `publish-edge` runner 安装了 verifier dependency，
+> 验证了完整的双架构集合，并通过了限定范围的 Store credential 校验。按顺序执行
+> Store upload 时，amd64 传输完成并进入 Store processing，此时 job 被取消；
+> 流程没有返回或记录精确 revision，arm64 Store upload 从未开始。精确
+> revision release、`latest/edge` mutation、公开 channel 验证与可信 revision
+> record 保存均未执行。公开 `latest/edge` 仍是 amd64 Motrix 1.8.19
+> revision 49。取消后最多可能有 1 个未上 channel 的内部 amd64 revision
+> 完成 processing；没有 beta.6 Snap revision 被发布到任何 channel。
+>
+> 因此 beta.6 未创建 GitHub Release，也未发布 R2 数据源、Docker Hub 或
+> GHCR 镜像及公开 Snap 分发，外部分发为零。请改用
+> [Motrix 2.0.0-beta.7](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.7/docs/release-notes/2.0.0-beta.7.zh-CN.md)。
+> 下文仅作为 beta.6 原定范围的历史记录保留。
+
+Motrix 2.0.0-beta.6 原计划开始公开验证重新开发的 v2 桌面应用与 Headless
+server、共用下载内核、MDXP 集成和沙箱化插件系统。
 
 受保护的 `v2.0.0-beta.1` 至 `v2.0.0-beta.5` 发布尝试均在对外分发前停止，
 没有创建 GitHub Release，也未发布 R2 更新数据源、Docker Hub 或 GHCR 容器镜像
-及 Snap Store revision。beta.6 取代这些尝试；
+及 Snap Store revision。beta.6 原计划取代这些尝试；
 [beta.5 发布说明](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.6/docs/release-notes/2.0.0-beta.5.zh-CN.md)
-保留了最近一次失败记录。
+保留了前序失败记录。
 
-## 发布恢复修复
+## 已包含的发布恢复修复
 
 - 在 checkout 后、下载或验证 Snap artifact 前准备隔离的 `publish-edge` runner。
   使用固定 SHA 的 setup action 配置 pnpm `11.21.0` 和 Node.js 24，再执行
@@ -34,7 +61,7 @@ MDXP 集成和沙箱化插件系统。
   信息。
 - 补全 Electron runtime 依赖，确保打包后的桌面应用包含启动时所需的 module。
 
-## 主要变化
+## 原计划主要变化
 
 - 使用 Electron 43、React 19 和 TypeScript 7 从头重建桌面应用，提供可自定义
   Dashboard、深色模式、跨平台应用菜单，以及更清晰的任务检查器反馈。
@@ -44,12 +71,12 @@ MDXP 集成和沙箱化插件系统。
 - 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地安全发现及远程 Server
   的 device-code 配对。
 - 提供带能力授权的 QuickJS 插件沙箱、已签名的内置插件和应用内插件市场。
-- 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器，并同时发布到
+- 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器，原计划同时发布到
   Docker Hub 与 GHCR。
 - 重建发布流水线，隔离 macOS 签名步骤，并明确支持未签名的 Windows
   最终处理，同时加入安装包验证、第三方声明和 SPDX SBOM。
 
-## 测试前须知
+## 原计划的测试须知
 
 这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1
 数据的迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
@@ -57,34 +84,35 @@ MDXP 集成和沙箱化插件系统。
 条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录与现有环境
 并行测试 v2。请勿让本 beta 成为重要下载文件的唯一存储位置。
 
-## 建议测试项
+## 原计划的测试项
 
 - HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
 - 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
 - Headless Server 部署、数据持久化和远程配对
 
-## 可用下载
+## 原计划下载（未发布）
 
-| 发布方式 | 架构 | 发布产物 |
-|----------|------|----------|
+| 发布方式 | 架构 | 原计划产物 |
+|----------|------|------------|
 | macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
 | Windows | `x64` | NSIS 安装包（`.exe`）和 ZIP |
 | Linux | `x64`、`arm64` | DEB 和 RPM |
-| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中均发布不可变 tag `2.0.0-beta.6` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 原计划在两个 registry 中使用不可变 tag `2.0.0-beta.6` |
 | Snap Store | `amd64`、`arm64` | `latest/edge` |
 
-容器镜像地址为 `docker.io/motrixapp/motrix-server:2.0.0-beta.6` 和
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.6`。数据持久化、网络和升级方法请参阅
+原计划的容器镜像地址为 `docker.io/motrixapp/motrix-server:2.0.0-beta.6` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.6`，但它们并未发布。数据持久化、网络和升级方法请参阅
 [Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.6/docs/docker-server.zh-CN.md)。
 
 ## 已知发布限制
 
-- 本 beta 不发布 AppImage。
-- Flatpak 会单独验证，不会随该版本 tag 发布。
-- 不提供 Windows `arm64` 和任何 32 位安装包。
-- Windows 安装包未进行 Authenticode 签名，可能触发 Windows SmartScreen
-  警告。请仅从此 GitHub 官方 Release 下载。
-- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
+- 本 beta 未发布 AppImage。
+- Flatpak 验证仍保持独立，未随该版本 tag 发布。
+- 未提供 Windows `arm64` 和任何 32 位安装包。
+- 原计划的 Windows 安装包不会进行 Authenticode 签名，因而可能触发
+  Windows SmartScreen 警告。beta.6 实际并未发布 Windows 安装包。
+- 原计划的 beta container tag 不可变，不会更新 `latest`、`stable` 或其他
+  稳定版浮动 tag。
 
 ## 反馈
 

--- a/docs/release-notes/2.0.0-beta.7.md
+++ b/docs/release-notes/2.0.0-beta.7.md
@@ -1,0 +1,127 @@
+# Motrix 2.0.0-beta.7
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.7/docs/release-notes/2.0.0-beta.7.zh-CN.md)
+
+Motrix 2.0.0-beta.7 is the next Motrix Turbo beta intended for public
+distribution. It begins public validation of the rebuilt v2 desktop app and
+headless server, shared download core, MDXP integrations, and sandboxed plugin
+system.
+
+The protected `v2.0.0-beta.1` through `v2.0.0-beta.6` attempts all stopped
+before public external distribution. None created a GitHub Release, R2 update
+feed, Docker Hub or GHCR container image, or Snap channel change. The canceled
+beta.6 Store upload may have left at most one unchannelled internal amd64
+revision; it was not released to users. Beta.7 supersedes those attempts, and
+the
+[beta.6 notes](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.7/docs/release-notes/2.0.0-beta.6.md)
+retain the preceding failure record.
+
+## Release recovery fixes
+
+- Keeps job-level empty-value sanitization for inherited Electron Builder
+  binary custom-directory settings, then truly removes all four overrides from
+  the macOS and Windows finalizer process environment immediately before that
+  process starts Electron Builder:
+  `NPM_CONFIG_ELECTRON_BUILDER_BINARIES_CUSTOM_DIR`,
+  `npm_config_electron_builder_binaries_custom_dir`,
+  `npm_package_config_electron_builder_binaries_custom_dir`, and
+  `ELECTRON_BUILDER_BINARIES_CUSTOM_DIR`.
+- Works around an Electron Builder 26.15.7 behavior in which a custom-directory
+  variable that is defined but empty is still treated as an active override.
+  During beta.6 this removed the built-in NSIS release tag from the download
+  URL and produced `.../releases/download//nsis-3.0.4.1.7z`. With all four
+  overrides absent at the finalization boundary, the built-in, digest-verified
+  URLs regain their canonical suffixes:
+  `.../releases/download/nsis-3.0.4.1/nsis-3.0.4.1.7z` and
+  `.../releases/download/nsis-resources-3.4.1/nsis-resources-3.4.1.7z`.
+- Adds a network-free regression that exercises the actual lockfile-resolved
+  `app-builder-lib` downloader from the Electron Builder 26.15.7 dependency
+  closure with a stub transport. It proves that defined empty custom-directory
+  values reproduce the missing-tag URL and that truly unsetting all four
+  values restores both canonical tool URLs.
+- Changes only the controlled Electron Builder launch environment. Windows
+  publication remains explicitly unsigned when both Authenticode credentials
+  are absent. Digest-complete signing inputs are still verified before secret
+  access, and build jobs remain secret-free. Byte-stable control files,
+  canonical manifest ordering, path safety and uniqueness, fixed dependency
+  and Electron inputs, isolated secret access, `--publish never`, finalized
+  package verification, fail-closed assembly, and protected-tag and
+  environment gates remain unchanged.
+- Retains the isolated Snap publish-runner setup introduced for beta.6:
+  SHA-pinned pnpm and Node.js setup plus a frozen-lockfile, no-lifecycle-script
+  dependency install occur before artifact verification and Store access. The
+  complete two-architecture set must still verify before credentials or
+  mutation; uploads do not release automatically, and only exact returned
+  revisions may enter `latest/edge` before public verification and revision
+  record preservation.
+- Hydrates Electron runtime dependencies so the packaged desktop app contains
+  the modules required when it launches.
+
+## Highlights
+
+- A ground-up desktop rebuild with Electron 43, React 19, and TypeScript 7,
+  including a customizable Dashboard, dark mode, a cross-platform application
+  menu, and clearer task-inspector feedback.
+- One host-neutral download core for both the desktop app and the new Node/Web
+  Server, with SQLite session recovery, tracker management, UPnP/NAT-PMP, and
+  HTTP, FTP, BitTorrent, and magnet support.
+- MDXP-based integration for the official CLI and browser handoff, including
+  secure local discovery and device-code pairing for remote Server instances.
+- A QuickJS plugin sandbox with capability consent, signed builtin plugins,
+  and an in-app plugin marketplace.
+- Persistent, multi-architecture Server containers for NAS and home-server
+  deployments, published to both Docker Hub and GHCR.
+- A rebuilt release pipeline with isolated macOS signing, explicit unsigned
+  Windows finalization, package verification, third-party notices, and an SPDX
+  SBOM.
+
+## Before testing
+
+This is prerelease software. Back up your existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Please do not rely on this beta for your only copy of
+important downloads.
+
+## What to test
+
+- HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
+  session recovery
+- Desktop integrations, browser and CLI handoff through MDXP, and sandboxed
+  plugins
+- Headless Server deployment, persistent storage, and remote pairing
+
+## Available downloads
+
+| Distribution | Architectures | Published output |
+|--------------|---------------|------------------|
+| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | DEB and RPM |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.7` tag in both registries |
+| Snap Store | `amd64`, `arm64` | `latest/edge` |
+
+Container images are available as
+`docker.io/motrixapp/motrix-server:2.0.0-beta.7` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.7`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.7/docs/docker-server.md)
+for storage, networking, and upgrade guidance.
+
+## Known distribution limits
+
+- AppImage is not published for this beta.
+- Flatpak is validated separately and is not published by the release tag.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are not Authenticode-signed and may trigger a Windows
+  SmartScreen warning. Download them only from this official GitHub release.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.7.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.7.zh-CN.md
@@ -1,0 +1,104 @@
+# Motrix 2.0.0-beta.7
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.7/docs/release-notes/2.0.0-beta.7.md) | 简体中文
+
+Motrix 2.0.0-beta.7 是下一次计划对外发布的 Motrix Turbo beta。
+该版本开始公开验证重新开发的 v2 桌面应用与 Headless server、共用下载内核、
+MDXP 集成和沙箱化插件系统。
+
+受保护的 `v2.0.0-beta.1` 至 `v2.0.0-beta.6` 发布尝试均在对外公开分发前停止，
+没有创建 GitHub Release，也没有发布 R2 更新数据源、Docker Hub 或 GHCR
+容器镜像，Snap channel 也未变更。已取消的 beta.6 Store upload 最多可能留下
+1 个未上 channel 的内部 amd64 revision，但它并未发布给用户。beta.7 取代这些尝试；
+[beta.6 发布说明](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.7/docs/release-notes/2.0.0-beta.6.zh-CN.md)
+保留了前序失败记录。
+
+## 发布恢复修复
+
+- 保留 job 级的空值净化，用于中和继承的 Electron Builder binary
+  custom-directory 设置；随后在 macOS 和 Windows finalizer 进程启动
+  Electron Builder 前，立即从该进程环境中真正删除全部 4 个覆盖变量：
+  `NPM_CONFIG_ELECTRON_BUILDER_BINARIES_CUSTOM_DIR`、
+  `npm_config_electron_builder_binaries_custom_dir`、
+  `npm_package_config_electron_builder_binaries_custom_dir` 和
+  `ELECTRON_BUILDER_BINARIES_CUSTOM_DIR`。
+- 规避 Electron Builder 26.15.7 将“已定义但为空”的 custom-directory 变量仍视为
+  有效覆盖的行为。beta.6 因此丢失了下载 URL 中内置的 NSIS release tag，
+  生成 `.../releases/download//nsis-3.0.4.1.7z`。在 finalization 边界删除全部
+  4 个覆盖后，内置且经摘要校验的 URL 会恢复 canonical suffix：
+  `.../releases/download/nsis-3.0.4.1/nsis-3.0.4.1.7z` 与
+  `.../releases/download/nsis-resources-3.4.1/nsis-resources-3.4.1.7z`。
+- 新增无网络回归测试，通过 stub transport 直接执行 Electron Builder 26.15.7
+  dependency closure 中真实由 lockfile 固定的 `app-builder-lib` downloader。
+  测试证明已定义的空 custom-directory 会复现缺少 tag 的 URL，也证明真正
+  unset 全部 4 个变量后会恢复两个 canonical 工具 URL。
+- 仅修改受控的 Electron Builder 启动环境。当两个 Authenticode credential
+  均未配置时，Windows 仍会明确按未签名模式发布。完整摘要的 signing
+  input 仍在访问 secret 前验证，build job 仍不获得 secret。字节稳定的控制文件、
+  canonical manifest 排序、路径安全与唯一性、
+  固定的 dependency 与 Electron 输入、隔离 secret 访问、`--publish never`、
+  最终安装包验证、fail-closed assemble 以及受保护 tag 和 environment gate
+  均保持不变。
+- 保留 beta.6 引入的隔离 Snap publish-runner 准备：使用固定 SHA 的 pnpm 与
+  Node.js setup，并在 artifact 验证和 Store 访问前执行 frozen-lockfile、禁用
+  lifecycle script 的 dependency 安装。完整双架构集合仍必须在 credential
+  或 mutation 之前通过验证；upload 仍不会自动 release，只有返回的精确
+  revision 可进入 `latest/edge`，随后才会进行公开验证并保存 revision record。
+- 补全 Electron runtime 依赖，确保打包后的桌面应用包含启动时所需的 module。
+
+## 主要变化
+
+- 使用 Electron 43、React 19 和 TypeScript 7 从头重建桌面应用，提供可自定义
+  Dashboard、深色模式、跨平台应用菜单，以及更清晰的任务检查器反馈。
+- 桌面应用和全新的 Node/Web Server 共用与宿主无关的下载内核，支持 SQLite
+  session 恢复、Tracker 管理、UPnP/NAT-PMP，以及 HTTP、FTP、BitTorrent 和
+  磁力链接下载。
+- 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地安全发现及远程 Server
+  的 device-code 配对。
+- 提供带能力授权的 QuickJS 插件沙箱、已签名的内置插件和应用内插件市场。
+- 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器，并同时发布到
+  Docker Hub 与 GHCR。
+- 重建发布流水线，隔离 macOS 签名步骤，并明确支持未签名的 Windows
+  最终处理，同时加入安装包验证、第三方声明和 SPDX SBOM。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1
+数据的迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
+
+条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录与现有环境
+并行测试 v2。请勿让本 beta 成为重要下载文件的唯一存储位置。
+
+## 建议测试项
+
+- HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
+- 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
+- Headless Server 部署、数据持久化和远程配对
+
+## 可用下载
+
+| 发布方式 | 架构 | 发布产物 |
+|----------|------|----------|
+| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
+| Windows | `x64` | NSIS 安装包（`.exe`）和 ZIP |
+| Linux | `x64`、`arm64` | DEB 和 RPM |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中均发布不可变 tag `2.0.0-beta.7` |
+| Snap Store | `amd64`、`arm64` | `latest/edge` |
+
+容器镜像地址为 `docker.io/motrixapp/motrix-server:2.0.0-beta.7` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.7`。数据持久化、网络和升级方法请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.7/docs/docker-server.zh-CN.md)。
+
+## 已知发布限制
+
+- 本 beta 不发布 AppImage。
+- Flatpak 会单独验证，不会随该版本 tag 发布。
+- 不提供 Windows `arm64` 和任何 32 位安装包。
+- Windows 安装包未进行 Authenticode 签名，可能触发 Windows SmartScreen
+  警告。请仅从此 GitHub 官方 Release 下载。
+- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
+
+## 反馈
+
+请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现的问题，
+并附上操作系统、架构、安装包类型和复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -76,12 +76,25 @@
   <releases>
     <!-- Update this list on every release; Flathub linter requires the most
          recent version listed here to match the manifest's source tag. -->
+    <release version="2.0.0-beta.7" date="2026-08-16">
+      <description>
+        <p>
+          Release recovery update that removes Electron Builder binary
+          custom-directory variables from the macOS and Windows finalizer
+          process environments before invoking the lockfile-resolved Electron
+          Builder 26.15.7.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.6" date="2026-08-15">
       <description>
         <p>
-          Release recovery update that installs the lockfile-pinned workspace
-          dependency closure without lifecycle scripts on the isolated Snap
-          publish runner before artifact verification and Store access.
+          Unpublished Motrix Turbo beta attempt. All five desktop builds and
+          both strict Snap builds succeeded, but an empty Electron Builder
+          binary custom-directory value produced an invalid NSIS tool URL
+          during unsigned Windows finalization. Snap publication was canceled
+          while the amd64 upload was processing; latest/edge did not change,
+          and no external distribution was published.
         </p>
       </description>
     </release>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.6",
+  "version": "2.0.0-beta.7",
   "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1",
   "description": "A full-featured download manager",
   "keywords": [],

--- a/tests/scripts/release-version-contract.test.ts
+++ b/tests/scripts/release-version-contract.test.ts
@@ -82,6 +82,12 @@ describe('release version contract', () => {
   it('preserves current release references', () => {
     const english = read(`docs/release-notes/${packageVersion}.md`)
     const chinese = read(`docs/release-notes/${packageVersion}.zh-CN.md`)
+    const releaseMetadata = resolveReleaseMetadata({
+      eventName: 'workflow_dispatch',
+      refName: 'main',
+      refProtected: 'false',
+      packageVersion,
+    })
 
     expect(english).toContain(
       `https://github.com/agalwood/Motrix/blob/${releaseTag}/docs/docker-server.md`
@@ -97,20 +103,111 @@ describe('release version contract', () => {
       expect(source).toContain(
         `ghcr.io/agalwood/motrix-server:${packageVersion}`
       )
+      if (releaseMetadata.channel === 'beta') {
+        expect(source).toContain('latest/edge')
+      }
     }
   })
 
-  it('preserves beta.6 Snap publish-runner dependency recovery history', () => {
+  it('preserves beta.7 Electron Builder custom-directory recovery history', () => {
+    const english = read('docs/release-notes/2.0.0-beta.7.md')
+    const chinese = read('docs/release-notes/2.0.0-beta.7.zh-CN.md')
+    const normalizedEnglish = english
+      .replace(/^>\s?/gm, '')
+      .replace(/\s+/g, ' ')
+    const normalizedChinese = chinese
+      .replace(/^>\s?/gm, '')
+      .replace(/\s+/g, ' ')
+
+    expect(english).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.7/docs/release-notes/2.0.0-beta.6.md'
+    )
+    expect(chinese).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.7/docs/release-notes/2.0.0-beta.6.zh-CN.md'
+    )
+    expect(normalizedEnglish).toContain(
+      'Keeps job-level empty-value sanitization for inherited Electron Builder binary custom-directory settings, then truly removes all four overrides from the macOS and Windows finalizer process environment immediately before that process starts Electron Builder'
+    )
+    expect(normalizedEnglish).toContain(
+      'a custom-directory variable that is defined but empty is still treated as an active override'
+    )
+    expect(normalizedEnglish).toContain(
+      'actual lockfile-resolved `app-builder-lib` downloader from the Electron Builder 26.15.7 dependency closure with a stub transport'
+    )
+    expect(normalizedEnglish).toContain(
+      'truly unsetting all four values restores both canonical tool URLs'
+    )
+    expect(normalizedEnglish).toContain(
+      'Digest-complete signing inputs are still verified before secret access, and build jobs remain secret-free'
+    )
+    expect(normalizedEnglish).toContain(
+      'fail-closed assembly, and protected-tag and environment gates remain unchanged'
+    )
+    expect(normalizedChinese).toContain(
+      '保留 job 级的空值净化，用于中和继承的 Electron Builder binary custom-directory 设置'
+    )
+    expect(normalizedChinese).toContain(
+      '在 macOS 和 Windows finalizer 进程启动 Electron Builder 前，立即从该进程环境中真正删除全部 4 个覆盖变量'
+    )
+    expect(normalizedChinese).toContain(
+      '通过 stub transport 直接执行 Electron Builder 26.15.7 dependency closure 中真实由 lockfile 固定的 `app-builder-lib` downloader'
+    )
+    expect(normalizedChinese).toContain(
+      '真正 unset 全部 4 个变量后会恢复两个 canonical 工具 URL'
+    )
+    expect(normalizedChinese).toContain(
+      '完整摘要的 signing input 仍在访问 secret 前验证，build job 仍不获得 secret'
+    )
+    expect(normalizedChinese).toContain(
+      'fail-closed assemble 以及受保护 tag 和 environment gate 均保持不变'
+    )
+    for (const source of [english, chinese]) {
+      expect(source).toContain(
+        '`NPM_CONFIG_ELECTRON_BUILDER_BINARIES_CUSTOM_DIR`'
+      )
+      expect(source).toContain(
+        '`npm_config_electron_builder_binaries_custom_dir`'
+      )
+      expect(source).toContain(
+        '`npm_package_config_electron_builder_binaries_custom_dir`'
+      )
+      expect(source).toContain('`ELECTRON_BUILDER_BINARIES_CUSTOM_DIR`')
+      expect(source).toContain('26.15.7')
+      expect(source).toContain('download//nsis-3.0.4.1.7z')
+      expect(source).toContain('releases/download/nsis-3.0.4.1/nsis-3.0.4.1.7z')
+      expect(source).toContain(
+        'releases/download/nsis-resources-3.4.1/nsis-resources-3.4.1.7z'
+      )
+      expect(source).toContain('--publish never')
+      expect(source).toContain('latest/edge')
+      expect(source).toContain('AppImage')
+      expect(source).toContain('Flatpak')
+      expect(source).toContain('Authenticode')
+      expect(source).toContain('SmartScreen')
+    }
+  })
+
+  it('preserves beta.6 Snap recovery and canceled release history', () => {
     const english = read('docs/release-notes/2.0.0-beta.6.md')
     const chinese = read('docs/release-notes/2.0.0-beta.6.zh-CN.md')
-    const normalizedEnglish = english.replace(/\s+/g, ' ')
-    const normalizedChinese = chinese.replace(/\s+/g, ' ')
+    const normalizedEnglish = english
+      .replace(/^>\s?/gm, '')
+      .replace(/\s+/g, ' ')
+    const normalizedChinese = chinese
+      .replace(/^>\s?/gm, '')
+      .replace(/\s+/g, ' ')
 
     expect(english).toContain(
       'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.6/docs/release-notes/2.0.0-beta.5.md'
     )
     expect(chinese).toContain(
       'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.6/docs/release-notes/2.0.0-beta.5.zh-CN.md'
+    )
+    expect(english).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.7/docs/release-notes/2.0.0-beta.6.zh-CN.md'
+    )
+    expect(chinese).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.7/docs/release-notes/2.0.0-beta.6.md'
     )
     expect(normalizedEnglish).toContain(
       'Prepares the isolated `publish-edge` runner immediately after checkout and before Snap artifact download or verification'
@@ -148,6 +245,80 @@ describe('release version contract', () => {
     expect(normalizedChinese).toContain(
       '受保护 tag 和 environment gate 保持不变，build job 仍不会获得 Store secret'
     )
+    expect(normalizedEnglish).toContain('All five desktop build jobs')
+    expect(normalizedEnglish).toContain(
+      'both macOS finalization jobs were canceled without running'
+    )
+    expect(normalizedEnglish).toContain(
+      'unsigned Windows mode selection all succeeded'
+    )
+    expect(normalizedEnglish).toContain(
+      '`.../releases/download//nsis-3.0.4.1.7z`, which returned HTTP 404'
+    )
+    expect(normalizedEnglish).toContain(
+      'The failure was unrelated to absent Authenticode credentials'
+    )
+    expect(normalizedEnglish).toContain(
+      'Assemble, GitHub Release, R2 update-feed publishing, and Docker Hub/GHCR container publishing were canceled without running'
+    )
+    expect(normalizedEnglish).toContain(
+      'the amd64 transfer completed and entered Store processing before the job was canceled'
+    )
+    expect(normalizedEnglish).toContain(
+      'successfully built, verified, and uploaded the internal GitHub Actions artifacts for both `amd64` and `arm64`'
+    )
+    expect(normalizedEnglish).toContain(
+      'verified the complete `amd64`/`arm64` set, and validated the scoped Store credential'
+    )
+    expect(normalizedEnglish).toContain(
+      'no exact revision was returned or recorded'
+    )
+    expect(normalizedEnglish).toContain('the arm64 Store upload never started')
+    expect(normalizedEnglish).toContain(
+      'Public `latest/edge` remained on amd64 Motrix 1.8.19 revision 49'
+    )
+    expect(normalizedEnglish).toContain(
+      'At most one unchannelled internal amd64 revision may have completed processing after cancellation'
+    )
+    expect(normalizedEnglish).toContain(
+      'no beta.6 Snap revision was released to a channel'
+    )
+    expect(normalizedEnglish).toContain('external distribution remained zero')
+    expect(normalizedChinese).toContain('5 个桌面构建 job')
+    expect(normalizedChinese).toContain(
+      '两个 macOS finalize job 均未执行而被取消'
+    )
+    expect(normalizedChinese).toContain('未签名 Windows 模式选择均已成功')
+    expect(normalizedChinese).toContain(
+      '`.../releases/download//nsis-3.0.4.1.7z`，并收到 HTTP 404'
+    )
+    expect(normalizedChinese).toContain(
+      '该失败与缺少 Authenticode credential 无关'
+    )
+    expect(normalizedChinese).toContain(
+      'assemble、GitHub Release、R2 更新数据源发布以及 Docker Hub/GHCR container publish 均未执行而被取消'
+    )
+    expect(normalizedChinese).toContain(
+      'amd64 传输完成并进入 Store processing，此时 job 被取消'
+    )
+    expect(normalizedChinese).toContain(
+      '成功构建、验证和上传 `amd64`、`arm64` 两个架构的内部 GitHub Actions artifact'
+    )
+    expect(normalizedChinese).toContain(
+      '验证了完整的双架构集合，并通过了限定范围的 Store credential 校验'
+    )
+    expect(normalizedChinese).toContain('流程没有返回或记录精确 revision')
+    expect(normalizedChinese).toContain('arm64 Store upload 从未开始')
+    expect(normalizedChinese).toContain(
+      '公开 `latest/edge` 仍是 amd64 Motrix 1.8.19 revision 49'
+    )
+    expect(normalizedChinese).toContain(
+      '取消后最多可能有 1 个未上 channel 的内部 amd64 revision 完成 processing'
+    )
+    expect(normalizedChinese).toContain(
+      '没有 beta.6 Snap revision 被发布到任何 channel'
+    )
+    expect(normalizedChinese).toContain('外部分发为零')
     for (const source of [english, chinese]) {
       expect(source).toContain('pnpm `11.21.0`')
       expect(source).toContain('Node.js 24')

--- a/tests/scripts/workflow-release-matrix.test.ts
+++ b/tests/scripts/workflow-release-matrix.test.ts
@@ -30,6 +30,12 @@ const parseYaml = require('js-yaml').load as (source: string) => unknown
 const PNPM_VERSION = '11.21.0'
 const PNPM_PACKAGE_MANAGER =
   'pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1'
+const ELECTRON_BUILDER_CUSTOM_DIR_ENVIRONMENT_VARIABLES = [
+  'NPM_CONFIG_ELECTRON_BUILDER_BINARIES_CUSTOM_DIR',
+  'npm_config_electron_builder_binaries_custom_dir',
+  'npm_package_config_electron_builder_binaries_custom_dir',
+  'ELECTRON_BUILDER_BINARIES_CUSTOM_DIR',
+] as const
 const EXPECTED_ACTION_PINS = new Map([
   [
     'actions/checkout',
@@ -1155,6 +1161,182 @@ describe('release workflow publication contract', () => {
     const command = stringField(createInput as LooseRecord, 'run')
     expect(command).toContain(`--commit "\${{ github.sha }}"`)
     expect(command).not.toContain('$GITHUB_SHA')
+  })
+
+  it('sanitizes then unsets builder custom directories inside each finalization boundary', () => {
+    const signJob = asRecord(workflowJobs(releaseWorkflow).sign, 'sign job')
+    const signEnvironment = asRecord(signJob.env, 'sign job environment')
+    for (const variable of [
+      'NPM_CONFIG_ELECTRON_BUILDER_BINARIES_CUSTOM_DIR',
+      'ELECTRON_BUILDER_BINARIES_CUSTOM_DIR',
+    ]) {
+      expect(stringField(signEnvironment, variable)).toBe('')
+    }
+
+    const steps = jobSteps(signJob)
+    const boundaries = [
+      {
+        name: 'Electron Builder (macOS signing boundary)',
+        shell: 'bash',
+        unsetCommand: (variable: string) => `unset ${variable}`,
+      },
+      {
+        name: 'Electron Builder (Windows finalization boundary)',
+        shell: 'pwsh',
+        unsetCommand: (variable: string) =>
+          `Remove-Item Env:${path.win32.sep}${variable} -ErrorAction SilentlyContinue`,
+      },
+    ]
+
+    for (const boundary of boundaries) {
+      const step = steps.find((candidate) => candidate.name === boundary.name)
+      expect(step).toBeDefined()
+      expect(stringField(step as LooseRecord, 'shell')).toBe(boundary.shell)
+      const command = stringField(step as LooseRecord, 'run')
+      const builderIndex = command.indexOf(
+        'node node_modules/electron-builder/out/cli/cli.js'
+      )
+      expect(builderIndex).toBeGreaterThanOrEqual(0)
+      for (const variable of ELECTRON_BUILDER_CUSTOM_DIR_ENVIRONMENT_VARIABLES) {
+        const unsetIndex = command.indexOf(boundary.unsetCommand(variable))
+        expect(
+          unsetIndex,
+          `${boundary.name} must unset ${variable}`
+        ).toBeGreaterThanOrEqual(0)
+        expect(unsetIndex).toBeLessThan(builderIndex)
+      }
+    }
+  })
+
+  it('restores canonical 26.15.7 NSIS URLs after custom directories are unset', async () => {
+    const signingToolPackages = asRecord(
+      asRecord(
+        JSON.parse(signingToolLockSource) as unknown,
+        'signing tool lock'
+      ).packages,
+      'signing tool lock packages'
+    )
+    const lockedAppBuilder = asRecord(
+      signingToolPackages['node_modules/app-builder-lib'],
+      'locked app-builder-lib package'
+    )
+    expect(stringField(lockedAppBuilder, 'version')).toBe('26.15.7')
+
+    const packageMetadata = asRecord(
+      require('app-builder-lib/package.json') as unknown,
+      'app-builder-lib package metadata'
+    )
+    expect(stringField(packageMetadata, 'version')).toBe('26.15.7')
+
+    const electronGetPath = require.resolve(
+      'app-builder-lib/out/util/electronGet.js'
+    )
+    const binDownloadPath = require.resolve(
+      'app-builder-lib/out/binDownload.js'
+    )
+    const electronGet = asRecord(
+      require(electronGetPath) as unknown,
+      'app-builder-lib electron downloader'
+    )
+    const originalDownloadBuilderToolset = electronGet.downloadBuilderToolset
+    if (typeof originalDownloadBuilderToolset !== 'function') {
+      throw new TypeError('downloadBuilderToolset must be a function')
+    }
+
+    const customDirNames = new Set(
+      ELECTRON_BUILDER_CUSTOM_DIR_ENVIRONMENT_VARIABLES.map((name) =>
+        name.toLowerCase()
+      )
+    )
+    const originalEnvironment = Object.entries(process.env).filter(([name]) =>
+      customDirNames.has(name.toLowerCase())
+    )
+    const clearCustomDirectories = () => {
+      for (const name of Object.keys(process.env)) {
+        if (customDirNames.has(name.toLowerCase())) {
+          delete process.env[name]
+        }
+      }
+    }
+    type GetBinFromUrl = (
+      releaseName: string,
+      filenameWithExt: string,
+      checksum: string
+    ) => Promise<string>
+    const loadGetBinFromUrl = (): GetBinFromUrl => {
+      delete require.cache[binDownloadPath]
+      const binDownload = asRecord(
+        require(binDownloadPath) as unknown,
+        'app-builder-lib binary downloader'
+      )
+      if (typeof binDownload.getBinFromUrl !== 'function') {
+        throw new TypeError('getBinFromUrl must be a function')
+      }
+      return binDownload.getBinFromUrl as GetBinFromUrl
+    }
+
+    const downloads: LooseRecord[] = []
+    electronGet.downloadBuilderToolset = async (options: unknown) => {
+      downloads.push(asRecord(options, 'builder toolset download options'))
+      return path.join(ROOT, '.stub-electron-builder-toolset')
+    }
+
+    try {
+      clearCustomDirectories()
+      for (const variable of ELECTRON_BUILDER_CUSTOM_DIR_ENVIRONMENT_VARIABLES) {
+        process.env[variable] = ''
+      }
+      await loadGetBinFromUrl()(
+        'nsis-3.0.4.1',
+        'nsis-3.0.4.1.7z',
+        '0'.repeat(64)
+      )
+
+      expect(downloads).toHaveLength(1)
+      expect(stringField(downloads[0] as LooseRecord, 'releaseName')).toBe(
+        'download'
+      )
+      expect(stringField(downloads[0] as LooseRecord, 'overrideUrl')).toBe(
+        'https://github.com/electron-userland/electron-builder-binaries/releases/download/'
+      )
+
+      clearCustomDirectories()
+      const getBinFromUrl = loadGetBinFromUrl()
+      await getBinFromUrl('nsis-3.0.4.1', 'nsis-3.0.4.1.7z', '0'.repeat(64))
+      await getBinFromUrl(
+        'nsis-resources-3.4.1',
+        'nsis-resources-3.4.1.7z',
+        '0'.repeat(64)
+      )
+
+      expect(
+        downloads.slice(1).map((download) => ({
+          filenameWithExt: stringField(download, 'filenameWithExt'),
+          overrideUrl: stringField(download, 'overrideUrl'),
+          releaseName: stringField(download, 'releaseName'),
+        }))
+      ).toEqual([
+        {
+          filenameWithExt: 'nsis-3.0.4.1.7z',
+          overrideUrl:
+            'https://github.com/electron-userland/electron-builder-binaries/releases/download/nsis-3.0.4.1',
+          releaseName: 'nsis-3.0.4.1',
+        },
+        {
+          filenameWithExt: 'nsis-resources-3.4.1.7z',
+          overrideUrl:
+            'https://github.com/electron-userland/electron-builder-binaries/releases/download/nsis-resources-3.4.1',
+          releaseName: 'nsis-resources-3.4.1',
+        },
+      ])
+    } finally {
+      electronGet.downloadBuilderToolset = originalDownloadBuilderToolset
+      delete require.cache[binDownloadPath]
+      clearCustomDirectories()
+      for (const [name, value] of originalEnvironment) {
+        process.env[name] = value
+      }
+    }
   })
 
   it('verifies notarization stapling in addition to macOS signatures', () => {


### PR DESCRIPTION
## Summary

- prepare Motrix 2.0.0-beta.7 metadata, bilingual release notes, README links, container tags, and AppStream history
- keep the isolated finalizer's job-level binary-download sanitization, then truly remove all four Electron Builder custom-directory environment variants inside both macOS and Windows launch boundaries
- add an offline regression against the lockfile-resolved app-builder-lib 26.15.7 downloader for the NSIS and NSIS-resources canonical URLs
- backfill the beta.6 outcome: all five builds passed, Windows unsigned finalization failed before assembly, Snap edge did not change, and external distribution remained zero

## Root cause

Electron Builder 26.15.7 treats a custom-directory environment variable that is defined as an empty string as an active override. The isolated Windows finalizer intentionally set two variants to empty values, so the NSIS URL lost its built-in release tag and became `.../releases/download//nsis-3.0.4.1.7z`.

The finalizer now retains the job-level neutralization and truly unsets all four recognized variable spellings immediately before launching Electron Builder. Existing digest pins, secret isolation, unsigned Windows policy, `--publish never`, final package verification, and fail-closed assembly remain unchanged.

## Validation

- Vitest: 57 focused release tests passed
- actionlint
- Biome
- TypeScript `--noEmit`
- architecture boundary and file-name checks
- AppStream XML validation
- `git diff --check`

## Distribution policy

Windows x64 remains intentionally unsigned and may trigger SmartScreen. AppImage remains excluded, and Flatpak remains independently validated rather than published by the release tag.
