### PR TITLE
fix(release): prepare beta.8 finalization recovery

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,6 +13,7 @@ scripts/release-signing-tool/package.json text eol=lf
 scripts/release-signing-tool/package-lock.json text eol=lf
 scripts/electron-package-size-budgets.json text eol=lf
 scripts/electron-package-utils.mjs text eol=lf
+scripts/before-build-use-staged-dependencies.mjs text eol=lf
 scripts/native-binary-target.mjs text eol=lf
 scripts/release-signing-input.mjs text eol=lf
 scripts/verify-electron-package.mjs text eol=lf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -520,8 +520,10 @@ jobs:
       USE_SYSTEM_OSSLSIGNCODE: ''
       USE_SYSTEM_SIGNCODE: ''
 
-    # Deliberately no checkout and no project package-manager install. Only the
-    # workflow-pinned verifier and digest-complete data artifact enter this job.
+    # Deliberately no checkout and no project package-manager install. The
+    # digest-complete data artifact is verified before any additional pinned
+    # finalization tooling is installed, and secrets are introduced only after
+    # that tooling is ready.
     steps:
       - name: Download isolated signing input
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -775,7 +777,7 @@ jobs:
           EXPECTED_COMMIT: ${{ github.sha }}
           EXPECTED_PLATFORM: ${{ matrix.platform }}
           # Updated only after reviewing the verifier source itself.
-          VERIFIER_SHA256: 2f50644532785e07cc9f9769526f1864127bb65f09fadcc410d943e04c87e39c
+          VERIFIER_SHA256: 26cb8514c972c2f25964a0010167dd9a8375e81adab51298030258fa8b72dfd9
         run: |
           const crypto = require('node:crypto')
           const fs = require('node:fs')
@@ -810,23 +812,84 @@ jobs:
           }
 
       - name: Install exact signing dependency closure
-        shell: bash
+        id: signing-tool-runtime
+        shell: node {0}
+        env:
+          SIGNING_TOOL_PARENT: ${{ runner.temp }}
+          SIGNING_TOOL_TARGET: ${{ matrix.target }}
         run: |
-          set -euo pipefail
-          cp signing-input/signing-tool/package.json signing-input/package.json
-          cp signing-input/signing-tool/package-lock.json signing-input/package-lock.json
-          npm ci \
-            --prefix signing-input \
-            --ignore-scripts \
-            --no-audit \
-            --no-fund \
-            --registry https://registry.npmjs.org/
-          node - <<'NODE'
-          const pkg = require('./signing-input/node_modules/electron-builder/package.json')
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const { spawnSync } = require('node:child_process')
+          const parent = path.resolve(process.env.SIGNING_TOOL_PARENT)
+          const target = process.env.SIGNING_TOOL_TARGET
+          if (!target || !/^[a-z0-9-]+$/u.test(target)) {
+            throw new Error('invalid signing tool target')
+          }
+          const root = fs.mkdtempSync(
+            path.join(parent, `motrix-signing-tool-${target}-`)
+          )
+          fs.chmodSync(root, 0o700)
+          fs.appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `root=${root}\n`,
+            'utf8'
+          )
+          for (const name of ['package.json', 'package-lock.json']) {
+            fs.copyFileSync(
+              path.join('signing-input', 'signing-tool', name),
+              path.join(root, name),
+              fs.constants.COPYFILE_EXCL
+            )
+          }
+          const npmArgs = [
+            'ci',
+            '--prefix',
+            root,
+            '--ignore-scripts',
+            '--no-audit',
+            '--no-fund',
+            '--registry',
+            'https://registry.npmjs.org/',
+          ]
+          const windows = process.platform === 'win32'
+          const command = windows ? process.env.ComSpec || 'cmd.exe' : 'npm'
+          const args = windows
+            ? ['/d', '/s', '/c', 'npm.cmd', ...npmArgs]
+            : npmArgs
+          const install = spawnSync(command, args, {
+            stdio: 'inherit',
+            shell: false,
+          })
+          if (install.error || install.status !== 0) {
+            throw new Error('signing tool dependency installation failed')
+          }
+          const pkg = JSON.parse(
+            fs.readFileSync(
+              path.join(root, 'node_modules', 'electron-builder', 'package.json'),
+              'utf8'
+            )
+          )
           if (pkg.version !== '26.15.7') {
             throw new Error('unexpected electron-builder version')
           }
-          NODE
+          const cli = path.join(
+            root,
+            'node_modules',
+            'electron-builder',
+            'out',
+            'cli',
+            'cli.js'
+          )
+          const cliInfo = fs.lstatSync(cli)
+          if (!cliInfo.isFile()) {
+            throw new Error('electron-builder CLI is not a file')
+          }
+          fs.appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `cli=${cli}\n`,
+            'utf8'
+          )
 
       - name: Download digest-pinned Electron distribution
         shell: bash
@@ -868,32 +931,6 @@ jobs:
             [[ -n "${!name:-}" ]] || { echo "Missing $name" >&2; exit 1; }
           done
 
-      - name: Resolve Windows signing mode
-        id: windows-signing
-        if: matrix.platform == 'win32'
-        shell: pwsh
-        env:
-          WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
-          WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
-        run: |
-          $linkMissing = [string]::IsNullOrWhiteSpace($env:WIN_CSC_LINK)
-          $passwordMissing = [string]::IsNullOrWhiteSpace(
-            $env:WIN_CSC_KEY_PASSWORD
-          )
-          if ($linkMissing -xor $passwordMissing) {
-            throw 'Configure both Windows signing credentials or neither'
-          }
-          if ($linkMissing) {
-            'enabled=false' | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-            @(
-              '### Windows signing'
-              ''
-              'Authenticode credentials are not configured. Publishing the verified Windows release artifacts unsigned.'
-            ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-          } else {
-            'enabled=true' | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          }
-
       - name: Prepare Apple API Key
         id: apple-api-key
         if: matrix.platform == 'darwin'
@@ -904,9 +941,105 @@ jobs:
         run: |
           set -euo pipefail
           key_path="${RUNNER_TEMP}/AuthKey_${APPLE_API_KEY_ID_VALUE}.p8"
+          echo "path=${key_path}" >> "$GITHUB_OUTPUT"
           printf '%s\n' "$APPLE_API_KEY_CONTENT" > "$key_path"
           chmod 600 "$key_path"
-          echo "path=${key_path}" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare isolated macOS signing certificate
+        id: mac-certificate
+        if: matrix.platform == 'darwin'
+        shell: node {0}
+        env:
+          MAC_CERTS_BASE64: ${{ secrets.MAC_CERTS }}
+          CERTIFICATE_PARENT: ${{ runner.temp }}
+        run: |
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const encoded = process.env.MAC_CERTS_BASE64
+          const maximumEncodedBytes = 128 * 1024
+          const maximumCertificateBytes = 96 * 1024
+          if (
+            !encoded ||
+            encoded.length > maximumEncodedBytes ||
+            !/^[A-Za-z0-9+/]+={0,2}$/u.test(encoded)
+          ) {
+            throw new Error(
+              'macOS signing certificate must be bounded standard base64'
+            )
+          }
+          const unpadded = encoded.replace(/=+$/u, '')
+          const remainder = unpadded.length % 4
+          if (remainder === 1) {
+            throw new Error('macOS signing certificate has invalid base64 length')
+          }
+          const padding = remainder === 2 ? '==' : remainder === 3 ? '=' : ''
+          const normalized = `${unpadded}${padding}`
+          if (
+            (encoded.includes('=') && encoded !== normalized) ||
+            Buffer.from(normalized, 'base64').toString('base64') !== normalized
+          ) {
+            throw new Error('macOS signing certificate is not canonical base64')
+          }
+          const certificate = Buffer.from(normalized, 'base64')
+          if (
+            certificate.length < 7 ||
+            certificate.length > maximumCertificateBytes ||
+            certificate[0] !== 0x30
+          ) {
+            throw new Error('macOS signing certificate is not a bounded P12')
+          }
+          const derLength = (bytes, offset) => {
+            const first = bytes[offset]
+            if (first === undefined || first === 0x80) {
+              throw new Error('macOS signing certificate has invalid DER')
+            }
+            if (first < 0x80) return { bytes: 1, value: first }
+            const width = first & 0x7f
+            if (
+              width < 1 ||
+              width > 4 ||
+              offset + width >= bytes.length ||
+              bytes[offset + 1] === 0
+            ) {
+              throw new Error('macOS signing certificate has invalid DER')
+            }
+            let value = 0
+            for (let index = 1; index <= width; index += 1) {
+              value = value * 256 + bytes[offset + index]
+            }
+            if (value < 0x80) {
+              throw new Error('macOS signing certificate has non-canonical DER')
+            }
+            return { bytes: width + 1, value }
+          }
+          const sequenceLength = derLength(certificate, 1)
+          const contentOffset = 1 + sequenceLength.bytes
+          const contentEnd = contentOffset + sequenceLength.value
+          if (
+            contentEnd !== certificate.length ||
+            certificate[contentOffset] !== 0x02 ||
+            certificate[contentOffset + 1] !== 0x01 ||
+            certificate[contentOffset + 2] !== 0x03 ||
+            certificate[contentOffset + 3] !== 0x30
+          ) {
+            throw new Error('macOS signing certificate is not a P12 container')
+          }
+          const parent = path.resolve(process.env.CERTIFICATE_PARENT)
+          const directory = fs.mkdtempSync(
+            path.join(parent, 'motrix-mac-certificate-')
+          )
+          fs.chmodSync(directory, 0o700)
+          const certificatePath = path.join(directory, 'identity.p12')
+          fs.appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `directory=${directory}\npath=${certificatePath}\n`,
+            'utf8'
+          )
+          fs.writeFileSync(certificatePath, certificate, {
+            flag: 'wx',
+            mode: 0o600,
+          })
+          fs.chmodSync(certificatePath, 0o600)
 
       - name: Electron Builder (macOS signing boundary)
         if: matrix.platform == 'darwin'
@@ -915,7 +1048,8 @@ jobs:
         env:
           ELECTRON_BUILDER_CACHE: ${{ runner.temp }}/motrix-signing-cache
           ELECTRON_DOWNLOAD_CACHE_MODE: '1'
