### PR TITLE
fix(release): prepare beta.9 recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -821,6 +821,7 @@ jobs:
           const fs = require('node:fs')
           const path = require('node:path')
           const { spawnSync } = require('node:child_process')
+          const { pathToFileURL } = require('node:url')
           const parent = path.resolve(process.env.SIGNING_TOOL_PARENT)
           const target = process.env.SIGNING_TOOL_TARGET
           if (!target || !/^[a-z0-9-]+$/u.test(target)) {
@@ -885,9 +886,42 @@ jobs:
           if (!cliInfo.isFile()) {
             throw new Error('electron-builder CLI is not a file')
           }
+          const verifierDirectory = path.join(root, 'scripts')
+          fs.mkdirSync(verifierDirectory, { mode: 0o700 })
+          fs.chmodSync(verifierDirectory, 0o700)
+          for (const name of [
+            'electron-package-size-budgets.json',
+            'electron-package-utils.mjs',
+            'native-binary-target.mjs',
+            'verify-electron-package.mjs',
+          ]) {
+            const source = path.join('signing-input', 'scripts', name)
+            const sourceInfo = fs.lstatSync(source)
+            if (!sourceInfo.isFile()) {
+              throw new Error(`package verifier input is not a file: ${name}`)
+            }
+            const destination = path.join(verifierDirectory, name)
+            fs.copyFileSync(source, destination, fs.constants.COPYFILE_EXCL)
+            fs.chmodSync(destination, 0o600)
+          }
+          const verifier = fs.realpathSync(
+            path.join(verifierDirectory, 'verify-electron-package.mjs')
+          )
+          const verifierImport = spawnSync(
+            process.execPath,
+            [
+              '--input-type=module',
+              '--eval',
+              `await import(${JSON.stringify(pathToFileURL(verifier).href)})`,
+            ],
+            { stdio: 'inherit' }
+          )
+          if (verifierImport.error || verifierImport.status !== 0) {
+            throw new Error('package verifier dependency import failed')
+          }
           fs.appendFileSync(
             process.env.GITHUB_OUTPUT,
-            `cli=${cli}\n`,
+            `cli=${cli}\nverifier=${verifier}\n`,
             'utf8'
           )
 
@@ -1088,14 +1122,13 @@ jobs:
             ${{ matrix.electron_builder_args }} `
             --publish never
 
-      - name: Remove finalization temporary inputs
+      - name: Remove finalization credentials
         if: always()
         shell: node {0}
         env:
           APPLE_API_KEY_PATH: ${{ steps.apple-api-key.outputs.path }}
           MAC_CERTIFICATE_DIRECTORY: ${{ steps.mac-certificate.outputs.directory }}
           MAC_CERTIFICATE_PATH: ${{ steps.mac-certificate.outputs.path }}
-          SIGNING_TOOL_ROOT: ${{ steps.signing-tool-runtime.outputs.root }}
           TEMPORARY_ROOT: ${{ runner.temp }}
         run: |
           const fs = require('node:fs')
@@ -1122,10 +1155,7 @@ jobs:
             const candidate = insideRoot(value)
             if (candidate) fs.rmSync(candidate, { force: true })
           }
-          for (const value of [
-            process.env.MAC_CERTIFICATE_DIRECTORY,
-            process.env.SIGNING_TOOL_ROOT,
-          ]) {
+          for (const value of [process.env.MAC_CERTIFICATE_DIRECTORY]) {
             const candidate = insideRoot(value)
             if (candidate) {
               fs.rmSync(candidate, { recursive: true, force: true })
@@ -1146,11 +1176,35 @@ jobs:
       - name: Verify finalized Electron package
         working-directory: signing-input
         run: >-
-          node scripts/verify-electron-package.mjs
+          node "${{ steps.signing-tool-runtime.outputs.verifier }}"
           --app-dir "${{ matrix.app_path }}"
           --platform ${{ matrix.platform }}
           --arch ${{ matrix.arch }}
           --report "release/size-reports/${{ matrix.target }}.json"
+
+      - name: Remove isolated signing runtime
+        if: always()
+        shell: node {0}
+        env:
+          SIGNING_TOOL_ROOT: ${{ steps.signing-tool-runtime.outputs.root }}
+          TEMPORARY_ROOT: ${{ runner.temp }}
+        run: |
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const root = path.resolve(process.env.TEMPORARY_ROOT)
+          const value = process.env.SIGNING_TOOL_ROOT
+          if (!value) process.exit(0)
+          const candidate = path.resolve(value)
+          const relative = path.relative(root, candidate)
+          if (
+            !relative ||
+            relative === '..' ||
+            relative.startsWith(`..${path.sep}`) ||
+            path.isAbsolute(relative)
+          ) {
+            throw new Error('refusing to clean a path outside runner temp')
+          }
+          fs.rmSync(candidate, { recursive: true, force: true })
 
       - name: Upload finalized release input
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ The same core powers two ways to run Motrix:
 
 ## 🧪 Beta testing
 
-Motrix Turbo v2 is currently in beta. Download
-[v2.0.0-beta.8 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.8)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.8.md)
-before installing it.
+Motrix Turbo v2 is currently in beta. After its remaining release gates pass,
+download [v2.0.0-beta.9 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.9)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.9.md) before
+installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
 Motrix v1 data has not yet been validated, so do not use your only copy of v1
@@ -114,15 +114,17 @@ Plugins run inside a QuickJS sandbox. Each plugin declares the host capabilities
 
 Download Motrix from [motrix.app](https://motrix.app) and choose the package for your operating system. Most Mac users should choose the Apple Silicon build; Intel builds are available for older Macs with Intel processors.
 
-The current beta desktop packages are distributed through the GitHub
-prerelease linked above, with Snap available from its edge channel. Choose the
-package that matches your operating system and architecture:
+After the remaining release gates pass, the current beta desktop packages
+will be distributed through the GitHub prerelease linked above. Snap will
+become available from its edge channel only after the required Store review
+and protected publication gates complete. Choose the package that matches your
+operating system and architecture:
 
 | Platform | Architectures | Packages / channel | Recommendation |
 |----------|---------------|--------------------|----------------|
 | macOS 12+ | `arm64` (Apple Silicon), `x64` (Intel) | `.dmg` / `.zip` | Use the `.dmg` matching your Mac; choose `x64` only for an Intel-based Mac |
 | Windows | `x64` | `.exe` (NSIS installer) / `.zip` | Use the `.exe` installer for a normal installation or `.zip` for a manually extracted copy |
-| Linux | `x64`, `arm64` | `.deb` / `.rpm`; Snap `latest/edge` | Use `.deb` on Debian or Ubuntu, `.rpm` on Fedora or openSUSE, or the edge Snap for beta testing |
+| Linux | `x64`, `arm64` | `.deb` / `.rpm`; Snap `latest/edge` after Store approval | Use `.deb` on Debian or Ubuntu, `.rpm` on Fedora or openSUSE, or the edge Snap after publication completes |
 
 This beta does not publish an AppImage. Flatpak is validated separately and is
 not published by the release tag. Windows `arm64` and all 32-bit packages are
@@ -147,7 +149,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.8'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.9'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -21,9 +21,9 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 
 ## 🧪 Beta 测试
 
-Motrix Turbo v2 目前仍处于 beta 阶段。安装前请从 GitHub Releases
-下载 [v2.0.0-beta.8](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.8)，
-并阅读[完整发布说明](./docs/release-notes/2.0.0-beta.8.zh-CN.md)。
+Motrix Turbo v2 目前仍处于 beta 阶段。剩余发布门禁通过后，请从 GitHub Releases
+下载 [v2.0.0-beta.9](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.9)，
+并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.9.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -112,14 +112,15 @@ pnpm create motrix-plugin my-plugin
 
 访问 Motrix 官网 [motrix.app](https://motrix.app)，选择对应操作系统的安装包。macOS 用户通常下载 Apple Silicon 版本即可；如果使用较早的 Intel 芯片 Mac，请选择 Intel 版本。
 
-当前 beta 桌面安装包通过上方链接的 GitHub 预发布版提供，Snap 则通过
-edge 通道提供。请根据操作系统和架构选择安装包：
+剩余发布门禁通过后，当前 beta 桌面安装包将通过上方链接的 GitHub 预发布版
+提供。Snap 只有在必要的 Store 审核与受保护发布门禁完成后，才会通过 edge
+通道提供。请根据操作系统和架构选择安装包：
 
 | 平台 | 架构 | 安装包 / 通道 | 选择建议 |
 |------|------|---------------|----------|
 | macOS 12+ | `arm64`（Apple Silicon）、`x64`（Intel） | `.dmg` / `.zip` | 选择与 Mac 架构匹配的 `.dmg`；仅 Intel Mac 使用 `x64` |
 | Windows | `x64` | `.exe`（NSIS 安装包）/ `.zip` | 常规安装使用 `.exe`；`.zip` 可解压后手动运行 |
-| Linux | `x64`、`arm64` | `.deb` / `.rpm`；Snap `latest/edge` | Debian 或 Ubuntu 使用 `.deb`，Fedora 或 openSUSE 使用 `.rpm`；beta 测试也可使用 edge Snap |
+| Linux | `x64`、`arm64` | `.deb` / `.rpm`；Store 批准后的 Snap `latest/edge` | Debian 或 Ubuntu 使用 `.deb`，Fedora 或 openSUSE 使用 `.rpm`；发布完成后也可使用 edge Snap |
 
 本 beta 不发布 AppImage。Flatpak 会单独验证，不会随该版本 tag 发布。
 同时不提供 Windows `arm64` 和任何 32 位安装包。Windows `x64` 安装包未签名，
@@ -142,7 +143,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.8'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.9'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/build/snap/snapcraft.yaml.in
+++ b/build/snap/snapcraft.yaml.in
@@ -6,8 +6,8 @@ description: |
   BitTorrent, Magnet, and Metalink downloads.
 license: MIT
 website: https://motrix.app
-source-code: https://gitlab.com/agalwood/motrix-turbo
-issues: https://gitlab.com/agalwood/motrix-turbo/-/issues
+source-code: https://github.com/agalwood/Motrix
+issues: https://github.com/agalwood/Motrix/issues
 version: '@MOTRIX_VERSION@'
 base: core24
 grade: stable

--- a/docs/release-notes/2.0.0-beta.8.md
+++ b/docs/release-notes/2.0.0-beta.8.md
@@ -1,105 +1,43 @@
 # Motrix 2.0.0-beta.8
 
-English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.8.zh-CN.md)
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.9/docs/release-notes/2.0.0-beta.8.zh-CN.md)
 
-Motrix 2.0.0-beta.8 is the next Motrix Turbo beta intended for public
-distribution. It begins public validation of the rebuilt v2 desktop app and
-headless server, shared download core, MDXP integrations, and sandboxed plugin
-system.
+> Motrix 2.0.0-beta.8 was not published. This historical record was
+> backfilled for beta.9.
 
-Motrix 2.0.0-beta.7 was not published. Its macOS and Windows Finalize gates did
-not pass, and both release workflows were canceled before any external
-distribution. The
-[beta.7 historical record](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.7.md)
-is preserved with this release.
+## Desktop release outcome
 
-## Release reliability updates
+- All five desktop build jobs completed successfully.
+- The explicitly unsigned Windows Finalize job completed Electron Builder and
+  produced its final package candidates. The final verifier then stopped
+  before package scanning because its isolated tool dependency set could not
+  resolve `@electron/asar`.
+- Both macOS Finalize jobs were canceled without running while awaiting
+  approval.
+- Desktop assembly, the GitHub Release, R2 update-feed publication, and Docker
+  Hub/GHCR container publication were canceled without running.
 
-- Strengthens cross-platform finalization reliability while retaining
-  complete-platform-set gates within each release workflow.
-- macOS finalization now uses an isolated temporary handoff that is removed
-  when the job ends.
-- Windows finalization keeps its packaging toolchain outside the staged app and
-  preserves the already verified staged dependency inventory and package
-  placements, preventing inventory drift.
-- Adds regression checks for temporary-file cleanup, packaging-tool isolation,
-  and staged dependency inventory and placement consistency throughout
-  finalization.
-- Keeps complete-set checks explicit within each publishing path: desktop
-  assets are assembled before the GitHub Release, both Snap architectures are
-  verified before Store publication, and R2 feeds and containers start only
-  after the GitHub Release succeeds.
-- Keeps Windows `x64` packages explicitly unsigned while retaining package
-  verification before release.
-- Retains complete `amd64` and `arm64` Snap staging and public `latest/edge`
-  verification before the beta is offered through the Snap Store.
+## Snap release outcome
 
-## Highlights
+- The source gate and strict `amd64` and `arm64` Snap builds completed. Both
+  artifacts passed package verification and were uploaded to the workflow's
+  internal artifact set.
+- The publication job downloaded and verified the complete two-architecture
+  set before contacting the Store.
+- The `amd64` upload reached Store processing, which required human review of
+  the `personal-files` `allow-installation` declaration. The Store did not
+  return an exact revision, and the `arm64` Store upload did not start.
+- Exact-revision release to `latest/edge`, public channel verification, and
+  preservation of the revision record did not run. Public `latest/edge`
+  remained unchanged at amd64 Motrix 1.8.19 with no arm64 entry.
 
-- A ground-up desktop rebuild with Electron 43, React 19, and TypeScript 7,
-  including a customizable Dashboard, dark mode, a cross-platform application
-  menu, and clearer task-inspector feedback.
-- One host-neutral download core for both the desktop app and the new Node/Web
-  Server, with SQLite session recovery, tracker management, UPnP/NAT-PMP, and
-  HTTP, FTP, BitTorrent, and magnet support.
-- MDXP-based integration for the official CLI and browser handoff, including
-  local discovery and device-code pairing for remote Server instances.
-- A QuickJS plugin sandbox with capability consent, bundled builtin plugins,
-  and an in-app plugin marketplace.
-- Persistent, multi-architecture Server containers for NAS and home-server
-  deployments, published to both Docker Hub and GHCR.
-- A coordinated release pipeline with explicit unsigned Windows finalization,
-  package verification, third-party notices, and an SPDX SBOM.
+## Distribution outcome
 
-## Before testing
+No GitHub Release, R2 update feed, Docker Hub or GHCR container image, or
+public Snap distribution was created. External distribution remained zero.
 
-This is prerelease software. Back up your existing Motrix application data and
-downloads before installing it. Migration from Motrix v1 data has not yet been
-validated, so do not use your only copy of v1 data with this beta.
-
-When practical, test v2 in parallel using a separate OS account, machine, or
-Docker data directory. Please do not rely on this beta for your only copy of
-important downloads.
-
-## What to test
-
-- HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
-  session recovery
-- Desktop integrations, browser and CLI handoff through MDXP, and sandboxed
-  plugins
-- Headless Server deployment, persistent storage, and remote pairing
-
-## Available downloads
-
-| Distribution | Architectures | Published output |
-|--------------|---------------|------------------|
-| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
-| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
-| Linux | `x64`, `arm64` | DEB and RPM |
-| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.8-linux-<arch>.tar.gz` |
-| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.8` tag in both registries |
-| Snap Store | `amd64`, `arm64` | `latest/edge` |
-
-Container images are available as
-`docker.io/motrixapp/motrix-server:2.0.0-beta.8` and
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.8`. See the
-[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/docker-server.md)
-for storage, networking, and upgrade guidance.
-
-## Known distribution limits
-
-- AppImage is not published for this beta.
-- Flatpak is validated separately and is not published by the release tag;
-  the GitHub Release includes its Native Host companion archives.
-- Windows `arm64` and all 32-bit packages are not available.
-- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
-  Download them only from this official GitHub release.
-- Beta container tags are immutable and do not update `latest`, `stable`, or
-  other stable floating tags.
-
-## Feedback
-
-Please report reproducible problems through
-[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
-operating system, architecture, package type, and the steps needed to reproduce
-the issue.
+Motrix 2.0.0-beta.9 supersedes this unpublished attempt. See the
+[beta.9 release notes](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.9/docs/release-notes/2.0.0-beta.9.md)
+for the next beta. The
+[beta.7 notes](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.7.md)
+retain the preceding historical record.

--- a/docs/release-notes/2.0.0-beta.8.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.8.zh-CN.md
@@ -1,85 +1,37 @@
 # Motrix 2.0.0-beta.8
 
-[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.8.md) | 简体中文
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.9/docs/release-notes/2.0.0-beta.8.md) | 简体中文
 
-Motrix 2.0.0-beta.8 是下一次计划公开发布的 Motrix Turbo beta。该版本开始公开
-验证重新开发的 v2 桌面应用与 Headless Server、共用下载内核、MDXP 集成和沙箱化
-插件系统。
+> Motrix 2.0.0-beta.8 未发布。本历史记录在 beta.9 中回填。
 
-Motrix 2.0.0-beta.7 未发布。其 macOS 与 Windows Finalize 门禁均未通过，两条
-发布流程也在任何外部分发前取消。本次发布保留了
-[beta.7 历史记录](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.7.zh-CN.md)。
+## 桌面发布结果
 
-## 发布可靠性更新
+- 5 个桌面构建 job 均成功完成。
+- 明确采用未签名模式的 Windows Finalize job 成功完成 Electron Builder，并生成
+  最终安装包候选。随后最终 verifier 在扫描安装包前停止，因为其隔离工具依赖
+  集合无法解析 `@electron/asar`。
+- 两个 macOS Finalize job 在等待审批时被取消，均未执行。
+- 桌面产物组装、GitHub Release、R2 更新数据源发布以及 Docker Hub/GHCR
+  容器发布均被取消且未执行。
 
-- 加强跨平台 Finalize 的可靠性，同时保留每条发布 workflow 内的完整平台集合门禁。
-- macOS Finalize 现在使用隔离的临时文件进行交接，并在 job 结束时删除该文件。
-- Windows Finalize 将打包工具链放在已暂存应用之外，并原样保留已验证的暂存
-  依赖清单及包路径，避免清单漂移。
-- 新增回归检查，覆盖临时文件清理、打包工具隔离，以及 Finalize 全程已暂存
-  依赖清单与路径的一致性。
-- 继续明确每条发布路径内的完整集合门禁：桌面产物完成组装后才创建 GitHub
-  Release，两种 Snap 架构均通过验证后才进入 Store 发布；R2 更新数据源与容器
-  仅在 GitHub Release 成功后启动。
-- Windows `x64` 安装包继续明确采用未签名发布，同时保留发布前的安装包验证。
-- 继续完整暂存 `amd64` 与 `arm64` Snap，并在通过公开 `latest/edge` 验证后，
-  再通过 Snap Store 提供该 beta。
+## Snap 发布结果
 
-## 主要变化
+- source gate 以及 `amd64`、`arm64` 两个 strict Snap 构建均完成。两个产物都
+  通过了安装包验证，并上传到 workflow 的内部 artifact 集合。
+- 发布 job 在连接 Store 前下载并验证了完整的双架构集合。
+- `amd64` 上传进入 Store processing，随后 Store 要求人工审核 `personal-files`
+  的 `allow-installation` 声明。Store 没有返回精确 revision，`arm64` Store
+  upload 也未开始。
+- 将精确 revision 发布到 `latest/edge`、公开 channel 验证以及 revision record
+  保存均未执行。公开 `latest/edge` 保持不变，仍为 amd64 Motrix 1.8.19，且没有
+  arm64 条目。
 
-- 使用 Electron 43、React 19 和 TypeScript 7 从头重建桌面应用，提供可自定义
-  Dashboard、深色模式、跨平台应用菜单，以及更清晰的任务检查器反馈。
-- 桌面应用和全新的 Node/Web Server 共用与宿主无关的下载内核，支持 SQLite
-  session 恢复、Tracker 管理、UPnP/NAT-PMP，以及 HTTP、FTP、BitTorrent 和
-  磁力链接下载。
-- 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地发现及远程 Server 的
-  device-code 配对。
-- 提供带能力授权的 QuickJS 插件沙箱、内置插件和应用内插件市场。
-- 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器，并同时发布到
-  Docker Hub 与 GHCR。
-- 使用协调一致的发布流水线，明确支持未签名的 Windows 最终处理，并加入
-  安装包验证、第三方声明和 SPDX SBOM。
+## 分发结果
 
-## 测试前须知
+该次尝试没有创建 GitHub Release、R2 更新数据源、Docker Hub 或 GHCR 容器镜像，
+也没有产生公开 Snap 分发，外部分发为零。
 
-这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1
-数据的迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
-
-条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录与现有环境
-并行测试 v2。请勿让本 beta 成为重要下载文件的唯一存储位置。
-
-## 建议测试项
-
-- HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
-- 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
-- Headless Server 部署、数据持久化和远程配对
-
-## 可用下载
-
-| 发布方式 | 架构 | 发布产物 |
-|----------|------|----------|
-| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
-| Windows | `x64` | 未签名的 NSIS 安装包（`.exe`）和 ZIP |
-| Linux | `x64`、`arm64` | DEB 和 RPM |
-| Flatpak Native Host 配套程序 | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.8-linux-<arch>.tar.gz` |
-| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中均发布不可变 tag `2.0.0-beta.8` |
-| Snap Store | `amd64`、`arm64` | `latest/edge` |
-
-容器镜像地址为 `docker.io/motrixapp/motrix-server:2.0.0-beta.8` 和
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.8`。数据持久化、网络和升级方法请参阅
-[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/docker-server.zh-CN.md)。
-
-## 已知发布限制
-
-- 本 beta 不发布 AppImage。
-- Flatpak 会单独验证，不会随该版本 tag 发布；GitHub Release 会包含其 Native Host
-  配套程序压缩包。
-- 不提供 Windows `arm64` 和任何 32 位安装包。
-- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅从此 GitHub
-  官方 Release 下载。
-- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
-
-## 反馈
-
-请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现的问题，
-并附上操作系统、架构、安装包类型和复现步骤。
+Motrix 2.0.0-beta.9 已取代这次未发布的尝试。下一版 beta 请参阅
+[beta.9 发布说明](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.9/docs/release-notes/2.0.0-beta.9.zh-CN.md)。
+[beta.7 发布说明](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.7.zh-CN.md)
+保留了前序历史记录。

--- a/docs/release-notes/2.0.0-beta.9.md
+++ b/docs/release-notes/2.0.0-beta.9.md
@@ -1,0 +1,118 @@
+# Motrix 2.0.0-beta.9
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.9/docs/release-notes/2.0.0-beta.9.zh-CN.md)
+
+Motrix 2.0.0-beta.9 is the next Motrix Turbo beta intended for public
+distribution after every protected release gate passes. It continues public
+validation of the rebuilt v2 desktop app and headless server, shared download
+core, MDXP integrations, and sandboxed plugin system.
+
+Motrix 2.0.0-beta.8 was not published. All five desktop builds and both Snap
+builds succeeded, but final desktop verification and Snap Store processing did
+not complete. The
+[beta.8 historical record](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.9/docs/release-notes/2.0.0-beta.8.md)
+preserves the exact outcome.
+
+## Release reliability updates
+
+- Installs a complete, lockfile-pinned verifier dependency closure inside the
+  isolated finalization runtime. The verifier can resolve `@electron/asar`
+  without consulting the staged application or the repository dependency
+  tree.
+- Removes temporary signing inputs as soon as the Electron Builder step ends,
+  before final package verification begins.
+- Removes the isolated finalization and verification tool runtime after final
+  package verification and before finalized-artifact upload. A cleanup failure
+  prevents the upload from starting.
+- Adds release contracts for the pinned verifier closure and both cleanup
+  boundaries, including failure paths.
+- Keeps Windows `x64` packages explicitly unsigned while retaining final
+  package verification before release.
+- Retains complete-platform-set gates: every desktop target must finalize
+  before assembly, and both Snap architectures must verify before Store
+  publication can begin.
+
+## Snap Store review prerequisite
+
+The Snap uses the `personal-files` interface only for the browser native
+messaging manifest paths verified by the build. Installing a Snap with this
+interface requires a Store declaration signed by Canonical whose
+`allow-installation` constraint permits installation. This is a Store-side
+review requirement; the project will not bypass or weaken it in code.
+
+The `v2.0.0-beta.9` tag must wait until that declaration is approved. Until the
+approval is recorded and the protected tag workflow releases and publicly
+verifies both exact revisions, a beta.9 Snap must not be considered available
+from `latest/edge`.
+
+## Highlights
+
+- A ground-up desktop rebuild with Electron 43, React 19, and TypeScript 7,
+  including a customizable Dashboard, dark mode, a cross-platform application
+  menu, and clearer task-inspector feedback.
+- One host-neutral download core for both the desktop app and the Node/Web
+  Server, with SQLite session recovery, tracker management, UPnP/NAT-PMP, and
+  HTTP, FTP, BitTorrent, and magnet support.
+- MDXP-based integration for the official CLI and browser handoff, including
+  local discovery and device-code pairing for remote Server instances.
+- A QuickJS plugin sandbox with capability consent, bundled builtin plugins,
+  and an in-app plugin marketplace.
+- Persistent, multi-architecture Server containers for NAS and home-server
+  deployments, published to both Docker Hub and GHCR after the desktop release
+  succeeds.
+
+## Before testing
+
+This is prerelease software. Back up your existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Please do not rely on this beta for your only copy of
+important downloads.
+
+## What to test
+
+- HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
+  session recovery
+- Desktop integrations, browser and CLI handoff through MDXP, and sandboxed
+  plugins
+- Headless Server deployment, persistent storage, and remote pairing
+
+## Planned downloads after release gates pass
+
+| Distribution | Architectures | Planned output |
+|--------------|---------------|----------------|
+| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | DEB and RPM |
+| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.9-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.9` tag in both registries |
+| Snap Store | `amd64`, `arm64` | `latest/edge` only after Canonical approval and protected public verification |
+
+After publication, container images use
+`docker.io/motrixapp/motrix-server:2.0.0-beta.9` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.9`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.9/docs/docker-server.md)
+for storage, networking, and upgrade guidance.
+
+## Known distribution limits
+
+- AppImage is not published for this beta.
+- Flatpak is validated separately and is not published by the release tag;
+  the GitHub Release includes its Native Host companion archives.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
+  Download them only from the official GitHub Release after it is published.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+- Snap publication remains conditional on Canonical approval and successful
+  verification of the exact two-architecture set; these notes do not announce
+  a public beta.9 Snap.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.9.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.9.zh-CN.md
@@ -1,0 +1,94 @@
+# Motrix 2.0.0-beta.9
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.9/docs/release-notes/2.0.0-beta.9.md) | 简体中文
+
+Motrix 2.0.0-beta.9 是下一次计划公开发布的 Motrix Turbo beta，但只有全部受保护
+发布门禁通过后才会进入分发。该版本继续验证重新开发的 v2 桌面应用与 Headless
+Server、共用下载内核、MDXP 集成和沙箱化插件系统。
+
+Motrix 2.0.0-beta.8 未发布。5 个桌面构建和两个 Snap 构建均成功，但桌面最终
+验证与 Snap Store processing 未能完成。
+[beta.8 历史记录](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.9/docs/release-notes/2.0.0-beta.8.zh-CN.md)
+保留了该次尝试的准确结果。
+
+## 发布可靠性更新
+
+- 在隔离的 Finalize runtime 内安装由 lockfile 固定的完整 verifier dependency
+  closure。verifier 无需查询已暂存应用或仓库依赖树即可解析 `@electron/asar`。
+- Electron Builder 步骤结束后立即删除签名临时输入，再开始最终安装包验证。
+- 最终安装包验证完成后、finalized artifact 上传前，删除隔离的 Finalize 与验证
+  工具 runtime；清理失败会阻止上传开始。
+- 新增发布契约，固定 verifier closure 与两处清理边界，并覆盖失败路径。
+- Windows `x64` 安装包继续明确采用未签名发布，同时保留发布前的最终安装包验证。
+- 继续执行完整平台集合门禁：所有桌面目标完成 Finalize 后才能组装，两个 Snap
+  架构均通过验证后才允许开始 Store 发布。
+
+## Snap Store 审核前提
+
+Snap 只为构建时已验证的浏览器 native messaging manifest 路径使用
+`personal-files` interface。安装使用该 interface 的 Snap，需要由 Canonical
+签名的 Store declaration，并由其中的 `allow-installation` constraint 允许安装。
+这是 Store 侧的审核要求；项目不会通过代码绕过或弱化该要求。
+
+`v2.0.0-beta.9` tag 必须等待该 declaration 获批。只有批准状态已记录，且受保护
+tag workflow 已发布并公开验证两个精确 revision 后，才能认为 beta.9 Snap 已在
+`latest/edge` 提供。
+
+## 主要变化
+
+- 使用 Electron 43、React 19 和 TypeScript 7 从头重建桌面应用，提供可自定义
+  Dashboard、深色模式、跨平台应用菜单，以及更清晰的任务检查器反馈。
+- 桌面应用和 Node/Web Server 共用与宿主无关的下载内核，支持 SQLite session
+  恢复、Tracker 管理、UPnP/NAT-PMP，以及 HTTP、FTP、BitTorrent 和磁力链接下载。
+- 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地发现及远程 Server 的
+  device-code 配对。
+- 提供带能力授权的 QuickJS 插件沙箱、内置插件和应用内插件市场。
+- 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器；桌面发布成功后，
+  容器会同时发布到 Docker Hub 与 GHCR。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1 数据的
+迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
+
+条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录与现有环境并行
+测试 v2。请勿让本 beta 成为重要下载文件的唯一存储位置。
+
+## 建议测试项
+
+- HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
+- 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
+- Headless Server 部署、数据持久化和远程配对
+
+## 发布门禁通过后的计划下载
+
+| 发布方式 | 架构 | 计划产物 |
+|----------|------|----------|
+| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
+| Windows | `x64` | 未签名的 NSIS 安装包（`.exe`）和 ZIP |
+| Linux | `x64`、`arm64` | DEB 和 RPM |
+| Flatpak Native Host 配套程序 | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.9-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中不可变的 `2.0.0-beta.9` tag |
+| Snap Store | `amd64`、`arm64` | 仅在 Canonical 批准并通过受保护的公开验证后进入 `latest/edge` |
+
+发布完成后，容器镜像地址为
+`docker.io/motrixapp/motrix-server:2.0.0-beta.9` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.9`。数据持久化、网络和升级方法请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.9/docs/docker-server.zh-CN.md)。
+
+## 已知发布限制
+
+- 本 beta 不发布 AppImage。
+- Flatpak 会单独验证，不会随该版本 tag 发布；GitHub Release 会包含其 Native
+  Host 配套程序压缩包。
+- 不提供 Windows `arm64` 和任何 32 位安装包。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅在正式发布后
+  从 GitHub 官方 Release 下载。
+- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
+- Snap 发布仍取决于 Canonical 批准以及双架构精确集合验证成功；本说明不表示
+  beta.9 Snap 已公开提供。
+
+## 反馈
+
+请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现的问题，
+并附上操作系统、架构、安装包类型和复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -76,13 +76,29 @@
   <releases>
     <!-- Update this list on every release; Flathub linter requires the most
          recent version listed here to match the manifest's source tag. -->
+    <release version="2.0.0-beta.9" date="2026-08-16">
+      <description>
+        <p>
+          Release finalization update with a lockfile-pinned verifier closure
+          in an isolated runtime, temporary signing-input cleanup immediately
+          after Builder, and tool-runtime cleanup between package verification
+          and artifact upload. Windows packages remain unsigned. Snap
+          publication waits for Canonical approval of the personal-files
+          allow-installation declaration.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.8" date="2026-08-16">
       <description>
         <p>
-          Cross-platform finalization reliability update with isolated
-          temporary handoff cleanup on macOS, preserved staged dependency
-          placements for Windows, and complete-set gates within each
-          publishing workflow. Windows packages remain unsigned.
+          Unpublished Motrix Turbo beta attempt. All five desktop builds and
+          both strict Snap builds succeeded. Unsigned Windows Builder
+          completed, but final verification could not resolve @electron/asar
+          before scanning; macOS finalization was canceled without running
+          while awaiting approval. The
+          amd64 Snap upload required personal-files allow-installation review,
+          arm64 was not uploaded, latest/edge did not change, and external
+          distribution remained zero.
         </p>
       </description>
     </release>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1",
   "description": "A full-featured download manager",
   "keywords": [],

--- a/scripts/verify-snap-artifact.mjs
+++ b/scripts/verify-snap-artifact.mjs
@@ -175,12 +175,12 @@ function verifyMetadata(metadata, { arch, version }) {
   requireExactSet(links.website, ['https://motrix.app'], 'snap links.website')
   requireExactSet(
     links['source-code'],
-    ['https://gitlab.com/agalwood/motrix-turbo'],
+    ['https://github.com/agalwood/Motrix'],
     'snap links.source-code'
   )
   requireExactSet(
     links.issues,
-    ['https://gitlab.com/agalwood/motrix-turbo/-/issues'],
+    ['https://github.com/agalwood/Motrix/issues'],
     'snap links.issues'
   )
   requireExactSet(root.architectures, [arch], 'snap architectures')

--- a/tests/scripts/release-version-contract.test.ts
+++ b/tests/scripts/release-version-contract.test.ts
@@ -13,6 +13,10 @@ function read(relativePath: string): string {
 const packageVersion = (JSON.parse(read('package.json')) as { version: string })
   .version
 const releaseTag = `v${packageVersion}`
+const restrictedPublicLanguage =
+  /\b(?:certificates?|credentials?|secrets?|leak(?:ed|age|s)?|rotat(?:e|ed|ing|ion)|security incidents?)\b|证书|凭据|密钥|泄露|轮换|安全事件/iu
+const secretLikeIdentifier =
+  /\b[A-Z][A-Z0-9_]*(?:SECRET|CERT|KEY|TOKEN|CREDENTIAL)[A-Z0-9_]*\b/u
 
 describe('release version contract', () => {
   it('keeps package metadata, server fallback, and Flatpak metadata aligned', () => {
@@ -159,11 +163,15 @@ describe('release version contract', () => {
     expect(normalizedChinese).toContain('外部分发为零')
   })
 
-  it('preserves beta.8 release reliability and distribution disclosures', () => {
+  it('records beta.8 as an unpublished desktop and Snap attempt', () => {
     const english = read('docs/release-notes/2.0.0-beta.8.md')
     const chinese = read('docs/release-notes/2.0.0-beta.8.zh-CN.md')
-    const normalizedEnglish = english.replace(/\s+/g, ' ')
-    const normalizedChinese = chinese.replace(/\s+/g, ' ')
+    const normalizedEnglish = english
+      .replace(/^>\s?/gm, '')
+      .replace(/\s+/g, ' ')
+    const normalizedChinese = chinese
+      .replace(/^>\s?/gm, '')
+      .replace(/\s+/g, ' ')
     const metainfo = read('flatpak/app.motrix.native.metainfo.xml')
     const beta8Metainfo =
       /<release version="2\.0\.0-beta\.8"[\s\S]*?<\/release>/.exec(
@@ -173,16 +181,18 @@ describe('release version contract', () => {
       /<release version="2\.0\.0-beta\.7"[\s\S]*?<\/release>/.exec(
         metainfo
       )?.[0] ?? ''
-    const restrictedPublicLanguage =
-      /\b(?:certificates?|credentials?|secrets?|leak(?:ed|age|s)?|rotat(?:e|ed|ing|ion)|security incidents?)\b|证书|凭据|密钥|泄露|轮换|安全事件/iu
-    const secretLikeIdentifier =
-      /\b[A-Z][A-Z0-9_]*(?:SECRET|CERT|KEY|TOKEN|CREDENTIAL)[A-Z0-9_]*\b/u
 
     expect(english).toContain(
-      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.8.zh-CN.md'
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.9/docs/release-notes/2.0.0-beta.8.zh-CN.md'
     )
     expect(chinese).toContain(
-      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.8.md'
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.9/docs/release-notes/2.0.0-beta.8.md'
+    )
+    expect(english).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.9/docs/release-notes/2.0.0-beta.9.md'
+    )
+    expect(chinese).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.9/docs/release-notes/2.0.0-beta.9.zh-CN.md'
     )
     expect(english).toContain(
       'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.7.md'
@@ -190,54 +200,66 @@ describe('release version contract', () => {
     expect(chinese).toContain(
       'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.8/docs/release-notes/2.0.0-beta.7.zh-CN.md'
     )
+    expect(normalizedEnglish).toContain('Motrix 2.0.0-beta.8 was not published')
     expect(normalizedEnglish).toContain(
-      'Strengthens cross-platform finalization reliability while retaining complete-platform-set gates within each release workflow'
-    )
-    expect(normalizedEnglish).toContain(
-      'macOS finalization now uses an isolated temporary handoff that is removed when the job ends'
+      'All five desktop build jobs completed successfully'
     )
     expect(normalizedEnglish).toContain(
-      'Windows finalization keeps its packaging toolchain outside the staged app and preserves the already verified staged dependency inventory and package placements'
+      'The explicitly unsigned Windows Finalize job completed Electron Builder and produced its final package candidates'
     )
     expect(normalizedEnglish).toContain(
-      'desktop assets are assembled before the GitHub Release, both Snap architectures are verified before Store publication, and R2 feeds and containers start only after the GitHub Release succeeds'
+      'The final verifier then stopped before package scanning because its isolated tool dependency set could not resolve `@electron/asar`'
     )
     expect(normalizedEnglish).toContain(
-      'Keeps Windows `x64` packages explicitly unsigned'
+      'Both macOS Finalize jobs were canceled without running while awaiting approval'
+    )
+    expect(normalizedEnglish).toContain(
+      'Desktop assembly, the GitHub Release, R2 update-feed publication, and Docker Hub/GHCR container publication were canceled without running'
+    )
+    expect(normalizedEnglish).toContain(
+      'The source gate and strict `amd64` and `arm64` Snap builds completed'
+    )
+    expect(normalizedEnglish).toContain(
+      "Both artifacts passed package verification and were uploaded to the workflow's internal artifact set"
+    )
+    expect(normalizedEnglish).toContain(
+      'The `amd64` upload reached Store processing, which required human review of the `personal-files` `allow-installation` declaration'
+    )
+    expect(normalizedEnglish).toContain(
+      'The Store did not return an exact revision, and the `arm64` Store upload did not start'
+    )
+    expect(normalizedEnglish).toContain(
+      'Public `latest/edge` remained unchanged at amd64 Motrix 1.8.19 with no arm64 entry'
+    )
+    expect(normalizedEnglish).toContain('External distribution remained zero')
+    expect(normalizedChinese).toContain('5 个桌面构建 job 均成功完成')
+    expect(normalizedChinese).toContain(
+      'Windows Finalize job 成功完成 Electron Builder'
+    )
+    expect(normalizedChinese).toContain('最终 verifier 在扫描安装包前停止')
+    expect(chinese).toContain('`@electron/asar`')
+    expect(normalizedChinese).toContain(
+      '两个 macOS Finalize job 在等待审批时被取消，均未执行'
     )
     expect(normalizedChinese).toContain(
-      '加强跨平台 Finalize 的可靠性，同时保留每条发布 workflow 内的完整平台集合门禁'
+      '桌面产物组装、GitHub Release、R2 更新数据源发布以及 Docker Hub/GHCR 容器发布均被取消且未执行'
     )
     expect(normalizedChinese).toContain(
-      'macOS Finalize 现在使用隔离的临时文件进行交接，并在 job 结束时删除该文件'
+      'source gate 以及 `amd64`、`arm64` 两个 strict Snap 构建均完成'
     )
     expect(normalizedChinese).toContain(
-      'Windows Finalize 将打包工具链放在已暂存应用之外，并原样保留已验证的暂存 依赖清单及包路径，避免清单漂移'
+      'Store 要求人工审核 `personal-files` 的 `allow-installation` 声明'
     )
     expect(normalizedChinese).toContain(
-      '桌面产物完成组装后才创建 GitHub Release，两种 Snap 架构均通过验证后才进入 Store 发布'
+      'Store 没有返回精确 revision，`arm64` Store upload 也未开始'
     )
     expect(normalizedChinese).toContain(
-      'R2 更新数据源与容器 仅在 GitHub Release 成功后启动'
+      '公开 `latest/edge` 保持不变，仍为 amd64 Motrix 1.8.19'
     )
-    expect(normalizedChinese).toContain(
-      'Windows `x64` 安装包继续明确采用未签名发布'
-    )
-    for (const source of [english, chinese]) {
-      expect(source).toContain('2.0.0-beta.8')
-      expect(source).toContain('latest/edge')
-      expect(source).toContain('AppImage')
-      expect(source).toContain('Flatpak')
-      expect(source).toContain(
-        'Motrix-Native-Host-2.0.0-beta.8-linux-<arch>.tar.gz'
-      )
-      expect(source).toContain('SmartScreen')
-      expect(source).toContain('docker.io/motrixapp/motrix-server:2.0.0-beta.8')
-      expect(source).toContain('ghcr.io/agalwood/motrix-server:2.0.0-beta.8')
-      expect(source).not.toMatch(restrictedPublicLanguage)
-      expect(source).not.toMatch(secretLikeIdentifier)
-    }
+    expect(normalizedChinese).toContain('外部分发为零')
     for (const source of [
+      english,
+      chinese,
       read('docs/release-notes/2.0.0-beta.7.md'),
       read('docs/release-notes/2.0.0-beta.7.zh-CN.md'),
       beta8Metainfo,
@@ -249,12 +271,101 @@ describe('release version contract', () => {
     expect(metainfo).toContain(
       '<release version="2.0.0-beta.8" date="2026-08-16">'
     )
+    expect(metainfo).toContain('Unsigned Windows Builder')
     expect(metainfo).toContain(
-      'Cross-platform finalization reliability update with isolated'
+      'amd64 Snap upload required personal-files allow-installation review'
     )
+  })
+
+  it('preserves beta.9 finalization and Snap review disclosures', () => {
+    const english = read('docs/release-notes/2.0.0-beta.9.md')
+    const chinese = read('docs/release-notes/2.0.0-beta.9.zh-CN.md')
+    const normalizedEnglish = english.replace(/\s+/g, ' ')
+    const normalizedChinese = chinese.replace(/\s+/g, ' ')
+    const metainfo = read('flatpak/app.motrix.native.metainfo.xml')
+    const beta9Metainfo =
+      /<release version="2\.0\.0-beta\.9"[\s\S]*?<\/release>/.exec(
+        metainfo
+      )?.[0] ?? ''
+
+    expect(english).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.9/docs/release-notes/2.0.0-beta.8.md'
+    )
+    expect(chinese).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.9/docs/release-notes/2.0.0-beta.8.zh-CN.md'
+    )
+    expect(normalizedEnglish).toContain(
+      'Installs a complete, lockfile-pinned verifier dependency closure inside the isolated finalization runtime'
+    )
+    expect(normalizedEnglish).toContain(
+      'The verifier can resolve `@electron/asar` without consulting the staged application or the repository dependency tree'
+    )
+    expect(normalizedEnglish).toContain(
+      'Removes temporary signing inputs as soon as the Electron Builder step ends, before final package verification begins'
+    )
+    expect(normalizedEnglish).toContain(
+      'Removes the isolated finalization and verification tool runtime after final package verification and before finalized-artifact upload'
+    )
+    expect(normalizedEnglish).toContain(
+      'A cleanup failure prevents the upload from starting'
+    )
+    expect(normalizedEnglish).toContain(
+      'Installing a Snap with this interface requires a Store declaration signed by Canonical'
+    )
+    expect(normalizedEnglish).toContain(
+      'the project will not bypass or weaken it in code'
+    )
+    expect(normalizedEnglish).toContain(
+      'The `v2.0.0-beta.9` tag must wait until that declaration is approved'
+    )
+    expect(normalizedEnglish).toContain(
+      'a beta.9 Snap must not be considered available from `latest/edge`'
+    )
+    expect(normalizedChinese).toContain(
+      '在隔离的 Finalize runtime 内安装由 lockfile 固定的完整 verifier dependency closure'
+    )
+    expect(normalizedChinese).toContain(
+      'Electron Builder 步骤结束后立即删除签名临时输入'
+    )
+    expect(normalizedChinese).toContain(
+      '最终安装包验证完成后、finalized artifact 上传前，删除隔离的 Finalize 与验证 工具 runtime'
+    )
+    expect(normalizedChinese).toContain('清理失败会阻止上传开始')
+    expect(normalizedChinese).toContain(
+      '需要由 Canonical 签名的 Store declaration'
+    )
+    expect(normalizedChinese).toContain('项目不会通过代码绕过或弱化该要求')
+    expect(normalizedChinese).toContain(
+      '`v2.0.0-beta.9` tag 必须等待该 declaration 获批'
+    )
+    expect(normalizedChinese).toContain('本说明不表示 beta.9 Snap 已公开提供')
+    for (const source of [english, chinese]) {
+      expect(source).toContain('2.0.0-beta.9')
+      expect(source).toContain('latest/edge')
+      expect(source).toContain('personal-files')
+      expect(source).toContain('allow-installation')
+      expect(source).toContain('AppImage')
+      expect(source).toContain('Flatpak')
+      expect(source).toContain(
+        'Motrix-Native-Host-2.0.0-beta.9-linux-<arch>.tar.gz'
+      )
+      expect(source).toContain('SmartScreen')
+      expect(source).toContain('docker.io/motrixapp/motrix-server:2.0.0-beta.9')
+      expect(source).toContain('ghcr.io/agalwood/motrix-server:2.0.0-beta.9')
+      expect(source).not.toMatch(restrictedPublicLanguage)
+      expect(source).not.toMatch(secretLikeIdentifier)
+    }
     expect(metainfo).toContain(
-      'public Snap distribution was published; external distribution'
+      '<release version="2.0.0-beta.9" date="2026-08-16">'
     )
+    expect(beta9Metainfo).toContain('lockfile-pinned verifier closure')
+    expect(beta9Metainfo).toContain(
+      'tool-runtime cleanup between package verification'
+    )
+    expect(beta9Metainfo).toContain('personal-files')
+    expect(beta9Metainfo).toContain('allow-installation')
+    expect(beta9Metainfo).not.toMatch(restrictedPublicLanguage)
+    expect(beta9Metainfo).not.toMatch(secretLikeIdentifier)
   })
 
   it('preserves beta.6 Snap recovery and canceled release history', () => {

--- a/tests/scripts/snap-artifact.test.ts
+++ b/tests/scripts/snap-artifact.test.ts
@@ -36,8 +36,8 @@ function metadata(arch: 'amd64' | 'arm64', version = '2.0.0') {
     assumes: ['snapd2.43', 'snapd2.46'],
     links: {
       website: ['https://motrix.app'],
-      'source-code': ['https://gitlab.com/agalwood/motrix-turbo'],
-      issues: ['https://gitlab.com/agalwood/motrix-turbo/-/issues'],
+      'source-code': ['https://github.com/agalwood/Motrix'],
+      issues: ['https://github.com/agalwood/Motrix/issues'],
     },
     architectures: [arch],
     apps: {

--- a/tests/scripts/snap-project.test.ts
+++ b/tests/scripts/snap-project.test.ts
@@ -100,8 +100,8 @@ describe('prepare-snap-project', () => {
       confinement: 'strict',
       grade: 'stable',
       assumes: ['snapd2.46'],
-      'source-code': 'https://gitlab.com/agalwood/motrix-turbo',
-      issues: 'https://gitlab.com/agalwood/motrix-turbo/-/issues',
+      'source-code': 'https://github.com/agalwood/Motrix',
+      issues: 'https://github.com/agalwood/Motrix/issues',
       platforms: {
         amd64: {
           'build-on': ['amd64'],

--- a/tests/scripts/workflow-release-matrix.test.ts
+++ b/tests/scripts/workflow-release-matrix.test.ts
@@ -6,13 +6,16 @@ import {
   mkdtempSync,
   readdirSync,
   readFileSync,
+  realpathSync,
   rmSync,
   statSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { Script } from 'node:vm'
 import { describe, expect, it } from 'vitest'
 // @ts-expect-error -- JavaScript build script intentionally has no declarations
@@ -1184,6 +1187,229 @@ describe('release workflow publication contract', () => {
     expect(releaseSource).not.toContain('APPLE_TEAM_ID')
   })
 
+  it('runs the finalized package verifier from the isolated tool closure', () => {
+    const sign = asRecord(workflowJobs(releaseWorkflow).sign, 'sign job')
+    const steps = jobSteps(sign)
+    const installIndex = steps.findIndex(
+      (step) => step.name === 'Install exact signing dependency closure'
+    )
+    const credentialCleanupIndex = steps.findIndex(
+      (step) => step.name === 'Remove finalization credentials'
+    )
+    const verificationIndex = steps.findIndex(
+      (step) => step.name === 'Verify finalized Electron package'
+    )
+    const uploadIndex = steps.findIndex(
+      (step) => step.name === 'Upload finalized release input'
+    )
+    const runtimeCleanupIndex = steps.findIndex(
+      (step) => step.name === 'Remove isolated signing runtime'
+    )
+    expect(installIndex).toBeGreaterThanOrEqual(0)
+    expect(credentialCleanupIndex).toBeGreaterThan(installIndex)
+    for (const name of [
+      'Electron Builder (macOS signing boundary)',
+      'Electron Builder (Windows finalization boundary)',
+    ]) {
+      const builderIndex = steps.findIndex((step) => step.name === name)
+      expect(builderIndex, name).toBeGreaterThan(installIndex)
+      expect(builderIndex, name).toBeLessThan(credentialCleanupIndex)
+    }
+    expect(verificationIndex).toBeGreaterThan(credentialCleanupIndex)
+    expect(runtimeCleanupIndex).toBeGreaterThan(verificationIndex)
+    expect(uploadIndex).toBeGreaterThan(runtimeCleanupIndex)
+
+    const verifierFiles = [
+      'electron-package-size-budgets.json',
+      'electron-package-utils.mjs',
+      'native-binary-target.mjs',
+      'verify-electron-package.mjs',
+    ]
+    const install = steps[installIndex]!
+    const installSource = stringField(install, 'run')
+    expect(installSource).toContain("path.join(root, 'scripts')")
+    expect(installSource).toContain('fs.constants.COPYFILE_EXCL')
+    expect(installSource).toContain('fs.realpathSync')
+    expect(installSource).toContain(`verifier=\${verifier}`)
+    expect(installSource).toContain('pathToFileURL(verifier).href')
+    expect(installSource).toContain(
+      "throw new Error('package verifier dependency import failed')"
+    )
+    expect(installSource).not.toContain(
+      "path.join('signing-input', 'node_modules')"
+    )
+    const trustedPins = signingInputSource.slice(
+      signingInputSource.indexOf('const TRUSTED_INPUT_SHA256'),
+      signingInputSource.indexOf('const SOURCE_MAPPINGS')
+    )
+    const sourceMappings = signingInputSource.slice(
+      signingInputSource.indexOf('const SOURCE_MAPPINGS'),
+      signingInputSource.indexOf('async function sha256File')
+    )
+    const allowedPaths = signingInputSource.slice(
+      signingInputSource.indexOf('function isAllowedSigningDataPath'),
+      signingInputSource.indexOf('function isForbiddenControlPath')
+    )
+    for (const name of verifierFiles) {
+      expect(installSource, name).toContain(`'${name}'`)
+      const trustedPath = `'scripts/${name}'`
+      const pinIndex = trustedPins.indexOf(trustedPath)
+      expect(pinIndex, `${name} must be hard-pinned`).toBeGreaterThanOrEqual(0)
+      expect(
+        trustedPins.slice(pinIndex + trustedPath.length, pinIndex + 160),
+        `${name} must have a SHA-256 pin`
+      ).toMatch(/^\s*:\s*'[0-9a-f]{64}'/u)
+      expect(sourceMappings.split(trustedPath), name).toHaveLength(3)
+      expect(allowedPaths, name).toContain(trustedPath)
+    }
+
+    const verification = steps[verificationIndex]!
+    const verificationSource = stringField(verification, 'run')
+    expect(verificationSource).toContain(
+      'steps.signing-tool-runtime.outputs.verifier'
+    )
+    expect(verificationSource).not.toContain(
+      'node scripts/verify-electron-package.mjs'
+    )
+    expect(stringField(verification, 'if', '')).toBe('')
+    expect(stringField(verification, 'working-directory')).toBe('signing-input')
+    expect(
+      readFileSync(
+        path.join(ROOT, 'scripts/verify-electron-package.mjs'),
+        'utf8'
+      )
+    ).toMatch(
+      /path\.join\(\s*REPOSITORY_ROOT,\s*'scripts\/electron-package-size-budgets\.json'\s*\)/u
+    )
+
+    const fixture = realpathSync(
+      mkdtempSync(path.join(tmpdir(), 'motrix-isolated-package-verifier-'))
+    )
+    const signingInput = path.join(fixture, 'signing-input')
+    const runtime = path.join(fixture, 'runtime')
+    const stageVerifier = (root: string) => {
+      const scripts = path.join(root, 'scripts')
+      mkdirSync(scripts, { recursive: true })
+      for (const name of verifierFiles) {
+        writeFileSync(
+          path.join(scripts, name),
+          readFileSync(path.join(ROOT, 'scripts', name))
+        )
+      }
+      return path.join(scripts, 'verify-electron-package.mjs')
+    }
+    const importVerifier = (verifier: string) =>
+      spawnSync(
+        process.execPath,
+        [
+          '--input-type=module',
+          '--eval',
+          `await import(${JSON.stringify(pathToFileURL(verifier).href)})`,
+        ],
+        { cwd: signingInput, encoding: 'utf8' }
+      )
+
+    try {
+      const inaccessibleVerifier = stageVerifier(signingInput)
+      const inaccessible = importVerifier(inaccessibleVerifier)
+      expect(inaccessible.status).not.toBe(0)
+      expect(`${inaccessible.stdout}${inaccessible.stderr}`).toContain(
+        "Cannot find package '@electron/asar'"
+      )
+
+      const isolatedVerifier = stageVerifier(runtime)
+      const installedNodeModules = path.join(ROOT, 'node_modules')
+      expect(existsSync(installedNodeModules)).toBe(true)
+      symlinkSync(
+        installedNodeModules,
+        path.join(runtime, 'node_modules'),
+        process.platform === 'win32' ? 'junction' : 'dir'
+      )
+      for (const name of [
+        'package.json',
+        'package-lock.json',
+        'node_modules',
+      ]) {
+        expect(existsSync(path.join(signingInput, name)), name).toBe(false)
+      }
+      const signingToolPackages = asRecord(
+        asRecord(
+          JSON.parse(signingToolLockSource) as unknown,
+          'signing tool lock'
+        ).packages,
+        'signing tool lock packages'
+      )
+      const lockedAsar = asRecord(
+        signingToolPackages['node_modules/@electron/asar'],
+        'locked @electron/asar package'
+      )
+      const installedAsar = asRecord(
+        JSON.parse(
+          readFileSync(
+            path.join(installedNodeModules, '@electron/asar/package.json'),
+            'utf8'
+          )
+        ) as unknown,
+        'installed @electron/asar package'
+      )
+      expect(stringField(installedAsar, 'version')).toBe(
+        stringField(lockedAsar, 'version')
+      )
+      const isolated = importVerifier(isolatedVerifier)
+      expect(isolated.status, isolated.stderr).toBe(0)
+
+      const report = 'isolated-runtime-smoke-report.json'
+      const execution = spawnSync(
+        process.execPath,
+        [
+          isolatedVerifier,
+          '--app-dir',
+          'missing-app',
+          '--platform',
+          'win32',
+          '--arch',
+          'x64',
+          '--report',
+          report,
+        ],
+        { cwd: signingInput, encoding: 'utf8' }
+      )
+      expect(execution.status).not.toBe(0)
+      expect(execution.stdout).toContain(
+        '[verify-electron-package] failed win32-x64'
+      )
+      expect(`${execution.stdout}${execution.stderr}`).not.toContain(
+        'electron-package-size-budgets.json'
+      )
+      expect(`${execution.stdout}${execution.stderr}`).not.toContain(
+        "Cannot find package '@electron/asar'"
+      )
+      const reportPath = path.join(signingInput, report)
+      expect(existsSync(reportPath)).toBe(true)
+      const reportTools = asRecord(
+        asRecord(
+          JSON.parse(readFileSync(reportPath, 'utf8')) as unknown,
+          'isolated verifier report'
+        ).tools,
+        'isolated verifier tool versions'
+      )
+      expect(stringField(reportTools, 'asar')).toBe(
+        stringField(lockedAsar, 'version')
+      )
+      expect(stringField(reportTools, 'electronBuilder')).toBe(
+        stringField(
+          asRecord(
+            signingToolPackages['node_modules/electron-builder'],
+            'locked electron-builder package'
+          ),
+          'version'
+        )
+      )
+    } finally {
+      rmSync(fixture, { recursive: true, force: true })
+    }
+  })
+
   it('materializes only bounded P12 bytes and always removes temporary inputs', () => {
     const sign = asRecord(workflowJobs(releaseWorkflow).sign, 'sign job')
     const steps = jobSteps(sign)
@@ -1282,35 +1508,64 @@ describe('release workflow publication contract', () => {
       rmSync(temporaryRoot, { recursive: true, force: true })
     }
 
-    const cleanup = steps.find(
-      (step) => step.name === 'Remove finalization temporary inputs'
+    const credentialCleanup = steps.find(
+      (step) => step.name === 'Remove finalization credentials'
     )
-    expect(cleanup).toBeDefined()
-    expect(stringField(cleanup as LooseRecord, 'if')).toBe('always()')
-    expect(stringField(cleanup as LooseRecord, 'shell')).toBe('node {0}')
-    const cleanupEnvironment = asRecord(
-      cleanup?.env,
-      'temporary input cleanup environment'
+    expect(credentialCleanup).toBeDefined()
+    expect(stringField(credentialCleanup as LooseRecord, 'if')).toBe('always()')
+    expect(stringField(credentialCleanup as LooseRecord, 'shell')).toBe(
+      'node {0}'
     )
-    expect(stringField(cleanupEnvironment, 'TEMPORARY_ROOT')).toContain(
-      'runner.temp'
-    )
-    expect(stringField(cleanupEnvironment, 'MAC_CERTIFICATE_PATH')).toContain(
-      'steps.mac-certificate.outputs.path'
+    const credentialCleanupEnvironment = asRecord(
+      credentialCleanup?.env,
+      'credential cleanup environment'
     )
     expect(
-      stringField(cleanupEnvironment, 'MAC_CERTIFICATE_DIRECTORY')
+      stringField(credentialCleanupEnvironment, 'TEMPORARY_ROOT')
+    ).toContain('runner.temp')
+    expect(
+      stringField(credentialCleanupEnvironment, 'MAC_CERTIFICATE_PATH')
+    ).toContain('steps.mac-certificate.outputs.path')
+    expect(
+      stringField(credentialCleanupEnvironment, 'MAC_CERTIFICATE_DIRECTORY')
     ).toContain('steps.mac-certificate.outputs.directory')
-    expect(stringField(cleanupEnvironment, 'APPLE_API_KEY_PATH')).toContain(
-      'steps.apple-api-key.outputs.path'
+    expect(
+      stringField(credentialCleanupEnvironment, 'APPLE_API_KEY_PATH')
+    ).toContain('steps.apple-api-key.outputs.path')
+    expect(credentialCleanupEnvironment).not.toHaveProperty('SIGNING_TOOL_ROOT')
+    expect(JSON.stringify(credentialCleanup)).not.toContain('secrets.')
+    const credentialCleanupSource = stringField(
+      credentialCleanup as LooseRecord,
+      'run'
     )
-    expect(stringField(cleanupEnvironment, 'SIGNING_TOOL_ROOT')).toContain(
-      'steps.signing-tool-runtime.outputs.root'
+    expect(credentialCleanupSource).toContain('path.relative(root, candidate)')
+    expect(credentialCleanupSource).toContain('fs.rmSync')
+
+    const runtimeCleanup = steps.find(
+      (step) => step.name === 'Remove isolated signing runtime'
     )
-    expect(JSON.stringify(cleanup)).not.toContain('secrets.')
-    const cleanupSource = stringField(cleanup as LooseRecord, 'run')
-    expect(cleanupSource).toContain('path.relative(root, candidate)')
-    expect(cleanupSource).toContain('fs.rmSync')
+    expect(runtimeCleanup).toBeDefined()
+    expect(stringField(runtimeCleanup as LooseRecord, 'if')).toBe('always()')
+    expect(stringField(runtimeCleanup as LooseRecord, 'shell')).toBe('node {0}')
+    const runtimeCleanupEnvironment = asRecord(
+      runtimeCleanup?.env,
+      'signing runtime cleanup environment'
+    )
+    expect(stringField(runtimeCleanupEnvironment, 'TEMPORARY_ROOT')).toContain(
+      'runner.temp'
+    )
+    expect(
+      stringField(runtimeCleanupEnvironment, 'SIGNING_TOOL_ROOT')
+    ).toContain('steps.signing-tool-runtime.outputs.root')
+    expect(runtimeCleanupEnvironment).not.toHaveProperty('APPLE_API_KEY_PATH')
+    expect(runtimeCleanupEnvironment).not.toHaveProperty('MAC_CERTIFICATE_PATH')
+    expect(JSON.stringify(runtimeCleanup)).not.toContain('secrets.')
+    const runtimeCleanupSource = stringField(
+      runtimeCleanup as LooseRecord,
+      'run'
+    )
+    expect(runtimeCleanupSource).toContain('path.relative(root, candidate)')
+    expect(runtimeCleanupSource).toContain('fs.rmSync')
 
     const cleanupRoot = mkdtempSync(
       path.join(tmpdir(), 'motrix-finalization-cleanup-contract-')
@@ -1325,26 +1580,60 @@ describe('release workflow publication contract', () => {
       writeFileSync(apiKey, 'api key')
       writeFileSync(certificate, 'certificate')
       writeFileSync(path.join(signingTool, 'package.json'), '{}')
-      const result = spawnSync(process.execPath, ['-e', cleanupSource], {
-        cwd: ROOT,
-        encoding: 'utf8',
-        env: {
-          ...process.env,
-          APPLE_API_KEY_PATH: apiKey,
-          MAC_CERTIFICATE_DIRECTORY: certificateDirectory,
-          MAC_CERTIFICATE_PATH: certificate,
-          SIGNING_TOOL_ROOT: signingTool,
-          TEMPORARY_ROOT: cleanupRoot,
-        },
-      })
-      expect(result.status, result.stderr).toBe(0)
-      for (const candidate of [
-        apiKey,
-        certificate,
-        certificateDirectory,
-        signingTool,
-      ]) {
+      const credentialResult = spawnSync(
+        process.execPath,
+        ['-e', credentialCleanupSource],
+        {
+          cwd: ROOT,
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            APPLE_API_KEY_PATH: apiKey,
+            MAC_CERTIFICATE_DIRECTORY: certificateDirectory,
+            MAC_CERTIFICATE_PATH: certificate,
+            TEMPORARY_ROOT: cleanupRoot,
+          },
+        }
+      )
+      expect(credentialResult.status, credentialResult.stderr).toBe(0)
+      for (const candidate of [apiKey, certificate, certificateDirectory]) {
         expect(existsSync(candidate), candidate).toBe(false)
+      }
+      expect(existsSync(signingTool)).toBe(true)
+
+      const runtimeResult = spawnSync(
+        process.execPath,
+        ['-e', runtimeCleanupSource],
+        {
+          cwd: ROOT,
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            SIGNING_TOOL_ROOT: signingTool,
+            TEMPORARY_ROOT: cleanupRoot,
+          },
+        }
+      )
+      expect(runtimeResult.status, runtimeResult.stderr).toBe(0)
+      expect(existsSync(signingTool)).toBe(false)
+
+      for (const cleanupSource of [
+        credentialCleanupSource,
+        runtimeCleanupSource,
+      ]) {
+        const emptyResult = spawnSync(process.execPath, ['-e', cleanupSource], {
+          cwd: ROOT,
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            APPLE_API_KEY_PATH: '',
+            MAC_CERTIFICATE_DIRECTORY: '',
+            MAC_CERTIFICATE_PATH: '',
+            SIGNING_TOOL_ROOT: '',
+            TEMPORARY_ROOT: cleanupRoot,
+          },
+        })
+        expect(emptyResult.status, emptyResult.stderr).toBe(0)
       }
     } finally {
       rmSync(cleanupRoot, { recursive: true, force: true })


### PR DESCRIPTION
Summary:
- keep the isolated Finalize verifier closure available through final package verification, then clean it before artifact upload
- preserve unsigned Windows finalization and protected macOS signing gates
- record the unpublished beta.8 outcome and prepare version 2.0.0-beta.9
- update Snap source links while retaining the personal-files Store review requirement

Validation:
- tests/scripts: 506 passed
- focused release/Snap contracts: 89 passed
- actionlint, Biome, TypeScript, boundaries, Flatpak/XML, and diff checks passed

Release prerequisite:
- do not create v2.0.0-beta.9 until Canonical approves the personal-files allow-installation declaration for the Motrix snap