### PR TITLE
fix(release): skip snap for prerelease tags

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -58,8 +58,10 @@ them with local publishing steps.
 - Do not manually upload release files, reuse unverified artifacts, bypass
   protected environments, weaken signing-input isolation, or overwrite an
   existing immutable container tag.
-- Protected tags publish one verified amd64/arm64 Snap build set to
-  `latest/edge`. Promote those exact revisions with `snap-promote.yml` from
-  protected `main`; never rebuild during promotion. Stable rejects prereleases.
+- Protected stable tags publish one verified amd64/arm64 Snap build set to
+  `latest/edge`; prerelease tag runs stop after source validation and do not
+  build or publish Snap artifacts. Promote those exact revisions with
+  `snap-promote.yml` from protected `main`; never rebuild during promotion.
+  Stable rejects prereleases.
 - If a release gate fails, fix the source or workflow and run the complete
   gated path again. Do not publish a partial platform set.

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -3,8 +3,8 @@
 # Snap is deliberately independent from the GitHub Release workflow:
 #   - amd64 and arm64 are built on matching native Ubuntu runners;
 #   - pull requests and manual runs never receive Store credentials;
-#   - protected release tags publish a complete two-architecture build set to
-#     latest/edge only;
+#   - protected stable release tags publish a complete two-architecture build
+#     set to latest/edge only; prerelease tag runs stop after source validation;
 #   - candidate and stable receive that exact build set through snap-promote.yml.
 
 name: Snap
@@ -60,6 +60,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       version: ${{ steps.metadata.outputs.version }}
+      prerelease: ${{ steps.metadata.outputs.prerelease }}
     steps:
       - name: Checkout release source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -96,6 +97,9 @@ jobs:
 
   build:
     name: Build Snap / ${{ matrix.snap_arch }}
+    if: >-
+      github.event_name != 'push' ||
+      needs.preflight.outputs.prerelease == 'false'
     needs: preflight
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
@@ -240,6 +244,7 @@ jobs:
     name: Publish complete build set to edge
     if: >-
       github.event_name == 'push' &&
+      needs.preflight.outputs.prerelease == 'false' &&
       startsWith(github.ref, 'refs/tags/v') &&
       github.ref_protected == true
     needs: [preflight, build]