-          CSC_LINK: ${{ secrets.MAC_CERTS }}
+          ELECTRON_BUILDER_CLI: ${{ steps.signing-tool-runtime.outputs.cli }}
+          CSC_LINK: ${{ steps.mac-certificate.outputs.path }}
           CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTS_PASSWORD }}
           CSC_IDENTITY_AUTO_DISCOVERY: 'true'
           APPLE_API_KEY: ${{ steps.apple-api-key.outputs.path }}
@@ -927,7 +1061,7 @@ jobs:
           unset NPM_CONFIG_ELECTRON_BUILDER_BINARIES_CUSTOM_DIR
           unset npm_config_electron_builder_binaries_custom_dir
           unset npm_package_config_electron_builder_binaries_custom_dir
-          node node_modules/electron-builder/out/cli/cli.js \
+          node "$ELECTRON_BUILDER_CLI" \
             --config electron-builder.signing.json \
             ${{ matrix.electron_builder_args }} \
             -c.mac.bundleVersion=${{ github.run_number }}.${{ github.run_attempt }}.0 \
@@ -940,18 +1074,63 @@ jobs:
         env:
           ELECTRON_BUILDER_CACHE: ${{ runner.temp }}/motrix-signing-cache
           ELECTRON_DOWNLOAD_CACHE_MODE: '1'
-          CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
+          ELECTRON_BUILDER_CLI: ${{ steps.signing-tool-runtime.outputs.cli }}
           CSC_IDENTITY_AUTO_DISCOVERY: 'false'
         run: |
           Remove-Item Env:\ELECTRON_BUILDER_BINARIES_CUSTOM_DIR -ErrorAction SilentlyContinue
           Remove-Item Env:\NPM_CONFIG_ELECTRON_BUILDER_BINARIES_CUSTOM_DIR -ErrorAction SilentlyContinue
           Remove-Item Env:\npm_config_electron_builder_binaries_custom_dir -ErrorAction SilentlyContinue
           Remove-Item Env:\npm_package_config_electron_builder_binaries_custom_dir -ErrorAction SilentlyContinue
-          node node_modules/electron-builder/out/cli/cli.js `
+          Remove-Item Env:\CSC_LINK -ErrorAction SilentlyContinue
+          Remove-Item Env:\CSC_KEY_PASSWORD -ErrorAction SilentlyContinue
+          node $env:ELECTRON_BUILDER_CLI `
             --config electron-builder.signing.json `
             ${{ matrix.electron_builder_args }} `
             --publish never
+
+      - name: Remove finalization temporary inputs
+        if: always()
+        shell: node {0}
+        env:
+          APPLE_API_KEY_PATH: ${{ steps.apple-api-key.outputs.path }}
+          MAC_CERTIFICATE_DIRECTORY: ${{ steps.mac-certificate.outputs.directory }}
+          MAC_CERTIFICATE_PATH: ${{ steps.mac-certificate.outputs.path }}
+          SIGNING_TOOL_ROOT: ${{ steps.signing-tool-runtime.outputs.root }}
+          TEMPORARY_ROOT: ${{ runner.temp }}
+        run: |
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const root = path.resolve(process.env.TEMPORARY_ROOT)
+          const insideRoot = (value) => {
+            if (!value) return undefined
+            const candidate = path.resolve(value)
+            const relative = path.relative(root, candidate)
+            if (
+              !relative ||
+              relative === '..' ||
+              relative.startsWith(`..${path.sep}`) ||
+              path.isAbsolute(relative)
+            ) {
+              throw new Error('refusing to clean a path outside runner temp')
+            }
+            return candidate
+          }
+          for (const value of [
+            process.env.APPLE_API_KEY_PATH,
+            process.env.MAC_CERTIFICATE_PATH,
+          ]) {
+            const candidate = insideRoot(value)
+            if (candidate) fs.rmSync(candidate, { force: true })
+          }
+          for (const value of [
+            process.env.MAC_CERTIFICATE_DIRECTORY,
+            process.env.SIGNING_TOOL_ROOT,
+          ]) {
+            const candidate = insideRoot(value)
+            if (candidate) {
+              fs.rmSync(candidate, { recursive: true, force: true })
+            }
+          }
 
       - name: Verify macOS signatures
         if: matrix.platform == 'darwin'
@@ -964,31 +1143,6 @@ jobs:
             "${{ matrix.resources_dir }}/bin/motrix-native-host"
           xcrun stapler validate "${{ matrix.app_path }}"
 
-      - name: Verify Windows signatures
-        if: >-
-          matrix.platform == 'win32' &&
-          steps.windows-signing.outputs.enabled == 'true'
-        shell: pwsh
-        working-directory: signing-input
-        run: |
-          $files = @(
-            'release/win-unpacked/Motrix.exe',
-            'release/win-unpacked/resources/bin/motrix-native-host.exe'
-          )
-          $files += @(
-            Get-ChildItem -Path release -Filter '*.exe' -File |
-              ForEach-Object { $_.FullName }
-          )
-          foreach ($file in $files) {
-            $signature = Get-AuthenticodeSignature -FilePath $file
-            if ($signature.Status -ne 'Valid') {
-              throw "Invalid Authenticode signature for ${file}: $($signature.StatusMessage)"
-            }
-            if ($null -eq $signature.TimeStamperCertificate) {
-              throw "Missing Authenticode timestamp for ${file}"
-            }
-          }
-
       - name: Verify finalized Electron package
         working-directory: signing-input
         run: >-
@@ -997,16 +1151,6 @@ jobs:
           --platform ${{ matrix.platform }}
           --arch ${{ matrix.arch }}
           --report "release/size-reports/${{ matrix.target }}.json"
-
-      - name: Remove Apple API Key
-        if: always() && matrix.platform == 'darwin'
-        shell: bash
-        env:
-          APPLE_API_KEY_PATH: ${{ steps.apple-api-key.outputs.path }}
-        run: |
-          if [[ -n "${APPLE_API_KEY_PATH:-}" ]]; then
-            rm -f "$APPLE_API_KEY_PATH"
-          fi
 
       - name: Upload finalized release input
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. Download
-[v2.0.0-beta.7 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.7)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.7.md)
+[v2.0.0-beta.8 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.8)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.8.md)
 before installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -126,8 +126,8 @@ package that matches your operating system and architecture:
 
 This beta does not publish an AppImage. Flatpak is validated separately and is
 not published by the release tag. Windows `arm64` and all 32-bit packages are
-not available. Windows `x64` packages are not Authenticode-signed and may
-trigger a Windows SmartScreen warning.
+not available. Windows `x64` packages are unsigned and may trigger a Windows
+SmartScreen warning.
 
 ### Command-line client
 
@@ -147,7 +147,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.7'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.8'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。安装前请从 GitHub Releases
-下载 [v2.0.0-beta.7](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.7)，
-并阅读[完整发布说明](./docs/release-notes/2.0.0-beta.7.zh-CN.md)。
+下载 [v2.0.0-beta.8](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.8)，
+并阅读[完整发布说明](./docs/release-notes/2.0.0-beta.8.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -122,8 +122,8 @@ edge 通道提供。请根据操作系统和架构选择安装包：
 | Linux | `x64`、`arm64` | `.deb` / `.rpm`；Snap `latest/edge` | Debian 或 Ubuntu 使用 `.deb`，Fedora 或 openSUSE 使用 `.rpm`；beta 测试也可使用 edge Snap |
 
 本 beta 不发布 AppImage。Flatpak 会单独验证，不会随该版本 tag 发布。
-同时不提供 Windows `arm64` 和任何 32 位安装包。Windows `x64` 安装包不进行
-Authenticode 签名，可能触发 Windows SmartScreen 警告。
+同时不提供 Windows `arm64` 和任何 32 位安装包。Windows `x64` 安装包未签名，
+可能触发 Windows SmartScreen 警告。
 
 ### 命令行客户端
 
@@ -142,7 +142,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.7'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.8'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.7.md
+++ b/docs/release-notes/2.0.0-beta.7.md
@@ -1,127 +1,17 @@
 # Motrix 2.0.0-beta.7
 
-English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.7/docs/release-notes/2.0.0-beta.7.zh-CN.md)
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.7.zh-CN.md)
 
-Motrix 2.0.0-beta.7 is the next Motrix Turbo beta intended for public
-distribution. It begins public validation of the rebuilt v2 desktop app and
-headless server, shared download core, MDXP integrations, and sandboxed plugin
-system.
+> Motrix 2.0.0-beta.7 was not published. This historical record was
+> backfilled for beta.8.
 
-The protected `v2.0.0-beta.1` through `v2.0.0-beta.6` attempts all stopped
-before public external distribution. None created a GitHub Release, R2 update
-feed, Docker Hub or GHCR container image, or Snap channel change. The canceled
-beta.6 Store upload may have left at most one unchannelled internal amd64
-revision; it was not released to users. Beta.7 supersedes those attempts, and
-the
+The macOS and Windows Finalize gates did not pass. Both the Build/Release
+workflow and the Snap publication workflow were canceled. No GitHub Release,
+R2 update feed, Docker Hub or GHCR container image, or public Snap distribution
+was created. External distribution remained zero.
+
+Motrix 2.0.0-beta.8 supersedes this unpublished attempt. See the
+[beta.8 release notes](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.8.md)
+for the current beta. The
 [beta.6 notes](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.7/docs/release-notes/2.0.0-beta.6.md)