--- a/README.md
+++ b/README.md
@@ -115,21 +115,21 @@ Plugins run inside a QuickJS sandbox. Each plugin declares the host capabilities
 Download Motrix from [motrix.app](https://motrix.app) and choose the package for your operating system. Most Mac users should choose the Apple Silicon build; Intel builds are available for older Macs with Intel processors.
 
 After the remaining release gates pass, the current beta desktop packages
-will be distributed through the GitHub prerelease linked above. Snap will
-become available from its edge channel only after the required Store review
-and protected publication gates complete. Choose the package that matches your
+will be distributed through the GitHub prerelease linked above. Snap is not
+published for this beta; prerelease tag runs stop after source validation and
+do not build or publish Snap artifacts. Choose the package that matches your
 operating system and architecture:
 
 | Platform | Architectures | Packages / channel | Recommendation |
 |----------|---------------|--------------------|----------------|
 | macOS 12+ | `arm64` (Apple Silicon), `x64` (Intel) | `.dmg` / `.zip` | Use the `.dmg` matching your Mac; choose `x64` only for an Intel-based Mac |
 | Windows | `x64` | `.exe` (NSIS installer) / `.zip` | Use the `.exe` installer for a normal installation or `.zip` for a manually extracted copy |
-| Linux | `x64`, `arm64` | `.deb` / `.rpm`; Snap `latest/edge` after Store approval | Use `.deb` on Debian or Ubuntu, `.rpm` on Fedora or openSUSE, or the edge Snap after publication completes |
+| Linux | `x64`, `arm64` | `.deb` / `.rpm` | Use `.deb` on Debian or Ubuntu, or `.rpm` on Fedora or openSUSE |
 
-This beta does not publish an AppImage. Flatpak is validated separately and is
-not published by the release tag. Windows `arm64` and all 32-bit packages are
-not available. Windows `x64` packages are unsigned and may trigger a Windows
-SmartScreen warning.
+This beta does not publish an AppImage or Snap. Flatpak is validated separately
+and is not published by the release tag. Windows `arm64` and all 32-bit
+packages are not available. Windows `x64` packages are unsigned and may
+trigger a Windows SmartScreen warning.
 
 ### Command-line client
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -113,16 +113,16 @@ pnpm create motrix-plugin my-plugin
 访问 Motrix 官网 [motrix.app](https://motrix.app)，选择对应操作系统的安装包。macOS 用户通常下载 Apple Silicon 版本即可；如果使用较早的 Intel 芯片 Mac，请选择 Intel 版本。
 
 剩余发布门禁通过后，当前 beta 桌面安装包将通过上方链接的 GitHub 预发布版
-提供。Snap 只有在必要的 Store 审核与受保护发布门禁完成后，才会通过 edge
-通道提供。请根据操作系统和架构选择安装包：
+提供。本 beta 不发布 Snap；预发布 tag 的 Snap run 会在 source validation 后停止，
+不会构建或发布 Snap artifact。请根据操作系统和架构选择安装包：
 
 | 平台 | 架构 | 安装包 / 通道 | 选择建议 |
 |------|------|---------------|----------|
 | macOS 12+ | `arm64`（Apple Silicon）、`x64`（Intel） | `.dmg` / `.zip` | 选择与 Mac 架构匹配的 `.dmg`；仅 Intel Mac 使用 `x64` |
 | Windows | `x64` | `.exe`（NSIS 安装包）/ `.zip` | 常规安装使用 `.exe`；`.zip` 可解压后手动运行 |
-| Linux | `x64`、`arm64` | `.deb` / `.rpm`；Store 批准后的 Snap `latest/edge` | Debian 或 Ubuntu 使用 `.deb`，Fedora 或 openSUSE 使用 `.rpm`；发布完成后也可使用 edge Snap |
+| Linux | `x64`、`arm64` | `.deb` / `.rpm` | Debian 或 Ubuntu 使用 `.deb`，Fedora 或 openSUSE 使用 `.rpm` |
 
-本 beta 不发布 AppImage。Flatpak 会单独验证，不会随该版本 tag 发布。
+本 beta 不发布 AppImage 或 Snap。Flatpak 会单独验证，不会随该版本 tag 发布。
 同时不提供 Windows `arm64` 和任何 32 位安装包。Windows `x64` 安装包未签名，
 可能触发 Windows SmartScreen 警告。
 

--- a/docs/release-notes/2.0.0-beta.9.md
+++ b/docs/release-notes/2.0.0-beta.9.md
@@ -28,11 +28,11 @@ preserves the exact outcome.
   boundaries, including failure paths.
 - Keeps Windows `x64` packages explicitly unsigned while retaining final
   package verification before release.
-- Retains complete-platform-set gates: every desktop target must finalize
-  before assembly, and both Snap architectures must verify before Store
-  publication can begin.
+- Retains the complete desktop platform-set gate: every desktop target must
+  finalize before assembly. Protected prerelease Snap runs stop after source
+  validation.
 
-## Snap Store review prerequisite
+## Snap beta policy
 
 The Snap uses the `personal-files` interface only for the browser native
 messaging manifest paths verified by the build. Installing a Snap with this
@@ -40,10 +40,11 @@ interface requires a Store declaration signed by Canonical whose
 `allow-installation` constraint permits installation. This is a Store-side
 review requirement; the project will not bypass or weaken it in code.
 
-The `v2.0.0-beta.9` tag must wait until that declaration is approved. Until the
-approval is recorded and the protected tag workflow releases and publicly
-verifies both exact revisions, a beta.9 Snap must not be considered available
-from `latest/edge`.
+Snap is not part of the beta.9 distribution. Protected prerelease Snap runs
+stop after source validation, so they do not build Snap artifacts, upload Store
+revisions, or change `latest/edge`. Stable Snap publication retains its
+complete two-architecture verification, Store declaration requirement, and
+protected Store gates.
 
 ## Highlights
 
@@ -88,7 +89,7 @@ important downloads.
 | Linux | `x64`, `arm64` | DEB and RPM |
 | Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.9-linux-<arch>.tar.gz` |
 | Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.9` tag in both registries |
-| Snap Store | `amd64`, `arm64` | `latest/edge` only after Canonical approval and protected public verification |
+| Snap Store | — | Not published for this beta |
 
 After publication, container images use
 `docker.io/motrixapp/motrix-server:2.0.0-beta.9` and
@@ -106,9 +107,8 @@ for storage, networking, and upgrade guidance.
   Download them only from the official GitHub Release after it is published.
 - Beta container tags are immutable and do not update `latest`, `stable`, or
   other stable floating tags.
-- Snap publication remains conditional on Canonical approval and successful
-  verification of the exact two-architecture set; these notes do not announce
-  a public beta.9 Snap.
+- Snap is not published for this beta. Prerelease Snap runs stop after source
+  validation without building or publishing Snap artifacts.
 
 ## Feedback
 

--- a/docs/release-notes/2.0.0-beta.9.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.9.zh-CN.md
@@ -20,19 +20,20 @@ Motrix 2.0.0-beta.8 未发布。5 个桌面构建和两个 Snap 构建均成功�
   工具 runtime；清理失败会阻止上传开始。
 - 新增发布契约，固定 verifier closure 与两处清理边界，并覆盖失败路径。
 - Windows `x64` 安装包继续明确采用未签名发布，同时保留发布前的最终安装包验证。
-- 继续执行完整平台集合门禁：所有桌面目标完成 Finalize 后才能组装，两个 Snap
-  架构均通过验证后才允许开始 Store 发布。
+- 继续执行完整桌面平台集合门禁：所有桌面目标完成 Finalize 后才能组装。受保护
+  的预发布 Snap run 会在 source validation 后停止。
 
-## Snap Store 审核前提
+## Snap beta 策略
 
 Snap 只为构建时已验证的浏览器 native messaging manifest 路径使用
 `personal-files` interface。安装使用该 interface 的 Snap，需要由 Canonical
 签名的 Store declaration，并由其中的 `allow-installation` constraint 允许安装。
 这是 Store 侧的审核要求；项目不会通过代码绕过或弱化该要求。
 
-`v2.0.0-beta.9` tag 必须等待该 declaration 获批。只有批准状态已记录，且受保护
-tag workflow 已发布并公开验证两个精确 revision 后，才能认为 beta.9 Snap 已在
-`latest/edge` 提供。
+Snap 不属于 beta.9 的分发范围。受保护的预发布 Snap run 会在 source validation
+后停止，因此不会构建 Snap artifact、上传 Store revision 或修改 `latest/edge`。
+稳定版 Snap 发布仍保留完整的双架构验证、Store declaration 要求与受保护 Store
+门禁。
 
 ## 主要变化
 
@@ -69,7 +70,7 @@ tag workflow 已发布并公开验证两个精确 revision 后，才能认为 be
 | Linux | `x64`、`arm64` | DEB 和 RPM |
 | Flatpak Native Host 配套程序 | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.9-linux-<arch>.tar.gz` |
 | Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中不可变的 `2.0.0-beta.9` tag |
-| Snap Store | `amd64`、`arm64` | 仅在 Canonical 批准并通过受保护的公开验证后进入 `latest/edge` |
+| Snap Store | — | 本 beta 不发布 |
 
 发布完成后，容器镜像地址为
 `docker.io/motrixapp/motrix-server:2.0.0-beta.9` 和
@@ -85,8 +86,8 @@ tag workflow 已发布并公开验证两个精确 revision 后，才能认为 be
 - Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅在正式发布后
   从 GitHub 官方 Release 下载。
 - Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
-- Snap 发布仍取决于 Canonical 批准以及双架构精确集合验证成功；本说明不表示
-  beta.9 Snap 已公开提供。
+- 本 beta 不发布 Snap。预发布 Snap run 会在 source validation 后停止，不会构建
+  或发布 Snap artifact。
 
 ## 反馈
 

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -82,9 +82,10 @@
           Release finalization update with a lockfile-pinned verifier closure
           in an isolated runtime, temporary signing-input cleanup immediately
           after Builder, and tool-runtime cleanup between package verification
-          and artifact upload. Windows packages remain unsigned. Snap
-          publication waits for Canonical approval of the personal-files
-          allow-installation declaration.
+          and artifact upload. Windows packages remain unsigned. Prerelease
+          Snap runs stop after source validation without building or
+          publishing artifacts; stable Snap publication retains its
+          personal-files Store declaration requirement.
         </p>
       </description>
     </release>

--- a/tests/scripts/release-metadata.test.ts
+++ b/tests/scripts/release-metadata.test.ts
@@ -11,7 +11,9 @@ describe('release metadata', () => {
     ['2.0.0', false, 'stable'],
     ['2.0.0-beta.1', true, 'beta'],
     ['2.0.0-beta.1+build.7', true, 'beta'],
+    ['2.0.0-beta.1+build-linux', true, 'beta'],
     ['2.0.0+build.007', false, 'stable'],
+    ['2.0.0+build-linux', false, 'stable'],
   ] as const)('parses strict SemVer %s', (version, prerelease, channel) => {
     expect(parseStrictSemVer(version)).toEqual({
       version,
@@ -49,6 +51,21 @@ describe('release metadata', () => {
       version: '2.0.0-beta.1',
       prerelease: true,
       channel: 'beta',
+    })
+  })
+
+  it('keeps hyphenated build metadata on the stable channel', () => {
+    expect(
+      resolveReleaseMetadata({
+        eventName: 'push',
+        refName: 'v2.0.0+build-linux',
+        refProtected: 'true',
+        packageVersion: '2.0.0+build-linux',
+      })
+    ).toEqual({
+      version: '2.0.0+build-linux',
+      prerelease: false,
+      channel: 'stable',
     })
   })
 

--- a/tests/scripts/release-version-contract.test.ts
+++ b/tests/scripts/release-version-contract.test.ts
@@ -277,7 +277,7 @@ describe('release version contract', () => {
     )
   })
 
-  it('preserves beta.9 finalization and Snap review disclosures', () => {
+  it('preserves beta.9 finalization and Snap prerelease-skip disclosures', () => {
     const english = read('docs/release-notes/2.0.0-beta.9.md')
     const chinese = read('docs/release-notes/2.0.0-beta.9.zh-CN.md')
     const normalizedEnglish = english.replace(/\s+/g, ' ')
@@ -287,6 +287,7 @@ describe('release version contract', () => {
       /<release version="2\.0\.0-beta\.9"[\s\S]*?<\/release>/.exec(
         metainfo
       )?.[0] ?? ''
+    const normalizedBeta9Metainfo = beta9Metainfo.replace(/\s+/g, ' ')
 
     expect(english).toContain(
       'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.9/docs/release-notes/2.0.0-beta.8.md'
@@ -316,10 +317,13 @@ describe('release version contract', () => {
       'the project will not bypass or weaken it in code'
     )
     expect(normalizedEnglish).toContain(
-      'The `v2.0.0-beta.9` tag must wait until that declaration is approved'
+      'Snap is not part of the beta.9 distribution'
     )
     expect(normalizedEnglish).toContain(
-      'a beta.9 Snap must not be considered available from `latest/edge`'
+      'Protected prerelease Snap runs stop after source validation'
+    )
+    expect(normalizedEnglish).toContain(
+      'they do not build Snap artifacts, upload Store revisions, or change `latest/edge`'
     )
     expect(normalizedChinese).toContain(
       '在隔离的 Finalize runtime 内安装由 lockfile 固定的完整 verifier dependency closure'
@@ -335,10 +339,13 @@ describe('release version contract', () => {
       '需要由 Canonical 签名的 Store declaration'
     )
     expect(normalizedChinese).toContain('项目不会通过代码绕过或弱化该要求')
+    expect(normalizedChinese).toContain('Snap 不属于 beta.9 的分发范围')
     expect(normalizedChinese).toContain(
-      '`v2.0.0-beta.9` tag 必须等待该 declaration 获批'
+      '受保护的预发布 Snap run 会在 source validation 后停止'
     )
-    expect(normalizedChinese).toContain('本说明不表示 beta.9 Snap 已公开提供')
+    expect(normalizedChinese).toContain(
+      '不会构建 Snap artifact、上传 Store revision 或修改 `latest/edge`'
+    )
     for (const source of [english, chinese]) {
       expect(source).toContain('2.0.0-beta.9')
       expect(source).toContain('latest/edge')
@@ -362,8 +369,10 @@ describe('release version contract', () => {
     expect(beta9Metainfo).toContain(
       'tool-runtime cleanup between package verification'
     )
+    expect(normalizedBeta9Metainfo).toContain(
+      'Prerelease Snap runs stop after source validation'
+    )
     expect(beta9Metainfo).toContain('personal-files')
-    expect(beta9Metainfo).toContain('allow-installation')
     expect(beta9Metainfo).not.toMatch(restrictedPublicLanguage)
     expect(beta9Metainfo).not.toMatch(secretLikeIdentifier)
   })

--- a/tests/scripts/workflow-release-matrix.test.ts
+++ b/tests/scripts/workflow-release-matrix.test.ts
@@ -758,6 +758,9 @@ describe('release workflow publication contract', () => {
 
     const triggers = asRecord(releaseWorkflow.on, 'release workflow triggers')
     expect(triggers).toHaveProperty('workflow_dispatch')
+    expect(asRecord(triggers.push, 'release push trigger')).toEqual({
+      tags: ['v*'],
+    })
 
     const publishJob = asRecord(jobs.publish, 'publish job')
     const publishCondition = stringField(publishJob, 'if')

--- a/tests/scripts/workflow-snap.test.ts
+++ b/tests/scripts/workflow-snap.test.ts
@@ -166,12 +166,24 @@ describe('Snap build workflow contract', () => {
     }
   })
 
-  it('publishes only protected tags through the edge environment', () => {
+  it('publishes only protected stable tags through the edge environment', () => {
+    const preflight = workflowJob(snapWorkflow, 'preflight')
+    const preflightOutputs = asRecord(preflight.outputs, 'preflight outputs')
+    const build = workflowJob(snapWorkflow, 'build')
     const publish = workflowJob(snapWorkflow, 'publish-edge')
+    const buildCondition = stringField(build, 'if')
     const condition = stringField(publish, 'if')
     const environment = asRecord(publish.environment, 'publish environment')
 
+    expect(stringField(preflightOutputs, 'prerelease')).toBe(
+      `\${{ steps.metadata.outputs.prerelease }}`
+    )
+    expect(buildCondition).toContain("github.event_name != 'push'")
+    expect(buildCondition).toContain(
+      "needs.preflight.outputs.prerelease == 'false'"
+    )
     expect(condition).toContain("github.event_name == 'push'")
+    expect(condition).toContain("needs.preflight.outputs.prerelease == 'false'")
     expect(condition).toContain("startsWith(github.ref, 'refs/tags/v')")
     expect(condition).toContain('github.ref_protected == true')
     expect(stringField(environment, 'name')).toBe('snap-store-edge')


### PR DESCRIPTION
Summary:
- stop prerelease Snap runs after validated source metadata
- keep stable tag publication plus PR and manual Snap builds unchanged
- update beta.9 documentation and release policy to state that this beta does not publish Snap
- add fail-closed workflow and SemVer build-metadata contracts

Validation:
- full tests/scripts: 40 files, 509 tests
- actionlint for release and Snap workflows
- Biome, TypeScript, boundaries, file names, Flatpak/XML, and diff checks