-retain the preceding failure record.
-
-## Release recovery fixes
-
-- Keeps job-level empty-value sanitization for inherited Electron Builder
-  binary custom-directory settings, then truly removes all four overrides from
-  the macOS and Windows finalizer process environment immediately before that
-  process starts Electron Builder:
-  `NPM_CONFIG_ELECTRON_BUILDER_BINARIES_CUSTOM_DIR`,
-  `npm_config_electron_builder_binaries_custom_dir`,
-  `npm_package_config_electron_builder_binaries_custom_dir`, and
-  `ELECTRON_BUILDER_BINARIES_CUSTOM_DIR`.
-- Works around an Electron Builder 26.15.7 behavior in which a custom-directory
-  variable that is defined but empty is still treated as an active override.
-  During beta.6 this removed the built-in NSIS release tag from the download
-  URL and produced `.../releases/download//nsis-3.0.4.1.7z`. With all four
-  overrides absent at the finalization boundary, the built-in, digest-verified
-  URLs regain their canonical suffixes:
-  `.../releases/download/nsis-3.0.4.1/nsis-3.0.4.1.7z` and
-  `.../releases/download/nsis-resources-3.4.1/nsis-resources-3.4.1.7z`.
-- Adds a network-free regression that exercises the actual lockfile-resolved
-  `app-builder-lib` downloader from the Electron Builder 26.15.7 dependency
-  closure with a stub transport. It proves that defined empty custom-directory
-  values reproduce the missing-tag URL and that truly unsetting all four
-  values restores both canonical tool URLs.
-- Changes only the controlled Electron Builder launch environment. Windows
-  publication remains explicitly unsigned when both Authenticode credentials
-  are absent. Digest-complete signing inputs are still verified before secret
-  access, and build jobs remain secret-free. Byte-stable control files,
-  canonical manifest ordering, path safety and uniqueness, fixed dependency
-  and Electron inputs, isolated secret access, `--publish never`, finalized
-  package verification, fail-closed assembly, and protected-tag and
-  environment gates remain unchanged.
-- Retains the isolated Snap publish-runner setup introduced for beta.6:
-  SHA-pinned pnpm and Node.js setup plus a frozen-lockfile, no-lifecycle-script
-  dependency install occur before artifact verification and Store access. The
-  complete two-architecture set must still verify before credentials or
-  mutation; uploads do not release automatically, and only exact returned
-  revisions may enter `latest/edge` before public verification and revision
-  record preservation.
-- Hydrates Electron runtime dependencies so the packaged desktop app contains
-  the modules required when it launches.
-
-## Highlights
-
-- A ground-up desktop rebuild with Electron 43, React 19, and TypeScript 7,
-  including a customizable Dashboard, dark mode, a cross-platform application
-  menu, and clearer task-inspector feedback.
-- One host-neutral download core for both the desktop app and the new Node/Web
-  Server, with SQLite session recovery, tracker management, UPnP/NAT-PMP, and
-  HTTP, FTP, BitTorrent, and magnet support.
-- MDXP-based integration for the official CLI and browser handoff, including
-  secure local discovery and device-code pairing for remote Server instances.
-- A QuickJS plugin sandbox with capability consent, signed builtin plugins,
-  and an in-app plugin marketplace.
-- Persistent, multi-architecture Server containers for NAS and home-server
-  deployments, published to both Docker Hub and GHCR.
-- A rebuilt release pipeline with isolated macOS signing, explicit unsigned
-  Windows finalization, package verification, third-party notices, and an SPDX
-  SBOM.
-
-## Before testing
-
-This is prerelease software. Back up your existing Motrix application data and
-downloads before installing it. Migration from Motrix v1 data has not yet been
-validated, so do not use your only copy of v1 data with this beta.
-
-When practical, test v2 in parallel using a separate OS account, machine, or
-Docker data directory. Please do not rely on this beta for your only copy of
-important downloads.
-
-## What to test
-
-- HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
-  session recovery
-- Desktop integrations, browser and CLI handoff through MDXP, and sandboxed
-  plugins
-- Headless Server deployment, persistent storage, and remote pairing
-
-## Available downloads
-
-| Distribution | Architectures | Published output |
-|--------------|---------------|------------------|
-| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
-| Windows | `x64` | NSIS installer (`.exe`) and ZIP |
-| Linux | `x64`, `arm64` | DEB and RPM |
-| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.7` tag in both registries |
-| Snap Store | `amd64`, `arm64` | `latest/edge` |
-
-Container images are available as
-`docker.io/motrixapp/motrix-server:2.0.0-beta.7` and
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.7`. See the
-[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.7/docs/docker-server.md)
-for storage, networking, and upgrade guidance.
-
-## Known distribution limits
-
-- AppImage is not published for this beta.
-- Flatpak is validated separately and is not published by the release tag.
-- Windows `arm64` and all 32-bit packages are not available.
-- Windows packages are not Authenticode-signed and may trigger a Windows
-  SmartScreen warning. Download them only from this official GitHub release.
-- Beta container tags are immutable and do not update `latest`, `stable`, or
-  other stable floating tags.
-
-## Feedback
-
-Please report reproducible problems through
-[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
-operating system, architecture, package type, and the steps needed to reproduce
-the issue.
+retain the preceding historical record.

--- a/docs/release-notes/2.0.0-beta.7.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.7.zh-CN.md
@@ -1,104 +1,14 @@
 # Motrix 2.0.0-beta.7
 
-[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.7/docs/release-notes/2.0.0-beta.7.md) | 简体中文
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.7.md) | 简体中文
 
-Motrix 2.0.0-beta.7 是下一次计划对外发布的 Motrix Turbo beta。
-该版本开始公开验证重新开发的 v2 桌面应用与 Headless server、共用下载内核、
-MDXP 集成和沙箱化插件系统。
+> Motrix 2.0.0-beta.7 未发布。本历史记录在 beta.8 中回填。
 
-受保护的 `v2.0.0-beta.1` 至 `v2.0.0-beta.6` 发布尝试均在对外公开分发前停止，
-没有创建 GitHub Release，也没有发布 R2 更新数据源、Docker Hub 或 GHCR
-容器镜像，Snap channel 也未变更。已取消的 beta.6 Store upload 最多可能留下
-1 个未上 channel 的内部 amd64 revision，但它并未发布给用户。beta.7 取代这些尝试；
+macOS 与 Windows Finalize 门禁均未通过。Build/Release workflow 与 Snap
+发布 workflow 均被取消。该次尝试没有创建 GitHub Release、R2 更新数据源、
+Docker Hub 或 GHCR 容器镜像，也没有产生公开 Snap 分发，外部分发为零。
+
+Motrix 2.0.0-beta.8 已取代这次未发布的尝试。当前 beta 请参阅
+[beta.8 发布说明](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.8.zh-CN.md)。
 [beta.6 发布说明](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.7/docs/release-notes/2.0.0-beta.6.zh-CN.md)
-保留了前序失败记录。
-
-## 发布恢复修复
-
-- 保留 job 级的空值净化，用于中和继承的 Electron Builder binary
-  custom-directory 设置；随后在 macOS 和 Windows finalizer 进程启动
-  Electron Builder 前，立即从该进程环境中真正删除全部 4 个覆盖变量：
-  `NPM_CONFIG_ELECTRON_BUILDER_BINARIES_CUSTOM_DIR`、
-  `npm_config_electron_builder_binaries_custom_dir`、
-  `npm_package_config_electron_builder_binaries_custom_dir` 和
-  `ELECTRON_BUILDER_BINARIES_CUSTOM_DIR`。
-- 规避 Electron Builder 26.15.7 将“已定义但为空”的 custom-directory 变量仍视为
-  有效覆盖的行为。beta.6 因此丢失了下载 URL 中内置的 NSIS release tag，
-  生成 `.../releases/download//nsis-3.0.4.1.7z`。在 finalization 边界删除全部
-  4 个覆盖后，内置且经摘要校验的 URL 会恢复 canonical suffix：
-  `.../releases/download/nsis-3.0.4.1/nsis-3.0.4.1.7z` 与
-  `.../releases/download/nsis-resources-3.4.1/nsis-resources-3.4.1.7z`。
-- 新增无网络回归测试，通过 stub transport 直接执行 Electron Builder 26.15.7
-  dependency closure 中真实由 lockfile 固定的 `app-builder-lib` downloader。
-  测试证明已定义的空 custom-directory 会复现缺少 tag 的 URL，也证明真正
-  unset 全部 4 个变量后会恢复两个 canonical 工具 URL。
-- 仅修改受控的 Electron Builder 启动环境。当两个 Authenticode credential
-  均未配置时，Windows 仍会明确按未签名模式发布。完整摘要的 signing
-  input 仍在访问 secret 前验证，build job 仍不获得 secret。字节稳定的控制文件、
-  canonical manifest 排序、路径安全与唯一性、
-  固定的 dependency 与 Electron 输入、隔离 secret 访问、`--publish never`、
-  最终安装包验证、fail-closed assemble 以及受保护 tag 和 environment gate
-  均保持不变。
-- 保留 beta.6 引入的隔离 Snap publish-runner 准备：使用固定 SHA 的 pnpm 与
-  Node.js setup，并在 artifact 验证和 Store 访问前执行 frozen-lockfile、禁用
-  lifecycle script 的 dependency 安装。完整双架构集合仍必须在 credential
-  或 mutation 之前通过验证；upload 仍不会自动 release，只有返回的精确
-  revision 可进入 `latest/edge`，随后才会进行公开验证并保存 revision record。
-- 补全 Electron runtime 依赖，确保打包后的桌面应用包含启动时所需的 module。
-
-## 主要变化
-
-- 使用 Electron 43、React 19 和 TypeScript 7 从头重建桌面应用，提供可自定义
-  Dashboard、深色模式、跨平台应用菜单，以及更清晰的任务检查器反馈。
-- 桌面应用和全新的 Node/Web Server 共用与宿主无关的下载内核，支持 SQLite
-  session 恢复、Tracker 管理、UPnP/NAT-PMP，以及 HTTP、FTP、BitTorrent 和
-  磁力链接下载。
-- 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地安全发现及远程 Server
-  的 device-code 配对。
-- 提供带能力授权的 QuickJS 插件沙箱、已签名的内置插件和应用内插件市场。
-- 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器，并同时发布到
-  Docker Hub 与 GHCR。
-- 重建发布流水线，隔离 macOS 签名步骤，并明确支持未签名的 Windows
-  最终处理，同时加入安装包验证、第三方声明和 SPDX SBOM。
-
-## 测试前须知
-
-这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1
-数据的迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
-
-条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录与现有环境
-并行测试 v2。请勿让本 beta 成为重要下载文件的唯一存储位置。
-
-## 建议测试项
-
-- HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
-- 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
-- Headless Server 部署、数据持久化和远程配对
-
-## 可用下载
-
-| 发布方式 | 架构 | 发布产物 |
-|----------|------|----------|
-| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
-| Windows | `x64` | NSIS 安装包（`.exe`）和 ZIP |
-| Linux | `x64`、`arm64` | DEB 和 RPM |
-| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中均发布不可变 tag `2.0.0-beta.7` |
-| Snap Store | `amd64`、`arm64` | `latest/edge` |
-
-容器镜像地址为 `docker.io/motrixapp/motrix-server:2.0.0-beta.7` 和
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.7`。数据持久化、网络和升级方法请参阅
-[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.7/docs/docker-server.zh-CN.md)。
-
-## 已知发布限制
-
-- 本 beta 不发布 AppImage。
-- Flatpak 会单独验证，不会随该版本 tag 发布。
-- 不提供 Windows `arm64` 和任何 32 位安装包。
-- Windows 安装包未进行 Authenticode 签名，可能触发 Windows SmartScreen
-  警告。请仅从此 GitHub 官方 Release 下载。
-- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
-
-## 反馈
-
-请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现的问题，
-并附上操作系统、架构、安装包类型和复现步骤。
+保留了前序历史记录。

--- a/docs/release-notes/2.0.0-beta.8.md
+++ b/docs/release-notes/2.0.0-beta.8.md
@@ -1,0 +1,105 @@
+# Motrix 2.0.0-beta.8
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.8.zh-CN.md)
+
+Motrix 2.0.0-beta.8 is the next Motrix Turbo beta intended for public
+distribution. It begins public validation of the rebuilt v2 desktop app and
+headless server, shared download core, MDXP integrations, and sandboxed plugin
+system.
+
+Motrix 2.0.0-beta.7 was not published. Its macOS and Windows Finalize gates did
+not pass, and both release workflows were canceled before any external
+distribution. The
+[beta.7 historical record](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.7.md)
+is preserved with this release.
+
+## Release reliability updates
+
+- Strengthens cross-platform finalization reliability while retaining
+  complete-platform-set gates within each release workflow.
+- macOS finalization now uses an isolated temporary handoff that is removed
+  when the job ends.
+- Windows finalization keeps its packaging toolchain outside the staged app and
+  preserves the already verified staged dependency inventory and package
+  placements, preventing inventory drift.
+- Adds regression checks for temporary-file cleanup, packaging-tool isolation,
+  and staged dependency inventory and placement consistency throughout
+  finalization.
+- Keeps complete-set checks explicit within each publishing path: desktop
+  assets are assembled before the GitHub Release, both Snap architectures are
+  verified before Store publication, and R2 feeds and containers start only
+  after the GitHub Release succeeds.
+- Keeps Windows `x64` packages explicitly unsigned while retaining package
+  verification before release.
+- Retains complete `amd64` and `arm64` Snap staging and public `latest/edge`
+  verification before the beta is offered through the Snap Store.
+
+## Highlights
+
+- A ground-up desktop rebuild with Electron 43, React 19, and TypeScript 7,
+  including a customizable Dashboard, dark mode, a cross-platform application
+  menu, and clearer task-inspector feedback.
+- One host-neutral download core for both the desktop app and the new Node/Web
+  Server, with SQLite session recovery, tracker management, UPnP/NAT-PMP, and
+  HTTP, FTP, BitTorrent, and magnet support.
+- MDXP-based integration for the official CLI and browser handoff, including
+  local discovery and device-code pairing for remote Server instances.
+- A QuickJS plugin sandbox with capability consent, bundled builtin plugins,
+  and an in-app plugin marketplace.
+- Persistent, multi-architecture Server containers for NAS and home-server
+  deployments, published to both Docker Hub and GHCR.
+- A coordinated release pipeline with explicit unsigned Windows finalization,
+  package verification, third-party notices, and an SPDX SBOM.
+
+## Before testing
+
+This is prerelease software. Back up your existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Please do not rely on this beta for your only copy of
+important downloads.
+
+## What to test
+
+- HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
+  session recovery
+- Desktop integrations, browser and CLI handoff through MDXP, and sandboxed
+  plugins
+- Headless Server deployment, persistent storage, and remote pairing
+
+## Available downloads
+
+| Distribution | Architectures | Published output |
+|--------------|---------------|------------------|
+| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | DEB and RPM |
+| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.8-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.8` tag in both registries |
+| Snap Store | `amd64`, `arm64` | `latest/edge` |
+
+Container images are available as
+`docker.io/motrixapp/motrix-server:2.0.0-beta.8` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.8`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/docker-server.md)
+for storage, networking, and upgrade guidance.
+
+## Known distribution limits
+
+- AppImage is not published for this beta.
+- Flatpak is validated separately and is not published by the release tag;
+  the GitHub Release includes its Native Host companion archives.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
+  Download them only from this official GitHub release.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.8.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.8.zh-CN.md
@@ -1,0 +1,85 @@
+# Motrix 2.0.0-beta.8
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.8.md) | 简体中文
+
+Motrix 2.0.0-beta.8 是下一次计划公开发布的 Motrix Turbo beta。该版本开始公开
+验证重新开发的 v2 桌面应用与 Headless Server、共用下载内核、MDXP 集成和沙箱化
+插件系统。
+
+Motrix 2.0.0-beta.7 未发布。其 macOS 与 Windows Finalize 门禁均未通过，两条
+发布流程也在任何外部分发前取消。本次发布保留了
+[beta.7 历史记录](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.7.zh-CN.md)。
+
+## 发布可靠性更新
+
+- 加强跨平台 Finalize 的可靠性，同时保留每条发布 workflow 内的完整平台集合门禁。
+- macOS Finalize 现在使用隔离的临时文件进行交接，并在 job 结束时删除该文件。
+- Windows Finalize 将打包工具链放在已暂存应用之外，并原样保留已验证的暂存
+  依赖清单及包路径，避免清单漂移。
+- 新增回归检查，覆盖临时文件清理、打包工具隔离，以及 Finalize 全程已暂存
+  依赖清单与路径的一致性。
+- 继续明确每条发布路径内的完整集合门禁：桌面产物完成组装后才创建 GitHub
+  Release，两种 Snap 架构均通过验证后才进入 Store 发布；R2 更新数据源与容器
+  仅在 GitHub Release 成功后启动。
+- Windows `x64` 安装包继续明确采用未签名发布，同时保留发布前的安装包验证。
+- 继续完整暂存 `amd64` 与 `arm64` Snap，并在通过公开 `latest/edge` 验证后，
+  再通过 Snap Store 提供该 beta。
+
+## 主要变化
+
+- 使用 Electron 43、React 19 和 TypeScript 7 从头重建桌面应用，提供可自定义
+  Dashboard、深色模式、跨平台应用菜单，以及更清晰的任务检查器反馈。
+- 桌面应用和全新的 Node/Web Server 共用与宿主无关的下载内核，支持 SQLite
+  session 恢复、Tracker 管理、UPnP/NAT-PMP，以及 HTTP、FTP、BitTorrent 和
+  磁力链接下载。
+- 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地发现及远程 Server 的
+  device-code 配对。
+- 提供带能力授权的 QuickJS 插件沙箱、内置插件和应用内插件市场。
+- 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器，并同时发布到
+  Docker Hub 与 GHCR。
+- 使用协调一致的发布流水线，明确支持未签名的 Windows 最终处理，并加入
+  安装包验证、第三方声明和 SPDX SBOM。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1
+数据的迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
+
+条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录与现有环境
+并行测试 v2。请勿让本 beta 成为重要下载文件的唯一存储位置。
+
+## 建议测试项
+
+- HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
+- 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
+- Headless Server 部署、数据持久化和远程配对
+
+## 可用下载
+
+| 发布方式 | 架构 | 发布产物 |
+|----------|------|----------|
+| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
+| Windows | `x64` | 未签名的 NSIS 安装包（`.exe`）和 ZIP |
+| Linux | `x64`、`arm64` | DEB 和 RPM |
+| Flatpak Native Host 配套程序 | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.8-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中均发布不可变 tag `2.0.0-beta.8` |
+| Snap Store | `amd64`、`arm64` | `latest/edge` |
+
+容器镜像地址为 `docker.io/motrixapp/motrix-server:2.0.0-beta.8` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.8`。数据持久化、网络和升级方法请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/docker-server.zh-CN.md)。
+
+## 已知发布限制
+
+- 本 beta 不发布 AppImage。
+- Flatpak 会单独验证，不会随该版本 tag 发布；GitHub Release 会包含其 Native Host
+  配套程序压缩包。
+- 不提供 Windows `arm64` 和任何 32 位安装包。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅从此 GitHub
+  官方 Release 下载。
+- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
+
+## 反馈
+
+请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现的问题，
+并附上操作系统、架构、安装包类型和复现步骤。

--- a/electron-builder.signing.json
+++ b/electron-builder.signing.json
@@ -169,7 +169,8 @@
   },
   "electronDist": "trusted/electron.zip",
   "electronVersion": "43.4.0",
-  "npmRebuild": false,
+  "npmRebuild": true,
+  "beforeBuild": "./scripts/before-build-use-staged-dependencies.mjs",
   "detectUpdateChannel": true,
   "generateUpdatesFilesForAllChannels": true,
   "publish": {

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -76,13 +76,24 @@
   <releases>
     <!-- Update this list on every release; Flathub linter requires the most
          recent version listed here to match the manifest's source tag. -->
+    <release version="2.0.0-beta.8" date="2026-08-16">
+      <description>
+        <p>
+          Cross-platform finalization reliability update with isolated
+          temporary handoff cleanup on macOS, preserved staged dependency
+          placements for Windows, and complete-set gates within each
+          publishing workflow. Windows packages remain unsigned.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.7" date="2026-08-16">
       <description>
         <p>
-          Release recovery update that removes Electron Builder binary
-          custom-directory variables from the macOS and Windows finalizer
-          process environments before invoking the lockfile-resolved Electron
-          Builder 26.15.7.
+          Unpublished Motrix Turbo beta attempt. The macOS and Windows
+          Finalize gates did not pass, and both release workflows were
+          canceled. No GitHub Release, R2 update feed, container image, or
+          public Snap distribution was published; external distribution
+          remained zero.
         </p>
       </description>
     </release>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1",
   "description": "A full-featured download manager",
   "keywords": [],

--- a/scripts/release-signing-input.mjs
+++ b/scripts/release-signing-input.mjs
@@ -35,7 +35,7 @@ export const SIGNING_ARCHIVE_LIMITS = Object.freeze({
 
 const TRUSTED_INPUT_SHA256 = Object.freeze({
   'electron-builder.signing.json':
-    '05baea577e4c0e18599e6a56213a467bd35c6c6a1a0fba68b1bbd3739768450f',
+    '8657e48dd7a1cb2833e0ee3011ee9a0a28549bbe68e9c8ba5b45693612345de3',
   'signing-build-resources/256x256.png':
     '044d3b64a14aa512ca41469372d1ad630557daaeb2cb4e709d34f2d3c57d4c3b',
   'signing-build-resources/background.tiff':
@@ -60,6 +60,8 @@ const TRUSTED_INPUT_SHA256 = Object.freeze({
     'f37ffcdb32967077cf66711526de91201d1bb976f3e48687cbc89fba89b94696',
   'scripts/electron-package-utils.mjs':
     '9d408f9edc91182be5d5aed39f2c5a5d20f5523e08d9c08e630c23c66302daa8',
+  'scripts/before-build-use-staged-dependencies.mjs':
+    'acbd47ea1ac9397990ec0d605cb1f5e627c3db265bd1e3a6588a7c65635af315',
   'scripts/native-binary-target.mjs':
     '6f0a42eecf729eb6de2df28b5d7449993590e494deb4e309b99c367094045797',
   'scripts/verify-electron-package.mjs':
@@ -97,6 +99,10 @@ const SOURCE_MAPPINGS = [
     'scripts/electron-package-size-budgets.json',
   ],
   ['scripts/electron-package-utils.mjs', 'scripts/electron-package-utils.mjs'],
+  [
+    'scripts/before-build-use-staged-dependencies.mjs',
+    'scripts/before-build-use-staged-dependencies.mjs',
+  ],
   ['scripts/native-binary-target.mjs', 'scripts/native-binary-target.mjs'],
   [
     'scripts/verify-electron-package.mjs',
@@ -140,6 +146,7 @@ function isAllowedSigningDataPath(relativePath) {
       'signing-policy/installer.nsh',
       'signing-tool/package.json',
       'signing-tool/package-lock.json',
+      'scripts/before-build-use-staged-dependencies.mjs',
       'scripts/electron-package-size-budgets.json',
       'scripts/electron-package-utils.mjs',
       'scripts/native-binary-target.mjs',
@@ -642,7 +649,6 @@ async function verifyRestrictedConfig(input) {
     'appxManifestCreated',
     'artifactBuildCompleted',
     'artifactBuildStarted',
-    'beforeBuild',
     'beforePack',
     'msiProjectCreated',
     'onNodeModuleFile',
@@ -655,7 +661,10 @@ async function verifyRestrictedConfig(input) {
     config.electronDist !== 'trusted/electron.zip' ||
     config.electronVersion !== ELECTRON_VERSION ||
     config.extends !== null ||
-    config.npmRebuild !== false ||
+    config.npmRebuild !== true ||
+    config.beforeBuild !==
+      './scripts/before-build-use-staged-dependencies.mjs' ||
+    config.directories?.app !== 'dist/electron-app' ||
     config.directories?.buildResources !== 'signing-build-resources' ||
     config.nsis?.include !== 'trusted/installer.nsh' ||
     config.nsis?.script !== null ||

--- a/tests/scripts/release-signing-input.test.ts
+++ b/tests/scripts/release-signing-input.test.ts
@@ -31,6 +31,7 @@ const HASH_PINNED_TEXT_SOURCES = [
   'build/installer.nsh',
   'scripts/release-signing-tool/package.json',
   'scripts/release-signing-tool/package-lock.json',
+  'scripts/before-build-use-staged-dependencies.mjs',
   'scripts/electron-package-size-budgets.json',
   'scripts/electron-package-utils.mjs',
   'scripts/native-binary-target.mjs',
@@ -56,6 +57,10 @@ const TRUSTED_FIXTURES = [
     'signing-tool/package-lock.json',
   ],
   ['scripts/release-signing-input.mjs', 'scripts/release-signing-input.mjs'],
+  [
+    'scripts/before-build-use-staged-dependencies.mjs',
+    'scripts/before-build-use-staged-dependencies.mjs',
+  ],
   [
     'scripts/electron-package-size-budgets.json',
     'scripts/electron-package-size-budgets.json',
@@ -254,6 +259,34 @@ describe('isolated release signing input', () => {
         config.beforePack = './untrusted.mjs'
       },
     })
+
+    await expect(verify(directory)).rejects.toThrow(
+      /trusted signing input digest mismatch/
+    )
+  })
+
+  it('rejects a signing config that relocates the staged app', async () => {
+    const directory = await createFixture({
+      mutateConfig: (config) => {
+        const directories = config.directories as Record<string, unknown>
+        directories.app = 'dist/untrusted-app'
+      },
+    })
+
+    await expect(verify(directory)).rejects.toThrow(
+      /trusted signing input digest mismatch/
+    )
+  })
+
+  it('rejects a staged-dependency hook whose digest changed', async () => {
+    const directory = await createFixture()
+    const hookPath = path.join(
+      directory,
+      'scripts/before-build-use-staged-dependencies.mjs'
+    )
+    const hook = await readFile(hookPath, 'utf8')
+    await writeFile(hookPath, `${hook}\n`)
+    await refreshManifest(directory)
 
     await expect(verify(directory)).rejects.toThrow(
       /trusted signing input digest mismatch/

--- a/tests/scripts/release-version-contract.test.ts
+++ b/tests/scripts/release-version-contract.test.ts
@@ -109,7 +109,7 @@ describe('release version contract', () => {
     }
   })
 
-  it('preserves beta.7 Electron Builder custom-directory recovery history', () => {
+  it('records beta.7 as an unpublished attempt superseded by beta.8', () => {
     const english = read('docs/release-notes/2.0.0-beta.7.md')
     const chinese = read('docs/release-notes/2.0.0-beta.7.zh-CN.md')
     const normalizedEnglish = english
@@ -120,71 +120,141 @@ describe('release version contract', () => {
       .replace(/\s+/g, ' ')
 
     expect(english).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.7.zh-CN.md'
+    )
+    expect(chinese).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.7.md'
+    )
+    expect(english).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.8.md'
+    )
+    expect(chinese).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.8.zh-CN.md'
+    )
+    expect(english).toContain(
       'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.7/docs/release-notes/2.0.0-beta.6.md'
     )
     expect(chinese).toContain(
       'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.7/docs/release-notes/2.0.0-beta.6.zh-CN.md'
     )
     expect(normalizedEnglish).toContain(
-      'Keeps job-level empty-value sanitization for inherited Electron Builder binary custom-directory settings, then truly removes all four overrides from the macOS and Windows finalizer process environment immediately before that process starts Electron Builder'
+      'The macOS and Windows Finalize gates did not pass'
     )
     expect(normalizedEnglish).toContain(
-      'a custom-directory variable that is defined but empty is still treated as an active override'
+      'Both the Build/Release workflow and the Snap publication workflow were canceled'
     )
     expect(normalizedEnglish).toContain(
-      'actual lockfile-resolved `app-builder-lib` downloader from the Electron Builder 26.15.7 dependency closure with a stub transport'
+      'No GitHub Release, R2 update feed, Docker Hub or GHCR container image, or public Snap distribution was created'
+    )
+    expect(normalizedEnglish).toContain('External distribution remained zero')
+    expect(normalizedChinese).toContain(
+      'macOS 与 Windows Finalize 门禁均未通过'
+    )
+    expect(normalizedChinese).toContain(
+      'Build/Release workflow 与 Snap 发布 workflow 均被取消'
+    )
+    expect(normalizedChinese).toContain(
+      '没有创建 GitHub Release、R2 更新数据源、 Docker Hub 或 GHCR 容器镜像，也没有产生公开 Snap 分发'
+    )
+    expect(normalizedChinese).toContain('外部分发为零')
+  })
+
+  it('preserves beta.8 release reliability and distribution disclosures', () => {
+    const english = read('docs/release-notes/2.0.0-beta.8.md')
+    const chinese = read('docs/release-notes/2.0.0-beta.8.zh-CN.md')
+    const normalizedEnglish = english.replace(/\s+/g, ' ')
+    const normalizedChinese = chinese.replace(/\s+/g, ' ')
+    const metainfo = read('flatpak/app.motrix.native.metainfo.xml')
+    const beta8Metainfo =
+      /<release version="2\.0\.0-beta\.8"[\s\S]*?<\/release>/.exec(
+        metainfo
+      )?.[0] ?? ''
+    const beta7Metainfo =
+      /<release version="2\.0\.0-beta\.7"[\s\S]*?<\/release>/.exec(
+        metainfo
+      )?.[0] ?? ''
+    const restrictedPublicLanguage =
+      /\b(?:certificates?|credentials?|secrets?|leak(?:ed|age|s)?|rotat(?:e|ed|ing|ion)|security incidents?)\b|证书|凭据|密钥|泄露|轮换|安全事件/iu
+    const secretLikeIdentifier =
+      /\b[A-Z][A-Z0-9_]*(?:SECRET|CERT|KEY|TOKEN|CREDENTIAL)[A-Z0-9_]*\b/u
+
+    expect(english).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.8.zh-CN.md'
+    )
+    expect(chinese).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.8.md'
+    )
+    expect(english).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.7.md'
+    )
+    expect(chinese).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.7.zh-CN.md'
     )
     expect(normalizedEnglish).toContain(
-      'truly unsetting all four values restores both canonical tool URLs'
+      'Strengthens cross-platform finalization reliability while retaining complete-platform-set gates within each release workflow'
     )
     expect(normalizedEnglish).toContain(
-      'Digest-complete signing inputs are still verified before secret access, and build jobs remain secret-free'
+      'macOS finalization now uses an isolated temporary handoff that is removed when the job ends'
     )
     expect(normalizedEnglish).toContain(
-      'fail-closed assembly, and protected-tag and environment gates remain unchanged'
+      'Windows finalization keeps its packaging toolchain outside the staged app and preserves the already verified staged dependency inventory and package placements'
+    )
+    expect(normalizedEnglish).toContain(
+      'desktop assets are assembled before the GitHub Release, both Snap architectures are verified before Store publication, and R2 feeds and containers start only after the GitHub Release succeeds'
+    )
+    expect(normalizedEnglish).toContain(
+      'Keeps Windows `x64` packages explicitly unsigned'
     )
     expect(normalizedChinese).toContain(
-      '保留 job 级的空值净化，用于中和继承的 Electron Builder binary custom-directory 设置'
+      '加强跨平台 Finalize 的可靠性，同时保留每条发布 workflow 内的完整平台集合门禁'
     )
     expect(normalizedChinese).toContain(
-      '在 macOS 和 Windows finalizer 进程启动 Electron Builder 前，立即从该进程环境中真正删除全部 4 个覆盖变量'
+      'macOS Finalize 现在使用隔离的临时文件进行交接，并在 job 结束时删除该文件'
     )
     expect(normalizedChinese).toContain(
-      '通过 stub transport 直接执行 Electron Builder 26.15.7 dependency closure 中真实由 lockfile 固定的 `app-builder-lib` downloader'
+      'Windows Finalize 将打包工具链放在已暂存应用之外，并原样保留已验证的暂存 依赖清单及包路径，避免清单漂移'
     )
     expect(normalizedChinese).toContain(
-      '真正 unset 全部 4 个变量后会恢复两个 canonical 工具 URL'
+      '桌面产物完成组装后才创建 GitHub Release，两种 Snap 架构均通过验证后才进入 Store 发布'
     )
     expect(normalizedChinese).toContain(
-      '完整摘要的 signing input 仍在访问 secret 前验证，build job 仍不获得 secret'
+      'R2 更新数据源与容器 仅在 GitHub Release 成功后启动'
     )
     expect(normalizedChinese).toContain(
-      'fail-closed assemble 以及受保护 tag 和 environment gate 均保持不变'
+      'Windows `x64` 安装包继续明确采用未签名发布'
     )
     for (const source of [english, chinese]) {
-      expect(source).toContain(
-        '`NPM_CONFIG_ELECTRON_BUILDER_BINARIES_CUSTOM_DIR`'
-      )
-      expect(source).toContain(
-        '`npm_config_electron_builder_binaries_custom_dir`'
-      )
-      expect(source).toContain(
-        '`npm_package_config_electron_builder_binaries_custom_dir`'
-      )
-      expect(source).toContain('`ELECTRON_BUILDER_BINARIES_CUSTOM_DIR`')
-      expect(source).toContain('26.15.7')
-      expect(source).toContain('download//nsis-3.0.4.1.7z')
-      expect(source).toContain('releases/download/nsis-3.0.4.1/nsis-3.0.4.1.7z')
-      expect(source).toContain(
-        'releases/download/nsis-resources-3.4.1/nsis-resources-3.4.1.7z'
-      )
-      expect(source).toContain('--publish never')
+      expect(source).toContain('2.0.0-beta.8')
       expect(source).toContain('latest/edge')
       expect(source).toContain('AppImage')
       expect(source).toContain('Flatpak')
-      expect(source).toContain('Authenticode')
+      expect(source).toContain(
+        'Motrix-Native-Host-2.0.0-beta.8-linux-<arch>.tar.gz'
+      )
       expect(source).toContain('SmartScreen')
+      expect(source).toContain('docker.io/motrixapp/motrix-server:2.0.0-beta.8')
+      expect(source).toContain('ghcr.io/agalwood/motrix-server:2.0.0-beta.8')
+      expect(source).not.toMatch(restrictedPublicLanguage)
+      expect(source).not.toMatch(secretLikeIdentifier)
     }
+    for (const source of [
+      read('docs/release-notes/2.0.0-beta.7.md'),
+      read('docs/release-notes/2.0.0-beta.7.zh-CN.md'),
+      beta8Metainfo,
+      beta7Metainfo,
+    ]) {
+      expect(source).not.toMatch(restrictedPublicLanguage)
+      expect(source).not.toMatch(secretLikeIdentifier)
+    }
+    expect(metainfo).toContain(
+      '<release version="2.0.0-beta.8" date="2026-08-16">'
+    )
+    expect(metainfo).toContain(
+      'Cross-platform finalization reliability update with isolated'
+    )
+    expect(metainfo).toContain(
+      'public Snap distribution was published; external distribution'
+    )
   })
 
   it('preserves beta.6 Snap recovery and canceled release history', () => {

--- a/tests/scripts/workflow-release-matrix.test.ts
+++ b/tests/scripts/workflow-release-matrix.test.ts
@@ -1,6 +1,17 @@
+import { spawnSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
-import { readdirSync, readFileSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs'
 import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { Script } from 'node:vm'
 import { describe, expect, it } from 'vitest'
@@ -8,6 +19,8 @@ import { describe, expect, it } from 'vitest'
 import { BUILD_TARGETS } from '../../packages/native-host/build.mjs'
 // @ts-expect-error -- JavaScript release script intentionally has no declarations
 import { RELEASE_TARGETS } from '../../scripts/assemble-release-artifacts.mjs'
+// @ts-expect-error -- JavaScript build hook intentionally has no declarations
+import stagedDependenciesBoundary from '../../scripts/before-build-use-staged-dependencies.mjs'
 // @ts-expect-error -- JavaScript release script intentionally has no declarations
 import { resolveReleaseMetadata } from '../../scripts/release-metadata.mjs'
 
@@ -196,6 +209,10 @@ const signingConfigSource = readFileSync(
 )
 const signingInputSource = readFileSync(
   path.join(ROOT, 'scripts/release-signing-input.mjs'),
+  'utf8'
+)
+const stagedDependenciesHookSource = readFileSync(
+  path.join(ROOT, 'scripts/before-build-use-staged-dependencies.mjs'),
   'utf8'
 )
 const signingToolPackageSource = readFileSync(
@@ -1054,7 +1071,6 @@ describe('release workflow publication contract', () => {
 
     const steps = jobSteps(sign)
     expect(JSON.stringify(steps)).not.toContain('actions/checkout@')
-    expect(JSON.stringify(steps)).not.toContain('pnpm/action-setup@')
     expect(releaseSource).not.toContain('downloadBuilderToolset')
     const verifyIndex = steps.findIndex(
       (step) => step.name === 'Verify signing input before secrets'
@@ -1065,69 +1081,91 @@ describe('release workflow publication contract', () => {
     const firstSecretIndex = steps.findIndex((step) =>
       JSON.stringify(step).includes('secrets.')
     )
+    const installIndex = steps.findIndex(
+      (step) => step.name === 'Install exact signing dependency closure'
+    )
     expect(verifyIndex).toBeGreaterThanOrEqual(0)
+    expect(installIndex).toBeGreaterThan(verifyIndex)
+    expect(electronIndex).toBeGreaterThan(installIndex)
     expect(electronIndex).toBeGreaterThan(verifyIndex)
     expect(firstSecretIndex).toBeGreaterThan(electronIndex)
     expect(JSON.stringify(steps.slice(0, firstSecretIndex))).not.toContain(
       'secrets.'
     )
 
-    const install = steps.find(
-      (step) => step.name === 'Install exact signing dependency closure'
+    const install = steps[installIndex]!
+    const installCommand = stringField(install, 'run')
+    expect(stringField(install, 'id')).toBe('signing-tool-runtime')
+    expect(stringField(install, 'shell')).toBe('node {0}')
+    expect(installCommand).toContain('process.env.SIGNING_TOOL_PARENT')
+    expect(installCommand).toContain('fs.mkdtempSync')
+    expect(installCommand).toContain(
+      "path.join('signing-input', 'signing-tool', name)"
     )
-    const installCommand = stringField(install as LooseRecord, 'run')
-    expect(installCommand).toContain('npm ci')
+    expect(installCommand).not.toContain(
+      "path.join('signing-input', 'package.json')"
+    )
+    expect(installCommand).toContain("'ci'")
     expect(installCommand).toContain('--ignore-scripts')
     expect(installCommand).not.toContain('npm install')
+    expect(installCommand).toContain("process.env.ComSpec || 'cmd.exe'")
+    expect(installCommand).toContain(
+      "['/d', '/s', '/c', 'npm.cmd', ...npmArgs]"
+    )
+    expect(installCommand).toContain(": 'npm'")
+    expect(installCommand).toContain('shell: false')
+    expect(installCommand).not.toContain('shell: true')
+    const installEnvironment = asRecord(
+      install.env,
+      'signing tool runtime environment'
+    )
+    expect(stringField(installEnvironment, 'SIGNING_TOOL_PARENT')).toContain(
+      'runner.temp'
+    )
 
     const builderSteps = steps.filter((step) =>
-      stringField(step, 'run', '').includes('electron-builder')
+      stringField(step, 'name').startsWith('Electron Builder (')
     )
     const macStep = platformBuilderStep(builderSteps, 'darwin')
     const windowsStep = platformBuilderStep(builderSteps, 'win32')
     const macEnv = asRecord(macStep.env, 'macOS builder environment')
     const windowsEnv = asRecord(windowsStep.env, 'Windows builder environment')
-    expect(stringField(macEnv, 'CSC_LINK')).toContain('secrets.MAC_CERTS')
+    expect(stringField(macEnv, 'CSC_LINK')).toContain(
+      'steps.mac-certificate.outputs.path'
+    )
+    expect(stringField(macEnv, 'CSC_LINK')).not.toContain('secrets.')
     expect(stringField(macEnv, 'CSC_KEY_PASSWORD')).toContain(
       'secrets.MAC_CERTS_PASSWORD'
     )
+    expect(stringField(macEnv, 'ELECTRON_BUILDER_CLI')).toContain(
+      'steps.signing-tool-runtime.outputs.cli'
+    )
     expect(JSON.stringify(macEnv)).not.toContain('WIN_CSC')
 
-    expect(stringField(windowsEnv, 'CSC_LINK')).toContain(
-      'secrets.WIN_CSC_LINK'
-    )
-    expect(stringField(windowsEnv, 'CSC_KEY_PASSWORD')).toContain(
-      'secrets.WIN_CSC_KEY_PASSWORD'
-    )
+    expect(windowsEnv).not.toHaveProperty('CSC_LINK')
+    expect(windowsEnv).not.toHaveProperty('CSC_KEY_PASSWORD')
     expect(stringField(windowsEnv, 'CSC_IDENTITY_AUTO_DISCOVERY')).toBe('false')
+    expect(stringField(windowsEnv, 'ELECTRON_BUILDER_CLI')).toContain(
+      'steps.signing-tool-runtime.outputs.cli'
+    )
     expect(JSON.stringify(windowsEnv)).not.toContain('MAC_CERTS')
     expect(stringField(windowsStep, 'if')).toBe("matrix.platform == 'win32'")
-
-    const windowsMode = steps.find(
-      (step) => step.name === 'Resolve Windows signing mode'
+    const windowsCommand = stringField(windowsStep, 'run')
+    const builderIndex = windowsCommand.indexOf(
+      'node $env:ELECTRON_BUILDER_CLI'
     )
-    expect(windowsMode).toBeDefined()
-    expect(stringField(windowsMode as LooseRecord, 'id')).toBe(
-      'windows-signing'
-    )
-    const windowsModeCommand = stringField(windowsMode as LooseRecord, 'run')
-    expect(windowsModeCommand).toContain("'enabled=false'")
-    expect(windowsModeCommand).toContain("'enabled=true'")
-    expect(windowsModeCommand).toContain('-xor')
-    expect(windowsModeCommand).toContain('GITHUB_STEP_SUMMARY')
-    expect(windowsModeCommand).toContain('unsigned')
-    expect(JSON.stringify(windowsMode)).not.toContain(
-      'needs.preflight.outputs.prerelease'
-    )
-    expect(JSON.stringify(windowsMode)).not.toContain(
-      'needs.preflight.outputs.channel'
-    )
-
-    const windowsVerification = steps.find(
-      (step) => step.name === 'Verify Windows signatures'
-    )
-    expect(stringField(windowsVerification as LooseRecord, 'if')).toContain(
-      "steps.windows-signing.outputs.enabled == 'true'"
+    expect(builderIndex).toBeGreaterThanOrEqual(0)
+    for (const variable of ['CSC_LINK', 'CSC_KEY_PASSWORD']) {
+      const unsetIndex = windowsCommand.indexOf(
+        `Remove-Item Env:${path.win32.sep}${variable} -ErrorAction SilentlyContinue`
+      )
+      expect(unsetIndex, variable).toBeGreaterThanOrEqual(0)
+      expect(unsetIndex, variable).toBeLessThan(builderIndex)
+    }
+    expect(JSON.stringify(sign)).not.toContain('WIN_CSC')
+    expect(JSON.stringify(sign)).not.toContain('Get-AuthenticodeSignature')
+    expect(steps.map((step) => step.name)).not.toContain(
+      'Verify Windows signatures'
     )
 
     const packageVerification = steps.find(
@@ -1144,6 +1182,387 @@ describe('release workflow publication contract', () => {
     expect(releaseSource).toContain('APPLE_API_ISSUER')
     expect(releaseSource).not.toContain('secrets.TEAM_ID')
     expect(releaseSource).not.toContain('APPLE_TEAM_ID')
+  })
+
+  it('materializes only bounded P12 bytes and always removes temporary inputs', () => {
+    const sign = asRecord(workflowJobs(releaseWorkflow).sign, 'sign job')
+    const steps = jobSteps(sign)
+    const preparation = steps.find(
+      (step) => step.name === 'Prepare isolated macOS signing certificate'
+    )
+    expect(preparation).toBeDefined()
+    expect(stringField(preparation as LooseRecord, 'shell')).toBe('node {0}')
+    expect(stringField(preparation as LooseRecord, 'if')).toBe(
+      "matrix.platform == 'darwin'"
+    )
+    const preparationEnvironment = asRecord(
+      preparation?.env,
+      'macOS certificate preparation environment'
+    )
+    expect(stringField(preparationEnvironment, 'MAC_CERTS_BASE64')).toContain(
+      'secrets.MAC_CERTS'
+    )
+    expect(stringField(preparationEnvironment, 'CERTIFICATE_PARENT')).toContain(
+      'runner.temp'
+    )
+    const source = stringField(preparation as LooseRecord, 'run')
+    expect(source).toContain('maximumEncodedBytes')
+    expect(source).toContain('maximumCertificateBytes')
+    expect(source).toContain('fs.mkdtempSync')
+    expect(source).toContain('mode: 0o600')
+    expect(source).toContain("flag: 'wx'")
+    expect(source).not.toContain('console.')
+    expect(source).not.toContain('process.stdout')
+
+    const temporaryRoot = mkdtempSync(
+      path.join(tmpdir(), 'motrix-mac-certificate-contract-')
+    )
+    let run = 0
+    const execute = (encoded: string) => {
+      run += 1
+      const output = path.join(temporaryRoot, `github-output-${run}`)
+      writeFileSync(output, '')
+      const result = spawnSync(process.execPath, ['-e', source], {
+        cwd: ROOT,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          CERTIFICATE_PARENT: temporaryRoot,
+          GITHUB_OUTPUT: output,
+          MAC_CERTS_BASE64: encoded,
+        },
+      })
+      const values = Object.fromEntries(
+        readFileSync(output, 'utf8')
+          .trim()
+          .split('\n')
+          .filter(Boolean)
+          .map((line) => {
+            const separator = line.indexOf('=')
+            return [line.slice(0, separator), line.slice(separator + 1)]
+          })
+      )
+      return { result, values }
+    }
+
+    try {
+      const certificate = Buffer.alloc(1532)
+      certificate.set([0x30, 0x82, 0x05, 0xf8, 0x02, 0x01, 0x03, 0x30])
+      const padded = certificate.toString('base64')
+      const unpadded = padded.replace(/=+$/u, '')
+      expect(unpadded).toHaveLength(2043)
+
+      for (const encoded of [padded, unpadded]) {
+        const { result, values } = execute(encoded)
+        expect(result.status, result.stderr).toBe(0)
+        const certificatePath = values.path
+        expect(certificatePath).toBeDefined()
+        expect(readFileSync(certificatePath!)).toEqual(certificate)
+        expect(statSync(certificatePath!).mode & 0o777).toBe(0o600)
+        expect(path.dirname(certificatePath!)).toBe(values.directory)
+      }
+
+      for (const encoded of [
+        '',
+        'A',
+        'AB',
+        'AA-_',
+        ` ${padded}`,
+        `${padded}\n`,
+        'A'.repeat(128 * 1024 + 4),
+        Buffer.from([0x30, 0x00]).toString('base64'),
+      ]) {
+        const { result } = execute(encoded)
+        expect(result.status).not.toBe(0)
+        if (encoded) {
+          expect(`${result.stdout}${result.stderr}`).not.toContain(encoded)
+        }
+      }
+    } finally {
+      rmSync(temporaryRoot, { recursive: true, force: true })
+    }
+
+    const cleanup = steps.find(
+      (step) => step.name === 'Remove finalization temporary inputs'
+    )
+    expect(cleanup).toBeDefined()
+    expect(stringField(cleanup as LooseRecord, 'if')).toBe('always()')
+    expect(stringField(cleanup as LooseRecord, 'shell')).toBe('node {0}')
+    const cleanupEnvironment = asRecord(
+      cleanup?.env,
+      'temporary input cleanup environment'
+    )
+    expect(stringField(cleanupEnvironment, 'TEMPORARY_ROOT')).toContain(
+      'runner.temp'
+    )
+    expect(stringField(cleanupEnvironment, 'MAC_CERTIFICATE_PATH')).toContain(
+      'steps.mac-certificate.outputs.path'
+    )
+    expect(
+      stringField(cleanupEnvironment, 'MAC_CERTIFICATE_DIRECTORY')
+    ).toContain('steps.mac-certificate.outputs.directory')
+    expect(stringField(cleanupEnvironment, 'APPLE_API_KEY_PATH')).toContain(
+      'steps.apple-api-key.outputs.path'
+    )
+    expect(stringField(cleanupEnvironment, 'SIGNING_TOOL_ROOT')).toContain(
+      'steps.signing-tool-runtime.outputs.root'
+    )
+    expect(JSON.stringify(cleanup)).not.toContain('secrets.')
+    const cleanupSource = stringField(cleanup as LooseRecord, 'run')
+    expect(cleanupSource).toContain('path.relative(root, candidate)')
+    expect(cleanupSource).toContain('fs.rmSync')
+
+    const cleanupRoot = mkdtempSync(
+      path.join(tmpdir(), 'motrix-finalization-cleanup-contract-')
+    )
+    try {
+      const apiKey = path.join(cleanupRoot, 'AuthKey.p8')
+      const certificateDirectory = path.join(cleanupRoot, 'certificate')
+      const certificate = path.join(certificateDirectory, 'identity.p12')
+      const signingTool = path.join(cleanupRoot, 'signing-tool')
+      mkdirSync(certificateDirectory)
+      mkdirSync(signingTool)
+      writeFileSync(apiKey, 'api key')
+      writeFileSync(certificate, 'certificate')
+      writeFileSync(path.join(signingTool, 'package.json'), '{}')
+      const result = spawnSync(process.execPath, ['-e', cleanupSource], {
+        cwd: ROOT,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          APPLE_API_KEY_PATH: apiKey,
+          MAC_CERTIFICATE_DIRECTORY: certificateDirectory,
+          MAC_CERTIFICATE_PATH: certificate,
+          SIGNING_TOOL_ROOT: signingTool,
+          TEMPORARY_ROOT: cleanupRoot,
+        },
+      })
+      expect(result.status, result.stderr).toBe(0)
+      for (const candidate of [
+        apiKey,
+        certificate,
+        certificateDirectory,
+        signingTool,
+      ]) {
+        expect(existsSync(candidate), candidate).toBe(false)
+      }
+    } finally {
+      rmSync(cleanupRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('uses the locked 26.15.7 hook to preserve staged dependency placements', async () => {
+    const packageMetadata = asRecord(
+      require('app-builder-lib/package.json') as unknown,
+      'app-builder-lib package metadata'
+    )
+    expect(stringField(packageMetadata, 'version')).toBe('26.15.7')
+    const signingConfig = asRecord(
+      JSON.parse(signingConfigSource) as unknown,
+      'restricted signing config'
+    )
+    expect(signingConfig.npmRebuild).toBe(true)
+    expect(stringField(signingConfig, 'beforeBuild')).toBe(
+      './scripts/before-build-use-staged-dependencies.mjs'
+    )
+
+    const fixture = mkdtempSync(
+      path.join(tmpdir(), 'motrix-finalizer-staged-dependencies-')
+    )
+    const signingInput = path.join(fixture, 'signing-input')
+    const appDirectory = path.join(signingInput, 'dist', 'electron-app')
+    const scriptsDirectory = path.join(signingInput, 'scripts')
+    mkdirSync(appDirectory, { recursive: true })
+    mkdirSync(scriptsDirectory, { recursive: true })
+    writeFileSync(
+      path.join(signingInput, 'electron-builder.signing.json'),
+      signingConfigSource
+    )
+    writeFileSync(
+      path.join(scriptsDirectory, 'before-build-use-staged-dependencies.mjs'),
+      stagedDependenciesHookSource
+    )
+    writeFileSync(
+      path.join(appDirectory, 'package.json'),
+      JSON.stringify({ name: 'motrix-stage', private: true })
+    )
+
+    try {
+      await expect(
+        stagedDependenciesBoundary({ appDir: appDirectory })
+      ).resolves.toBe(false)
+      await expect(
+        stagedDependenciesBoundary({
+          appDir: path.join(fixture, 'untrusted-app'),
+        })
+      ).rejects.toThrow(/expected appDir to be dist\/electron-app/u)
+
+      const packagerModule = require.resolve('app-builder-lib/out/packager.js')
+      const platformPackagerModule = require.resolve(
+        'app-builder-lib/out/platformPackager.js'
+      )
+      const yarnModule = require.resolve('app-builder-lib/out/util/yarn.js')
+      const childSource = `
+        const fs = require('node:fs')
+        const path = require('node:path')
+        const yarn = require(process.env.YARN_MODULE)
+        let installCalls = 0
+        yarn.installOrRebuild = async () => { installCalls += 1 }
+        const { Packager } = require(process.env.PACKAGER_MODULE)
+        const { Arch } = require(process.env.BUILDER_UTIL_MODULE)
+        const config = JSON.parse(
+          fs.readFileSync('electron-builder.signing.json', 'utf8')
+        )
+        const context = {
+          options: {},
+          framework: {
+            isNpmRebuildRequired: true,
+            version: config.electronVersion,
+          },
+          config,
+          appInfo: { type: 'module' },
+          appDir: path.resolve('dist/electron-app'),
+          getWorkspaceRoot: async () => process.cwd(),
+          _nodeModulesHandledExternally: false,
+          runtimeEnvironmentVariables: {},
+        }
+        Packager.prototype.installAppDependencies.call(
+          context,
+          { nodeName: 'win32' },
+          Arch.x64
+        ).then(() => {
+          process.stdout.write(JSON.stringify({
+            handledExternally: context._nodeModulesHandledExternally,
+            installCalls,
+          }))
+        }).catch((error) => {
+          console.error(error instanceof Error ? error.message : String(error))
+          process.exitCode = 1
+        })
+      `
+      const execution = spawnSync(process.execPath, ['-e', childSource], {
+        cwd: signingInput,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          BUILDER_UTIL_MODULE: require.resolve('builder-util'),
+          PACKAGER_MODULE: packagerModule,
+          YARN_MODULE: yarnModule,
+        },
+      })
+      expect(execution.status, execution.stderr).toBe(0)
+      expect(JSON.parse(execution.stdout)).toEqual({
+        handledExternally: true,
+        installCalls: 0,
+      })
+
+      const packagerSource = readFileSync(packagerModule, 'utf8')
+      expect(packagerSource).toContain(
+        'this._nodeModulesHandledExternally = !performDependenciesInstallOrRebuild'
+      )
+      const platformPackagerSource = readFileSync(
+        platformPackagerModule,
+        'utf8'
+      )
+      expect(platformPackagerSource).toMatch(
+        /!this\.info\.areNodeModulesHandledExternally[\s\S]{0,400}computeNodeModuleFileSets/u
+      )
+
+      const nestedPlacements = [
+        'ajv/node_modules/fast-uri/package.json',
+        'electron-updater/node_modules/js-yaml/package.json',
+        'electron-updater/node_modules/semver/package.json',
+      ]
+      for (const relativePath of nestedPlacements) {
+        const destination = path.join(
+          appDirectory,
+          'node_modules',
+          relativePath
+        )
+        mkdirSync(path.dirname(destination), { recursive: true })
+        writeFileSync(destination, JSON.stringify({ name: relativePath }))
+      }
+
+      const initialConfig = asRecord(
+        JSON.parse(
+          readFileSync(path.join(ROOT, 'electron-builder.json'), 'utf8')
+        ) as unknown,
+        'initial Electron Builder config'
+      )
+      expect(signingConfig.asar).toBe(initialConfig.asar)
+      expect(signingConfig.asarUnpack).toEqual(initialConfig.asarUnpack)
+      expect(signingConfig.files).toEqual(initialConfig.files)
+      expect(
+        asRecord(signingConfig.directories, 'signing directories').app
+      ).toBe(asRecord(initialConfig.directories, 'initial directories').app)
+      const findNodeModulesMapping = (config: LooseRecord) =>
+        (config.files as unknown[]).find((value) => {
+          return (
+            typeof value === 'object' &&
+            value !== null &&
+            !Array.isArray(value) &&
+            (value as LooseRecord).from === 'node_modules'
+          )
+        })
+      const signingMapping = asRecord(
+        findNodeModulesMapping(signingConfig),
+        'signing node_modules mapping'
+      )
+      expect(signingMapping).toEqual(findNodeModulesMapping(initialConfig))
+
+      const fileMatcherModule = asRecord(
+        require('app-builder-lib/out/fileMatcher.js') as unknown,
+        'app-builder-lib file matcher module'
+      )
+      const appFileCopierModule = asRecord(
+        require('app-builder-lib/out/util/appFileCopier.js') as unknown,
+        'app-builder-lib app file copier module'
+      )
+      const FileMatcher = fileMatcherModule.FileMatcher as new (
+        from: string,
+        to: string,
+        macroExpander: (value: string) => string,
+        patterns: string[]
+      ) => unknown
+      const computeFileSets = appFileCopierModule.computeFileSets as (
+        matchers: unknown[],
+        transformer: null,
+        platformPackager: {
+          info: { areNodeModulesHandledExternally: boolean }
+        },
+        isElectronCompile: boolean
+      ) => Promise<Array<{ destination: string; files: string[]; src: string }>>
+      const getDestinationPath = appFileCopierModule.getDestinationPath as (
+        file: string,
+        fileSet: { destination: string; src: string }
+      ) => string
+      const stagedNodeModules = path.join(appDirectory, 'node_modules')
+      const outputNodeModules = path.join(fixture, 'output', 'node_modules')
+      const matcher = new FileMatcher(
+        stagedNodeModules,
+        outputNodeModules,
+        (value) => value,
+        signingMapping.filter as string[]
+      )
+      const fileSets = await computeFileSets(
+        [matcher],
+        null,
+        { info: { areNodeModulesHandledExternally: true } },
+        false
+      )
+      expect(fileSets).toHaveLength(1)
+      const selectedPlacements = fileSets[0]!.files
+        .map((file) =>
+          path
+            .relative(outputNodeModules, getDestinationPath(file, fileSets[0]!))
+            .split(path.sep)
+            .join('/')
+        )
+        .sort()
+      expect(selectedPlacements).toEqual(nestedPlacements)
+    } finally {
+      rmSync(fixture, { recursive: true, force: true })
+    }
   })
 
   it('passes the signing input commit through a shell-neutral expression', () => {
@@ -1178,11 +1597,13 @@ describe('release workflow publication contract', () => {
       {
         name: 'Electron Builder (macOS signing boundary)',
         shell: 'bash',
+        builderCommand: 'node "$ELECTRON_BUILDER_CLI"',
         unsetCommand: (variable: string) => `unset ${variable}`,
       },
       {
         name: 'Electron Builder (Windows finalization boundary)',
         shell: 'pwsh',
+        builderCommand: 'node $env:ELECTRON_BUILDER_CLI',
         unsetCommand: (variable: string) =>
           `Remove-Item Env:${path.win32.sep}${variable} -ErrorAction SilentlyContinue`,
       },
@@ -1193,9 +1614,7 @@ describe('release workflow publication contract', () => {
       expect(step).toBeDefined()
       expect(stringField(step as LooseRecord, 'shell')).toBe(boundary.shell)
       const command = stringField(step as LooseRecord, 'run')
-      const builderIndex = command.indexOf(
-        'node node_modules/electron-builder/out/cli/cli.js'
-      )
+      const builderIndex = command.indexOf(boundary.builderCommand)
       expect(builderIndex).toBeGreaterThanOrEqual(0)
       for (const variable of ELECTRON_BUILDER_CUSTOM_DIR_ENVIRONMENT_VARIABLES) {
         const unsetIndex = command.indexOf(boundary.unsetCommand(variable))
@@ -1371,21 +1790,29 @@ describe('release workflow publication contract', () => {
     expect(condition).toContain("needs.sign.result == 'skipped'")
   })
 
-  it('uses a bounded tar and a hook-free exact signing tool closure', () => {
+  it('uses a bounded tar and one exact staged-dependency hook', () => {
     const config = asRecord(
       JSON.parse(signingConfigSource) as unknown,
       'restricted signing config'
     )
     expect(config.extends).toBeNull()
-    expect(config.npmRebuild).toBe(false)
+    expect(config.npmRebuild).toBe(true)
+    expect(stringField(config, 'beforeBuild')).toBe(
+      './scripts/before-build-use-staged-dependencies.mjs'
+    )
+    expect(
+      stringField(asRecord(config.directories, 'signing directories'), 'app')
+    ).toBe('dist/electron-app')
     expect(stringField(config, 'electronDist')).toBe('trusted/electron.zip')
     expect(stringField(config, 'electronVersion')).toBe('43.4.0')
+    expect(signingInputSource).toContain(
+      "config.directories?.app !== 'dist/electron-app'"
+    )
     for (const hook of [
       'afterAllArtifactBuild',
       'afterExtract',
       'afterPack',
       'afterSign',
-      'beforeBuild',
       'beforePack',
       'onNodeModuleFile',
     ]) {


### PR DESCRIPTION
## Summary

- prepare version 2.0.0-beta.8, paired release notes, README links, and AppStream metadata
- keep Windows finalization explicitly unsigned while preserving the verified staged dependency inventory and nested package placements
- isolate finalization tooling from the staged app and safely clean temporary macOS signing inputs
- retain per-workflow complete-set publication gates and backfill beta.7 as unpublished without sensitive incident details

## Validation

- tests/scripts: 40 files, 504 tests passed
- focused release, signing-input, and version contracts: 91 tests passed
- actionlint, Biome, TypeScript, file-name, boundary, AppStream XML, third-party notice, and diff checks passed