### PR TITLE
fix(release): isolate macos signing keychain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1075,6 +1075,136 @@ jobs:
           })
           fs.chmodSync(certificatePath, 0o600)
 
+      - name: Prepare isolated macOS signing keychain
+        id: mac-keychain
+        if: matrix.platform == 'darwin'
+        shell: node {0}
+        env:
+          MAC_CERTIFICATE_PATH: ${{ steps.mac-certificate.outputs.path }}
+          MAC_CERTS_PASSWORD: ${{ secrets.MAC_CERTS_PASSWORD }}
+          KEYCHAIN_PARENT: ${{ runner.temp }}
+        run: |
+          const { spawnSync } = require('node:child_process')
+          const crypto = require('node:crypto')
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const parent = fs.realpathSync(process.env.KEYCHAIN_PARENT)
+          const certificatePath = fs.realpathSync(
+            process.env.MAC_CERTIFICATE_PATH
+          )
+          const certificateRelative = path.relative(parent, certificatePath)
+          if (
+            !certificateRelative ||
+            certificateRelative === '..' ||
+            certificateRelative.startsWith(`..${path.sep}`) ||
+            path.isAbsolute(certificateRelative)
+          ) {
+            throw new Error('macOS signing certificate is outside runner temp')
+          }
+          const certificatePassword = process.env.MAC_CERTS_PASSWORD
+          if (!certificatePassword) {
+            throw new Error('macOS signing certificate password is missing')
+          }
+          const directory = fs.mkdtempSync(
+            path.join(parent, 'motrix-mac-keychain-')
+          )
+          fs.chmodSync(directory, 0o700)
+          const keychainPath = path.join(directory, 'signing.keychain-db')
+          const originalListPath = path.join(directory, 'original-keychains.json')
+          fs.appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `directory=${directory}\npath=${keychainPath}\noriginal_list=${originalListPath}\n`,
+            'utf8'
+          )
+          const security = (args, operation) => {
+            const result = spawnSync('/usr/bin/security', args, {
+              encoding: 'utf8',
+              maxBuffer: 1024 * 1024,
+              shell: false,
+            })
+            if (result.error || result.status !== 0) {
+              throw new Error(`macOS signing keychain ${operation} failed`)
+            }
+            return result.stdout
+          }
+          const originalKeychains = security(
+            ['list-keychains', '-d', 'user'],
+            'inventory'
+          )
+            .split('\n')
+            .map((line) => line.trim())
+            .filter(Boolean)
+            .map((line) =>
+              line.startsWith('"') && line.endsWith('"')
+                ? line.slice(1, -1)
+                : line
+            )
+          fs.writeFileSync(originalListPath, JSON.stringify(originalKeychains), {
+            flag: 'wx',
+            mode: 0o600,
+          })
+          let keychainPassword
+          do {
+            keychainPassword = crypto.randomBytes(48).toString('base64url')
+          } while (keychainPassword === certificatePassword)
+          security(
+            ['create-keychain', '-p', keychainPassword, keychainPath],
+            'creation'
+          )
+          security(
+            ['unlock-keychain', '-p', keychainPassword, keychainPath],
+            'unlock'
+          )
+          security(
+            ['set-keychain-settings', '-lut', '21600', keychainPath],
+            'settings'
+          )
+          security(
+            [
+              'import',
+              certificatePath,
+              '-k',
+              keychainPath,
+              '-T',
+              '/usr/bin/codesign',
+              '-T',
+              '/usr/bin/productbuild',
+              '-P',
+              certificatePassword,
+            ],
+            'certificate import'
+          )
+          security(
+            [
+              'set-key-partition-list',
+              '-S',
+              'apple-tool:,apple:',
+              '-s',
+              '-k',
+              keychainPassword,
+              keychainPath,
+            ],
+            'partition configuration'
+          )
+          security(
+            [
+              'list-keychains',
+              '-d',
+              'user',
+              '-s',
+              keychainPath,
+              ...originalKeychains,
+            ],
+            'search-list configuration'
+          )
+          const identities = security(
+            ['find-identity', '-v', '-p', 'codesigning', keychainPath],
+            'identity verification'
+          )
+          if (!/Developer ID Application:/u.test(identities)) {
+            throw new Error('macOS signing identity is unavailable')
+          }
+
       - name: Electron Builder (macOS signing boundary)
         if: matrix.platform == 'darwin'
         shell: bash
@@ -1083,8 +1213,7 @@ jobs:
           ELECTRON_BUILDER_CACHE: ${{ runner.temp }}/motrix-signing-cache
           ELECTRON_DOWNLOAD_CACHE_MODE: '1'
           ELECTRON_BUILDER_CLI: ${{ steps.signing-tool-runtime.outputs.cli }}
-          CSC_LINK: ${{ steps.mac-certificate.outputs.path }}
-          CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTS_PASSWORD }}
+          CSC_KEYCHAIN: ${{ steps.mac-keychain.outputs.path }}
           CSC_IDENTITY_AUTO_DISCOVERY: 'true'
           APPLE_API_KEY: ${{ steps.apple-api-key.outputs.path }}
           APPLE_API_KEY_ID: ${{ secrets.API_KEY_ID }}
@@ -1095,6 +1224,8 @@ jobs:
           unset NPM_CONFIG_ELECTRON_BUILDER_BINARIES_CUSTOM_DIR
           unset npm_config_electron_builder_binaries_custom_dir
           unset npm_package_config_electron_builder_binaries_custom_dir
+          unset CSC_LINK
+          unset CSC_KEY_PASSWORD
           node "$ELECTRON_BUILDER_CLI" \
             --config electron-builder.signing.json \
             ${{ matrix.electron_builder_args }} \
@@ -1129,8 +1260,12 @@ jobs:
           APPLE_API_KEY_PATH: ${{ steps.apple-api-key.outputs.path }}
           MAC_CERTIFICATE_DIRECTORY: ${{ steps.mac-certificate.outputs.directory }}
           MAC_CERTIFICATE_PATH: ${{ steps.mac-certificate.outputs.path }}
+          MAC_KEYCHAIN_DIRECTORY: ${{ steps.mac-keychain.outputs.directory }}
+          MAC_KEYCHAIN_PATH: ${{ steps.mac-keychain.outputs.path }}
+          MAC_ORIGINAL_KEYCHAIN_LIST: ${{ steps.mac-keychain.outputs.original_list }}
           TEMPORARY_ROOT: ${{ runner.temp }}
         run: |
+          const { spawnSync } = require('node:child_process')
           const fs = require('node:fs')
           const path = require('node:path')
           const root = path.resolve(process.env.TEMPORARY_ROOT)
@@ -1148,18 +1283,80 @@ jobs:
             }
             return candidate
           }
+          const failures = []
+          const security = (args, operation) => {
+            const result = spawnSync('/usr/bin/security', args, {
+              encoding: 'utf8',
+              maxBuffer: 1024 * 1024,
+              shell: false,
+            })
+            if (result.error || result.status !== 0) {
+              failures.push(operation)
+            }
+          }
+          const keychainPath = insideRoot(process.env.MAC_KEYCHAIN_PATH)
+          const originalListPath = insideRoot(
+            process.env.MAC_ORIGINAL_KEYCHAIN_LIST
+          )
+          if (keychainPath) {
+            if (originalListPath && fs.existsSync(originalListPath)) {
+              let originalKeychains
+              try {
+                originalKeychains = JSON.parse(
+                  fs.readFileSync(originalListPath, 'utf8')
+                )
+                if (
+                  !Array.isArray(originalKeychains) ||
+                  originalKeychains.some((value) => typeof value !== 'string')
+                ) {
+                  throw new Error('invalid keychain inventory')
+                }
+                security(
+                  ['list-keychains', '-d', 'user', '-s', ...originalKeychains],
+                  'keychain search-list restoration'
+                )
+              } catch {
+                failures.push('keychain inventory restoration')
+              }
+            } else if (fs.existsSync(keychainPath)) {
+              failures.push('keychain inventory restoration')
+            }
+          }
+          if (keychainPath && fs.existsSync(keychainPath)) {
+            security(
+              ['delete-keychain', keychainPath],
+              'isolated keychain deletion'
+            )
+          }
           for (const value of [
             process.env.APPLE_API_KEY_PATH,
             process.env.MAC_CERTIFICATE_PATH,
+            process.env.MAC_ORIGINAL_KEYCHAIN_LIST,
           ]) {
             const candidate = insideRoot(value)
-            if (candidate) fs.rmSync(candidate, { force: true })
+            if (candidate) {
+              try {
+                fs.rmSync(candidate, { force: true })
+              } catch {
+                failures.push('temporary credential deletion')
+              }
+            }
           }
-          for (const value of [process.env.MAC_CERTIFICATE_DIRECTORY]) {
+          for (const value of [
+            process.env.MAC_CERTIFICATE_DIRECTORY,
+            process.env.MAC_KEYCHAIN_DIRECTORY,
+          ]) {
             const candidate = insideRoot(value)
             if (candidate) {
-              fs.rmSync(candidate, { recursive: true, force: true })
+              try {
+                fs.rmSync(candidate, { recursive: true, force: true })
+              } catch {
+                failures.push('temporary credential directory deletion')
+              }
             }
+          }
+          if (failures.length > 0) {
+            throw new Error('finalization credential cleanup failed')
           }
 
       - name: Verify macOS signatures

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. After its remaining release gates pass,
-download [v2.0.0-beta.9 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.9)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.9.md) before
+download [v2.0.0-beta.10 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.10)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.10.md) before
 installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -149,7 +149,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.9'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.10'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。剩余发布门禁通过后，请从 GitHub Releases
-下载 [v2.0.0-beta.9](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.9)，
-并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.9.zh-CN.md)。
+下载 [v2.0.0-beta.10](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.10)，
+并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.10.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -143,7 +143,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.9'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.10'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.10.md
+++ b/docs/release-notes/2.0.0-beta.10.md
@@ -1,0 +1,121 @@
+# Motrix 2.0.0-beta.10
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.10/docs/release-notes/2.0.0-beta.10.zh-CN.md)
+
+Motrix 2.0.0-beta.10 is the next Motrix Turbo beta intended for public
+distribution after every protected release gate passes. It continues public
+validation of the rebuilt v2 desktop app and headless server, shared download
+core, MDXP integrations, and sandboxed plugin system.
+
+Motrix 2.0.0-beta.9 was not published. All five desktop builds completed, as
+did unsigned Windows and Apple Silicon finalization, but Intel macOS
+finalization stopped before the complete desktop package set was available.
+The
+[beta.9 historical record](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.10/docs/release-notes/2.0.0-beta.9.md)
+preserves the exact outcome.
+
+## Release reliability updates
+
+- Creates an isolated macOS keychain independently on every Finalize runner.
+  The validated signing identity is imported with its protected import value,
+  while keychain creation, unlock, and partition configuration use a separate
+  fresh per-job value.
+- Passes only the isolated keychain path to Electron Builder. Builder no
+  longer creates or imports the keychain itself, so Apple Silicon and Intel
+  finalization use the same explicit setup boundary.
+- Saves and restores the runner's original user-keychain search list, then
+  deletes the isolated keychain and its temporary directory immediately after
+  Builder. Any setup or cleanup failure prevents finalized-artifact upload.
+- Adds release contracts that lock the distinct import and unlock operations,
+  path-only Builder handoff, original search-list restoration, and cleanup
+  ordering against the pinned Electron Builder implementation.
+- Keeps Windows `x64` packages explicitly unsigned while retaining final
+  package verification before release.
+- Retains the complete desktop platform-set gate: every desktop target must
+  finalize before assembly. Protected prerelease Snap runs stop after source
+  validation.
+
+## Snap beta policy
+
+The Snap uses the `personal-files` interface only for the browser native
+messaging manifest paths verified by the build. Installing a Snap with this
+interface requires a Store declaration signed by Canonical whose
+`allow-installation` constraint permits installation. This is a Store-side
+review requirement; the project will not bypass or weaken it in code.
+
+Snap is not part of the beta.10 distribution. Protected prerelease Snap runs
+stop after source validation, so they do not build Snap artifacts, upload Store
+revisions, or change `latest/edge`. Stable Snap publication retains its
+complete two-architecture verification, Store declaration requirement, and
+protected Store gates.
+
+## Highlights
+
+- A ground-up desktop rebuild with Electron 43, React 19, and TypeScript 7,
+  including a customizable Dashboard, dark mode, a cross-platform application
+  menu, and clearer task-inspector feedback.
+- One host-neutral download core for both the desktop app and the Node/Web
+  Server, with SQLite session recovery, tracker management, UPnP/NAT-PMP, and
+  HTTP, FTP, BitTorrent, and magnet support.
+- MDXP-based integration for the official CLI and browser handoff, including
+  local discovery and device-code pairing for remote Server instances.
+- A QuickJS plugin sandbox with capability consent, bundled builtin plugins,
+  and an in-app plugin marketplace.
+- Persistent, multi-architecture Server containers for NAS and home-server
+  deployments, published to both Docker Hub and GHCR after the desktop release
+  succeeds.
+
+## Before testing
+
+This is prerelease software. Back up your existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Please do not rely on this beta for your only copy of
+important downloads.
+
+## What to test
+
+- HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
+  session recovery
+- Desktop integrations, browser and CLI handoff through MDXP, and sandboxed
+  plugins
+- Headless Server deployment, persistent storage, and remote pairing
+
+## Planned downloads after release gates pass
+
+| Distribution | Architectures | Planned output |
+|--------------|---------------|----------------|
+| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | DEB and RPM |
+| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.10-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.10` tag in both registries |
+| Snap Store | — | Not published for this beta |
+
+After publication, container images use
+`docker.io/motrixapp/motrix-server:2.0.0-beta.10` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.10`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.10/docs/docker-server.md)
+for storage, networking, and upgrade guidance.
+
+## Known distribution limits
+
+- AppImage is not published for this beta.
+- Flatpak is validated separately and is not published by the release tag;
+  the GitHub Release includes its Native Host companion archives.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
+  Download them only from the official GitHub Release after it is published.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+- Snap is not published for this beta. Prerelease Snap runs stop after source
+  validation without building or publishing Snap artifacts.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.10.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.10.zh-CN.md
@@ -1,0 +1,99 @@
+# Motrix 2.0.0-beta.10
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.10/docs/release-notes/2.0.0-beta.10.md) | 简体中文
+
+Motrix 2.0.0-beta.10 是下一次计划公开发布的 Motrix Turbo beta，但只有全部受保护
+发布门禁通过后才会进入分发。该版本继续验证重新开发的 v2 桌面应用与 Headless
+Server、共用下载内核、MDXP 集成和沙箱化插件系统。
+
+Motrix 2.0.0-beta.9 未发布。5 个桌面构建、未签名 Windows Finalize 和 Apple
+Silicon Finalize 均完成，但 Intel macOS Finalize 在完整桌面安装包集合可用前停止。
+[beta.9 历史记录](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.10/docs/release-notes/2.0.0-beta.9.zh-CN.md)
+保留了该次尝试的准确结果。
+
+## 发布可靠性更新
+
+- 每个 macOS Finalize runner 都独立创建隔离 keychain。经过验证的签名 identity
+  使用受保护的导入值进行导入；keychain 创建、解锁与 partition 配置则使用另一
+  个每次 job 随机生成的值。
+- Electron Builder 只接收隔离 keychain 路径，不再自行创建或导入 keychain，
+  因此 Apple Silicon 与 Intel Finalize 使用相同的显式准备边界。
+- 保存并恢复 runner 原有的 user keychain 搜索列表，然后在 Builder 结束后立即
+  删除隔离 keychain 及其临时目录。任何准备或清理失败都会阻止 finalized
+  artifact 上传。
+- 新增发布契约，依据固定版本的 Electron Builder 实现锁定不同的导入与解锁
+  操作、仅路径的 Builder 交接、原搜索列表恢复以及清理顺序。
+- Windows `x64` 安装包继续明确采用未签名发布，同时保留发布前的最终安装包验证。
+- 继续执行完整桌面平台集合门禁：所有桌面目标完成 Finalize 后才能组装。受保护
+  的预发布 Snap run 会在 source validation 后停止。
+
+## Snap beta 策略
+
+Snap 只为构建时已验证的浏览器 native messaging manifest 路径使用
+`personal-files` interface。安装使用该 interface 的 Snap，需要由 Canonical
+签名的 Store declaration，并由其中的 `allow-installation` constraint 允许安装。
+这是 Store 侧的审核要求；项目不会通过代码绕过或弱化该要求。
+
+Snap 不属于 beta.10 的分发范围。受保护的预发布 Snap run 会在 source validation
+后停止，因此不会构建 Snap artifact、上传 Store revision 或修改 `latest/edge`。
+稳定版 Snap 发布仍保留完整的双架构验证、Store declaration 要求与受保护 Store
+门禁。
+
+## 主要变化
+
+- 使用 Electron 43、React 19 和 TypeScript 7 从头重建桌面应用，提供可自定义
+  Dashboard、深色模式、跨平台应用菜单，以及更清晰的任务检查器反馈。
+- 桌面应用和 Node/Web Server 共用与宿主无关的下载内核，支持 SQLite session
+  恢复、Tracker 管理、UPnP/NAT-PMP，以及 HTTP、FTP、BitTorrent 和磁力链接下载。
+- 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地发现及远程 Server 的
+  device-code 配对。
+- 提供带能力授权的 QuickJS 插件沙箱、内置插件和应用内插件市场。
+- 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器；桌面发布成功后，
+  容器会同时发布到 Docker Hub 与 GHCR。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1 数据的
+迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
+
+条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录与现有环境并行
+测试 v2。请勿让本 beta 成为重要下载文件的唯一存储位置。
+
+## 建议测试项
+
+- HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
+- 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
+- Headless Server 部署、数据持久化和远程配对
+
+## 发布门禁通过后的计划下载
+
+| 发布方式 | 架构 | 计划产物 |
+|----------|------|----------|
+| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
+| Windows | `x64` | 未签名的 NSIS 安装包（`.exe`）和 ZIP |
+| Linux | `x64`、`arm64` | DEB 和 RPM |
+| Flatpak Native Host 配套程序 | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.10-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中不可变的 `2.0.0-beta.10` tag |
+| Snap Store | — | 本 beta 不发布 |
+
+发布完成后，容器镜像地址为
+`docker.io/motrixapp/motrix-server:2.0.0-beta.10` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.10`。数据持久化、网络和升级方法请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.10/docs/docker-server.zh-CN.md)。
+
+## 已知发布限制
+
+- 本 beta 不发布 AppImage。
+- Flatpak 会单独验证，不会随该版本 tag 发布；GitHub Release 会包含其 Native
+  Host 配套程序压缩包。
+- 不提供 Windows `arm64` 和任何 32 位安装包。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅在正式发布后
+  从 GitHub 官方 Release 下载。
+- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
+- 本 beta 不发布 Snap。预发布 Snap run 会在 source validation 后停止，不会构建
+  或发布 Snap artifact。
+
+## 反馈
+
+请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现的问题，
+并附上操作系统、架构、安装包类型和复现步骤。

--- a/docs/release-notes/2.0.0-beta.9.md
+++ b/docs/release-notes/2.0.0-beta.9.md
@@ -1,118 +1,25 @@
 # Motrix 2.0.0-beta.9
 
-English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.9/docs/release-notes/2.0.0-beta.9.zh-CN.md)
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.10/docs/release-notes/2.0.0-beta.9.zh-CN.md)
 
-Motrix 2.0.0-beta.9 is the next Motrix Turbo beta intended for public
-distribution after every protected release gate passes. It continues public
-validation of the rebuilt v2 desktop app and headless server, shared download
-core, MDXP integrations, and sandboxed plugin system.
+> Motrix 2.0.0-beta.9 was not published. This historical record was
+> backfilled for beta.10.
 
-Motrix 2.0.0-beta.8 was not published. All five desktop builds and both Snap
-builds succeeded, but final desktop verification and Snap Store processing did
-not complete. The
+All five desktop build jobs completed successfully. The explicitly unsigned
+Windows Finalize job and the Apple Silicon macOS Finalize job both completed
+their full package verification. Intel macOS Finalize stopped in the macOS 26
+signing runtime before its final package set was produced.
+
+The complete desktop platform-set gate therefore prevented assembly. The
+GitHub Release, R2 update feed, and Docker Hub/GHCR container publication did
+not run. The protected prerelease Snap workflow passed source validation and,
+as designed, skipped both architecture builds and Store publication.
+
+No GitHub Release, update feed, container image, or public Snap channel was
+created. External distribution remained zero.
+
+Motrix 2.0.0-beta.10 supersedes this unpublished attempt. See the
+[beta.10 release notes](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.10/docs/release-notes/2.0.0-beta.10.md)
+for the next planned beta.
+
 [beta.8 historical record](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.9/docs/release-notes/2.0.0-beta.8.md)
-preserves the exact outcome.
-
-## Release reliability updates
-
-- Installs a complete, lockfile-pinned verifier dependency closure inside the
-  isolated finalization runtime. The verifier can resolve `@electron/asar`
-  without consulting the staged application or the repository dependency
-  tree.
-- Removes temporary signing inputs as soon as the Electron Builder step ends,
-  before final package verification begins.
-- Removes the isolated finalization and verification tool runtime after final
-  package verification and before finalized-artifact upload. A cleanup failure
-  prevents the upload from starting.
-- Adds release contracts for the pinned verifier closure and both cleanup
-  boundaries, including failure paths.
-- Keeps Windows `x64` packages explicitly unsigned while retaining final
-  package verification before release.
-- Retains the complete desktop platform-set gate: every desktop target must
-  finalize before assembly. Protected prerelease Snap runs stop after source
-  validation.
-
-## Snap beta policy
-
-The Snap uses the `personal-files` interface only for the browser native
-messaging manifest paths verified by the build. Installing a Snap with this
-interface requires a Store declaration signed by Canonical whose
-`allow-installation` constraint permits installation. This is a Store-side
-review requirement; the project will not bypass or weaken it in code.
-
-Snap is not part of the beta.9 distribution. Protected prerelease Snap runs
-stop after source validation, so they do not build Snap artifacts, upload Store
-revisions, or change `latest/edge`. Stable Snap publication retains its
-complete two-architecture verification, Store declaration requirement, and
-protected Store gates.
-
-## Highlights
-
-- A ground-up desktop rebuild with Electron 43, React 19, and TypeScript 7,
-  including a customizable Dashboard, dark mode, a cross-platform application
-  menu, and clearer task-inspector feedback.
-- One host-neutral download core for both the desktop app and the Node/Web
-  Server, with SQLite session recovery, tracker management, UPnP/NAT-PMP, and
-  HTTP, FTP, BitTorrent, and magnet support.
-- MDXP-based integration for the official CLI and browser handoff, including
-  local discovery and device-code pairing for remote Server instances.
-- A QuickJS plugin sandbox with capability consent, bundled builtin plugins,
-  and an in-app plugin marketplace.
-- Persistent, multi-architecture Server containers for NAS and home-server
-  deployments, published to both Docker Hub and GHCR after the desktop release
-  succeeds.
-
-## Before testing
-
-This is prerelease software. Back up your existing Motrix application data and
-downloads before installing it. Migration from Motrix v1 data has not yet been
-validated, so do not use your only copy of v1 data with this beta.
-
-When practical, test v2 in parallel using a separate OS account, machine, or
-Docker data directory. Please do not rely on this beta for your only copy of
-important downloads.
-
-## What to test
-
-- HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
-  session recovery
-- Desktop integrations, browser and CLI handoff through MDXP, and sandboxed
-  plugins
-- Headless Server deployment, persistent storage, and remote pairing
-
-## Planned downloads after release gates pass
-
-| Distribution | Architectures | Planned output |
-|--------------|---------------|----------------|
-| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
-| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
-| Linux | `x64`, `arm64` | DEB and RPM |
-| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.9-linux-<arch>.tar.gz` |
-| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.9` tag in both registries |
-| Snap Store | — | Not published for this beta |
-
-After publication, container images use
-`docker.io/motrixapp/motrix-server:2.0.0-beta.9` and
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.9`. See the
-[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.9/docs/docker-server.md)
-for storage, networking, and upgrade guidance.
-
-## Known distribution limits
-
-- AppImage is not published for this beta.
-- Flatpak is validated separately and is not published by the release tag;
-  the GitHub Release includes its Native Host companion archives.
-- Windows `arm64` and all 32-bit packages are not available.
-- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
-  Download them only from the official GitHub Release after it is published.
-- Beta container tags are immutable and do not update `latest`, `stable`, or
-  other stable floating tags.
-- Snap is not published for this beta. Prerelease Snap runs stop after source
-  validation without building or publishing Snap artifacts.
-
-## Feedback
-
-Please report reproducible problems through
-[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
-operating system, architecture, package type, and the steps needed to reproduce
-the issue.

--- a/docs/release-notes/2.0.0-beta.9.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.9.zh-CN.md
@@ -1,95 +1,21 @@
 # Motrix 2.0.0-beta.9
 
-[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.9/docs/release-notes/2.0.0-beta.9.md) | 简体中文
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.10/docs/release-notes/2.0.0-beta.9.md) | 简体中文
 
-Motrix 2.0.0-beta.9 是下一次计划公开发布的 Motrix Turbo beta，但只有全部受保护
-发布门禁通过后才会进入分发。该版本继续验证重新开发的 v2 桌面应用与 Headless
-Server、共用下载内核、MDXP 集成和沙箱化插件系统。
+> Motrix 2.0.0-beta.9 未发布。本历史记录在 beta.10 中回填。
 
-Motrix 2.0.0-beta.8 未发布。5 个桌面构建和两个 Snap 构建均成功，但桌面最终
-验证与 Snap Store processing 未能完成。
+5 个桌面构建 job 均成功完成。明确采用未签名模式的 Windows Finalize job 与
+Apple Silicon macOS Finalize job 均完成了完整安装包验证。Intel macOS Finalize
+在生成最终安装包集合前停止于 macOS 26 签名 runtime。
+
+因此，完整桌面平台集合门禁阻止了产物组装。GitHub Release、R2 更新数据源以及
+Docker Hub/GHCR 容器发布均未执行。受保护的预发布 Snap workflow 通过 source
+validation 后，按设计跳过了两个架构构建与 Store 发布。
+
+没有创建 GitHub Release、更新数据源、容器镜像或公开 Snap channel，外部分发
+为零。
+
+Motrix 2.0.0-beta.10 已取代这次未发布的尝试。下一版 beta 请参阅
+[beta.10 发布说明](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.10/docs/release-notes/2.0.0-beta.10.zh-CN.md)。
+
 [beta.8 历史记录](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.9/docs/release-notes/2.0.0-beta.8.zh-CN.md)
-保留了该次尝试的准确结果。
-
-## 发布可靠性更新
-
-- 在隔离的 Finalize runtime 内安装由 lockfile 固定的完整 verifier dependency
-  closure。verifier 无需查询已暂存应用或仓库依赖树即可解析 `@electron/asar`。
-- Electron Builder 步骤结束后立即删除签名临时输入，再开始最终安装包验证。
-- 最终安装包验证完成后、finalized artifact 上传前，删除隔离的 Finalize 与验证
-  工具 runtime；清理失败会阻止上传开始。
-- 新增发布契约，固定 verifier closure 与两处清理边界，并覆盖失败路径。
-- Windows `x64` 安装包继续明确采用未签名发布，同时保留发布前的最终安装包验证。
-- 继续执行完整桌面平台集合门禁：所有桌面目标完成 Finalize 后才能组装。受保护
-  的预发布 Snap run 会在 source validation 后停止。
-
-## Snap beta 策略
-
-Snap 只为构建时已验证的浏览器 native messaging manifest 路径使用
-`personal-files` interface。安装使用该 interface 的 Snap，需要由 Canonical
-签名的 Store declaration，并由其中的 `allow-installation` constraint 允许安装。
-这是 Store 侧的审核要求；项目不会通过代码绕过或弱化该要求。
-
-Snap 不属于 beta.9 的分发范围。受保护的预发布 Snap run 会在 source validation
-后停止，因此不会构建 Snap artifact、上传 Store revision 或修改 `latest/edge`。
-稳定版 Snap 发布仍保留完整的双架构验证、Store declaration 要求与受保护 Store
-门禁。
-
-## 主要变化
-
-- 使用 Electron 43、React 19 和 TypeScript 7 从头重建桌面应用，提供可自定义
-  Dashboard、深色模式、跨平台应用菜单，以及更清晰的任务检查器反馈。
-- 桌面应用和 Node/Web Server 共用与宿主无关的下载内核，支持 SQLite session
-  恢复、Tracker 管理、UPnP/NAT-PMP，以及 HTTP、FTP、BitTorrent 和磁力链接下载。
-- 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地发现及远程 Server 的
-  device-code 配对。
-- 提供带能力授权的 QuickJS 插件沙箱、内置插件和应用内插件市场。
-- 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器；桌面发布成功后，
-  容器会同时发布到 Docker Hub 与 GHCR。
-
-## 测试前须知
-
-这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1 数据的
-迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
-
-条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录与现有环境并行
-测试 v2。请勿让本 beta 成为重要下载文件的唯一存储位置。
-
-## 建议测试项
-
-- HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
-- 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
-- Headless Server 部署、数据持久化和远程配对
-
-## 发布门禁通过后的计划下载
-
-| 发布方式 | 架构 | 计划产物 |
-|----------|------|----------|
-| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
-| Windows | `x64` | 未签名的 NSIS 安装包（`.exe`）和 ZIP |
-| Linux | `x64`、`arm64` | DEB 和 RPM |
-| Flatpak Native Host 配套程序 | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.9-linux-<arch>.tar.gz` |
-| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中不可变的 `2.0.0-beta.9` tag |
-| Snap Store | — | 本 beta 不发布 |
-
-发布完成后，容器镜像地址为
-`docker.io/motrixapp/motrix-server:2.0.0-beta.9` 和
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.9`。数据持久化、网络和升级方法请参阅
-[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.9/docs/docker-server.zh-CN.md)。
-
-## 已知发布限制
-
-- 本 beta 不发布 AppImage。
-- Flatpak 会单独验证，不会随该版本 tag 发布；GitHub Release 会包含其 Native
-  Host 配套程序压缩包。
-- 不提供 Windows `arm64` 和任何 32 位安装包。
-- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅在正式发布后
-  从 GitHub 官方 Release 下载。
-- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
-- 本 beta 不发布 Snap。预发布 Snap run 会在 source validation 后停止，不会构建
-  或发布 Snap artifact。
-
-## 反馈
-
-请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现的问题，
-并附上操作系统、架构、安装包类型和复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -76,16 +76,28 @@
   <releases>
     <!-- Update this list on every release; Flathub linter requires the most
          recent version listed here to match the manifest's source tag. -->
+    <release version="2.0.0-beta.10" date="2026-08-16">
+      <description>
+        <p>
+          Release finalization update with an isolated per-job macOS keychain,
+          distinct import and keychain-unlock values, path-only Builder
+          handoff, and fail-closed cleanup. Windows packages remain unsigned.
+          Prerelease Snap runs stop after source validation without building
+          or publishing artifacts; stable Snap publication retains its
+          personal-files Store declaration requirement.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.9" date="2026-08-16">
       <description>
         <p>
-          Release finalization update with a lockfile-pinned verifier closure
-          in an isolated runtime, temporary signing-input cleanup immediately
-          after Builder, and tool-runtime cleanup between package verification
-          and artifact upload. Windows packages remain unsigned. Prerelease
-          Snap runs stop after source validation without building or
-          publishing artifacts; stable Snap publication retains its
-          personal-files Store declaration requirement.
+          Unpublished Motrix Turbo beta attempt. All five desktop builds
+          succeeded. Unsigned Windows and Apple Silicon finalization completed,
+          while Intel macOS finalization stopped in the signing runtime before
+          producing its final package set. Assembly, GitHub Release, R2, and
+          container publication did not run. The prerelease Snap workflow
+          stopped after source validation, and external distribution remained
+          zero.
         </p>
       </description>
     </release>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.9",
+  "version": "2.0.0-beta.10",
   "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1",
   "description": "A full-featured download manager",
   "keywords": [],

--- a/tests/scripts/release-version-contract.test.ts
+++ b/tests/scripts/release-version-contract.test.ts
@@ -277,7 +277,7 @@ describe('release version contract', () => {
     )
   })
 
-  it('preserves beta.9 finalization and Snap prerelease-skip disclosures', () => {
+  it('records beta.9 as an unpublished finalization attempt', () => {
     const english = read('docs/release-notes/2.0.0-beta.9.md')
     const chinese = read('docs/release-notes/2.0.0-beta.9.zh-CN.md')
     const normalizedEnglish = english.replace(/\s+/g, ' ')
@@ -290,91 +290,145 @@ describe('release version contract', () => {
     const normalizedBeta9Metainfo = beta9Metainfo.replace(/\s+/g, ' ')
 
     expect(english).toContain(
-      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.9/docs/release-notes/2.0.0-beta.8.md'
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.10/docs/release-notes/2.0.0-beta.9.zh-CN.md'
     )
     expect(chinese).toContain(
-      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.9/docs/release-notes/2.0.0-beta.8.zh-CN.md'
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.10/docs/release-notes/2.0.0-beta.9.md'
+    )
+    expect(normalizedEnglish).toContain('Motrix 2.0.0-beta.9 was not published')
+    expect(normalizedEnglish).toContain(
+      'All five desktop build jobs completed successfully'
     )
     expect(normalizedEnglish).toContain(
-      'Installs a complete, lockfile-pinned verifier dependency closure inside the isolated finalization runtime'
+      'The explicitly unsigned Windows Finalize job and the Apple Silicon macOS Finalize job both completed their full package verification'
     )
     expect(normalizedEnglish).toContain(
-      'The verifier can resolve `@electron/asar` without consulting the staged application or the repository dependency tree'
+      'Intel macOS Finalize stopped in the macOS 26 signing runtime before its final package set was produced'
     )
     expect(normalizedEnglish).toContain(
-      'Removes temporary signing inputs as soon as the Electron Builder step ends, before final package verification begins'
+      'The complete desktop platform-set gate therefore prevented assembly'
     )
     expect(normalizedEnglish).toContain(
-      'Removes the isolated finalization and verification tool runtime after final package verification and before finalized-artifact upload'
+      'The GitHub Release, R2 update feed, and Docker Hub/GHCR container publication did not run'
     )
     expect(normalizedEnglish).toContain(
-      'A cleanup failure prevents the upload from starting'
+      'The protected prerelease Snap workflow passed source validation and, as designed, skipped both architecture builds and Store publication'
     )
-    expect(normalizedEnglish).toContain(
-      'Installing a Snap with this interface requires a Store declaration signed by Canonical'
-    )
-    expect(normalizedEnglish).toContain(
-      'the project will not bypass or weaken it in code'
-    )
-    expect(normalizedEnglish).toContain(
-      'Snap is not part of the beta.9 distribution'
-    )
-    expect(normalizedEnglish).toContain(
-      'Protected prerelease Snap runs stop after source validation'
-    )
-    expect(normalizedEnglish).toContain(
-      'they do not build Snap artifacts, upload Store revisions, or change `latest/edge`'
+    expect(normalizedEnglish).toContain('External distribution remained zero')
+    expect(normalizedChinese).toContain('Motrix 2.0.0-beta.9 未发布')
+    expect(normalizedChinese).toContain('5 个桌面构建 job 均成功完成')
+    expect(normalizedChinese).toContain(
+      'Windows Finalize job 与 Apple Silicon macOS Finalize job 均完成了完整安装包验证'
     )
     expect(normalizedChinese).toContain(
-      '在隔离的 Finalize runtime 内安装由 lockfile 固定的完整 verifier dependency closure'
+      'Intel macOS Finalize 在生成最终安装包集合前停止于 macOS 26 签名 runtime'
     )
+    expect(normalizedChinese).toContain('完整桌面平台集合门禁阻止了产物组装')
     expect(normalizedChinese).toContain(
-      'Electron Builder 步骤结束后立即删除签名临时输入'
+      '受保护的预发布 Snap workflow 通过 source validation 后，按设计跳过了两个架构构建与 Store 发布'
     )
-    expect(normalizedChinese).toContain(
-      '最终安装包验证完成后、finalized artifact 上传前，删除隔离的 Finalize 与验证 工具 runtime'
-    )
-    expect(normalizedChinese).toContain('清理失败会阻止上传开始')
-    expect(normalizedChinese).toContain(
-      '需要由 Canonical 签名的 Store declaration'
-    )
-    expect(normalizedChinese).toContain('项目不会通过代码绕过或弱化该要求')
-    expect(normalizedChinese).toContain('Snap 不属于 beta.9 的分发范围')
-    expect(normalizedChinese).toContain(
-      '受保护的预发布 Snap run 会在 source validation 后停止'
-    )
-    expect(normalizedChinese).toContain(
-      '不会构建 Snap artifact、上传 Store revision 或修改 `latest/edge`'
-    )
+    expect(normalizedChinese).toContain('外部分发 为零')
     for (const source of [english, chinese]) {
       expect(source).toContain('2.0.0-beta.9')
-      expect(source).toContain('latest/edge')
-      expect(source).toContain('personal-files')
-      expect(source).toContain('allow-installation')
-      expect(source).toContain('AppImage')
-      expect(source).toContain('Flatpak')
-      expect(source).toContain(
-        'Motrix-Native-Host-2.0.0-beta.9-linux-<arch>.tar.gz'
-      )
-      expect(source).toContain('SmartScreen')
-      expect(source).toContain('docker.io/motrixapp/motrix-server:2.0.0-beta.9')
-      expect(source).toContain('ghcr.io/agalwood/motrix-server:2.0.0-beta.9')
+      expect(source).toContain('2.0.0-beta.10')
       expect(source).not.toMatch(restrictedPublicLanguage)
       expect(source).not.toMatch(secretLikeIdentifier)
     }
     expect(metainfo).toContain(
       '<release version="2.0.0-beta.9" date="2026-08-16">'
     )
-    expect(beta9Metainfo).toContain('lockfile-pinned verifier closure')
-    expect(beta9Metainfo).toContain(
-      'tool-runtime cleanup between package verification'
+    expect(beta9Metainfo).toContain('All five desktop builds')
+    expect(normalizedBeta9Metainfo).toContain(
+      'Intel macOS finalization stopped in the signing runtime'
     )
     expect(normalizedBeta9Metainfo).toContain(
-      'Prerelease Snap runs stop after source validation'
+      'The prerelease Snap workflow stopped after source validation'
     )
-    expect(beta9Metainfo).toContain('personal-files')
+    expect(normalizedBeta9Metainfo).toContain(
+      'external distribution remained zero'
+    )
     expect(beta9Metainfo).not.toMatch(restrictedPublicLanguage)
     expect(beta9Metainfo).not.toMatch(secretLikeIdentifier)
+  })
+
+  it('preserves beta.10 isolated-keychain and Snap disclosures', () => {
+    const english = read('docs/release-notes/2.0.0-beta.10.md')
+    const chinese = read('docs/release-notes/2.0.0-beta.10.zh-CN.md')
+    const normalizedEnglish = english.replace(/\s+/g, ' ')
+    const normalizedChinese = chinese.replace(/\s+/g, ' ')
+    const metainfo = read('flatpak/app.motrix.native.metainfo.xml')
+    const beta10Metainfo =
+      /<release version="2\.0\.0-beta\.10"[\s\S]*?<\/release>/.exec(
+        metainfo
+      )?.[0] ?? ''
+    const normalizedBeta10Metainfo = beta10Metainfo.replace(/\s+/g, ' ')
+
+    expect(english).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.10/docs/release-notes/2.0.0-beta.9.md'
+    )
+    expect(chinese).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.10/docs/release-notes/2.0.0-beta.9.zh-CN.md'
+    )
+    expect(normalizedEnglish).toContain(
+      'Creates an isolated macOS keychain independently on every Finalize runner'
+    )
+    expect(normalizedEnglish).toContain(
+      'keychain creation, unlock, and partition configuration use a separate fresh per-job value'
+    )
+    expect(normalizedEnglish).toContain(
+      'Passes only the isolated keychain path to Electron Builder'
+    )
+    expect(normalizedEnglish).toContain(
+      "Saves and restores the runner's original user-keychain search list"
+    )
+    expect(normalizedEnglish).toContain(
+      'Any setup or cleanup failure prevents finalized-artifact upload'
+    )
+    expect(normalizedChinese).toContain(
+      '每个 macOS Finalize runner 都独立创建隔离 keychain'
+    )
+    expect(normalizedChinese).toContain(
+      'keychain 创建、解锁与 partition 配置则使用另一 个每次 job 随机生成的值'
+    )
+    expect(normalizedChinese).toContain(
+      'Electron Builder 只接收隔离 keychain 路径'
+    )
+    expect(normalizedChinese).toContain(
+      '保存并恢复 runner 原有的 user keychain 搜索列表'
+    )
+    expect(normalizedChinese).toContain(
+      '任何准备或清理失败都会阻止 finalized artifact 上传'
+    )
+    for (const source of [english, chinese]) {
+      expect(source).toContain('Snap')
+      expect(source).toContain('latest/edge')
+      expect(source).toContain('personal-files')
+      expect(source).toContain('allow-installation')
+      expect(source).toContain('AppImage')
+      expect(source).toContain('Flatpak')
+      expect(source).toContain(
+        'Motrix-Native-Host-2.0.0-beta.10-linux-<arch>.tar.gz'
+      )
+      expect(source).toContain('SmartScreen')
+      expect(source).toContain(
+        'docker.io/motrixapp/motrix-server:2.0.0-beta.10'
+      )
+      expect(source).toContain('ghcr.io/agalwood/motrix-server:2.0.0-beta.10')
+      expect(source).not.toMatch(restrictedPublicLanguage)
+      expect(source).not.toMatch(secretLikeIdentifier)
+    }
+    expect(metainfo).toContain(
+      '<release version="2.0.0-beta.10" date="2026-08-16">'
+    )
+    expect(normalizedBeta10Metainfo).toContain(
+      'isolated per-job macOS keychain'
+    )
+    expect(normalizedBeta10Metainfo).toContain('path-only Builder handoff')
+    expect(normalizedBeta10Metainfo).toContain(
+      'Windows packages remain unsigned'
+    )
+    expect(beta10Metainfo).not.toMatch(restrictedPublicLanguage)
+    expect(beta10Metainfo).not.toMatch(secretLikeIdentifier)
   })
 
   it('preserves beta.6 Snap recovery and canceled release history', () => {

--- a/tests/scripts/workflow-release-matrix.test.ts
+++ b/tests/scripts/workflow-release-matrix.test.ts
@@ -1136,17 +1136,23 @@ describe('release workflow publication contract', () => {
     const windowsStep = platformBuilderStep(builderSteps, 'win32')
     const macEnv = asRecord(macStep.env, 'macOS builder environment')
     const windowsEnv = asRecord(windowsStep.env, 'Windows builder environment')
-    expect(stringField(macEnv, 'CSC_LINK')).toContain(
-      'steps.mac-certificate.outputs.path'
+    expect(stringField(macEnv, 'CSC_KEYCHAIN')).toContain(
+      'steps.mac-keychain.outputs.path'
     )
-    expect(stringField(macEnv, 'CSC_LINK')).not.toContain('secrets.')
-    expect(stringField(macEnv, 'CSC_KEY_PASSWORD')).toContain(
-      'secrets.MAC_CERTS_PASSWORD'
-    )
+    expect(macEnv).not.toHaveProperty('CSC_LINK')
+    expect(macEnv).not.toHaveProperty('CSC_KEY_PASSWORD')
     expect(stringField(macEnv, 'ELECTRON_BUILDER_CLI')).toContain(
       'steps.signing-tool-runtime.outputs.cli'
     )
     expect(JSON.stringify(macEnv)).not.toContain('WIN_CSC')
+    const macCommand = stringField(macStep, 'run')
+    const macBuilderIndex = macCommand.indexOf('node "$ELECTRON_BUILDER_CLI"')
+    expect(macBuilderIndex).toBeGreaterThanOrEqual(0)
+    for (const variable of ['CSC_LINK', 'CSC_KEY_PASSWORD']) {
+      const unsetIndex = macCommand.indexOf(`unset ${variable}`)
+      expect(unsetIndex, variable).toBeGreaterThanOrEqual(0)
+      expect(unsetIndex, variable).toBeLessThan(macBuilderIndex)
+    }
 
     expect(windowsEnv).not.toHaveProperty('CSC_LINK')
     expect(windowsEnv).not.toHaveProperty('CSC_KEY_PASSWORD')
@@ -1413,7 +1419,7 @@ describe('release workflow publication contract', () => {
     }
   })
 
-  it('materializes only bounded P12 bytes and always removes temporary inputs', () => {
+  it('uses separate certificate and keychain passwords in an isolated keychain', () => {
     const sign = asRecord(workflowJobs(releaseWorkflow).sign, 'sign job')
     const steps = jobSteps(sign)
     const preparation = steps.find(
@@ -1442,6 +1448,71 @@ describe('release workflow publication contract', () => {
     expect(source).toContain("flag: 'wx'")
     expect(source).not.toContain('console.')
     expect(source).not.toContain('process.stdout')
+
+    const keychainPreparation = steps.find(
+      (step) => step.name === 'Prepare isolated macOS signing keychain'
+    )
+    expect(keychainPreparation).toBeDefined()
+    expect(stringField(keychainPreparation as LooseRecord, 'id')).toBe(
+      'mac-keychain'
+    )
+    expect(stringField(keychainPreparation as LooseRecord, 'shell')).toBe(
+      'node {0}'
+    )
+    expect(stringField(keychainPreparation as LooseRecord, 'if')).toBe(
+      "matrix.platform == 'darwin'"
+    )
+    const keychainEnvironment = asRecord(
+      keychainPreparation?.env,
+      'macOS keychain preparation environment'
+    )
+    expect(stringField(keychainEnvironment, 'MAC_CERTIFICATE_PATH')).toContain(
+      'steps.mac-certificate.outputs.path'
+    )
+    expect(stringField(keychainEnvironment, 'MAC_CERTS_PASSWORD')).toContain(
+      'secrets.MAC_CERTS_PASSWORD'
+    )
+    expect(stringField(keychainEnvironment, 'KEYCHAIN_PARENT')).toContain(
+      'runner.temp'
+    )
+    const keychainSource = stringField(
+      keychainPreparation as LooseRecord,
+      'run'
+    )
+    expect(keychainSource).toContain(
+      "crypto.randomBytes(48).toString('base64url')"
+    )
+    expect(keychainSource).toContain(
+      'while (keychainPassword === certificatePassword)'
+    )
+    expect(keychainSource).toContain(
+      "'create-keychain', '-p', keychainPassword"
+    )
+    expect(keychainSource).toContain(
+      "'unlock-keychain', '-p', keychainPassword"
+    )
+    expect(keychainSource).toMatch(/'-P',\s*certificatePassword/u)
+    expect(keychainSource).toMatch(/'-k',\s*keychainPassword/u)
+    expect(keychainSource).toContain(
+      "'find-identity', '-v', '-p', 'codesigning'"
+    )
+    expect(keychainSource).toContain('original-keychains.json')
+    expect(keychainSource).toContain('mode: 0o600')
+    expect(keychainSource).not.toContain('console.')
+    expect(keychainSource).not.toContain('process.stdout')
+
+    const macCodeSignSource = readFileSync(
+      require.resolve('app-builder-lib/out/codeSign/macCodeSign.js'),
+      'utf8'
+    )
+    const macPackagerSource = readFileSync(
+      require.resolve('app-builder-lib/out/macPackager.js'),
+      'utf8'
+    )
+    expect(macCodeSignSource).toContain(
+      '["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", password, keychainFile]'
+    )
+    expect(macPackagerSource).toContain('process.env.CSC_KEYCHAIN || null')
 
     const temporaryRoot = mkdtempSync(
       path.join(tmpdir(), 'motrix-mac-certificate-contract-')
@@ -1535,6 +1606,15 @@ describe('release workflow publication contract', () => {
     expect(
       stringField(credentialCleanupEnvironment, 'APPLE_API_KEY_PATH')
     ).toContain('steps.apple-api-key.outputs.path')
+    expect(
+      stringField(credentialCleanupEnvironment, 'MAC_KEYCHAIN_PATH')
+    ).toContain('steps.mac-keychain.outputs.path')
+    expect(
+      stringField(credentialCleanupEnvironment, 'MAC_KEYCHAIN_DIRECTORY')
+    ).toContain('steps.mac-keychain.outputs.directory')
+    expect(
+      stringField(credentialCleanupEnvironment, 'MAC_ORIGINAL_KEYCHAIN_LIST')
+    ).toContain('steps.mac-keychain.outputs.original_list')
     expect(credentialCleanupEnvironment).not.toHaveProperty('SIGNING_TOOL_ROOT')
     expect(JSON.stringify(credentialCleanup)).not.toContain('secrets.')
     const credentialCleanupSource = stringField(
@@ -1543,6 +1623,12 @@ describe('release workflow publication contract', () => {
     )
     expect(credentialCleanupSource).toContain('path.relative(root, candidate)')
     expect(credentialCleanupSource).toContain('fs.rmSync')
+    expect(credentialCleanupSource).toContain(
+      "['list-keychains', '-d', 'user', '-s', ...originalKeychains]"
+    )
+    expect(credentialCleanupSource).toContain(
+      "['delete-keychain', keychainPath]"
+    )
 
     const runtimeCleanup = steps.find(
       (step) => step.name === 'Remove isolated signing runtime'
@@ -1577,11 +1663,20 @@ describe('release workflow publication contract', () => {
       const apiKey = path.join(cleanupRoot, 'AuthKey.p8')
       const certificateDirectory = path.join(cleanupRoot, 'certificate')
       const certificate = path.join(certificateDirectory, 'identity.p12')
+      const keychainDirectory = path.join(cleanupRoot, 'keychain')
+      const keychain = path.join(keychainDirectory, 'signing.keychain-db')
+      const originalKeychains = path.join(
+        keychainDirectory,
+        'original-keychains.json'
+      )
       const signingTool = path.join(cleanupRoot, 'signing-tool')
       mkdirSync(certificateDirectory)
+      mkdirSync(keychainDirectory)
       mkdirSync(signingTool)
       writeFileSync(apiKey, 'api key')
       writeFileSync(certificate, 'certificate')
+      writeFileSync(keychain, 'keychain')
+      writeFileSync(originalKeychains, '[]')
       writeFileSync(path.join(signingTool, 'package.json'), '{}')
       const credentialResult = spawnSync(
         process.execPath,
@@ -1594,12 +1689,22 @@ describe('release workflow publication contract', () => {
             APPLE_API_KEY_PATH: apiKey,
             MAC_CERTIFICATE_DIRECTORY: certificateDirectory,
             MAC_CERTIFICATE_PATH: certificate,
+            MAC_KEYCHAIN_DIRECTORY: keychainDirectory,
+            MAC_KEYCHAIN_PATH: '',
+            MAC_ORIGINAL_KEYCHAIN_LIST: originalKeychains,
             TEMPORARY_ROOT: cleanupRoot,
           },
         }
       )
       expect(credentialResult.status, credentialResult.stderr).toBe(0)
-      for (const candidate of [apiKey, certificate, certificateDirectory]) {
+      for (const candidate of [
+        apiKey,
+        certificate,
+        certificateDirectory,
+        keychain,
+        originalKeychains,
+        keychainDirectory,
+      ]) {
         expect(existsSync(candidate), candidate).toBe(false)
       }
       expect(existsSync(signingTool)).toBe(true)
@@ -1632,6 +1737,9 @@ describe('release workflow publication contract', () => {
             APPLE_API_KEY_PATH: '',
             MAC_CERTIFICATE_DIRECTORY: '',
             MAC_CERTIFICATE_PATH: '',
+            MAC_KEYCHAIN_DIRECTORY: '',
+            MAC_KEYCHAIN_PATH: '',
+            MAC_ORIGINAL_KEYCHAIN_LIST: '',
             SIGNING_TOOL_ROOT: '',
             TEMPORARY_ROOT: cleanupRoot,
           },


### PR DESCRIPTION
## What changed

- create a dedicated macOS keychain on each Finalize runner
- use separate values for signing-input import and keychain unlock/partition configuration
- pass only `CSC_KEYCHAIN` to Electron Builder and restore the original keychain search list during fail-closed cleanup
- record the unpublished beta.9 outcome and prepare bilingual beta.10 release metadata
- keep prerelease Snap builds and Store publication skipped

## Why

Electron Builder 26.15.7 uses the signing-input import value when configuring its randomly generated keychain. The Intel macOS 26 runner rejects that mismatch. Managing the keychain explicitly avoids the broken automatic path and gives Apple Silicon and Intel Finalize jobs the same setup.

## Verification

- `tests/scripts`: 510 passed
- workflow/release version contracts: 63 passed
- `actionlint .github/workflows/*.yml`
- Biome checks for `src/` and changed structured files
- `tsc --noEmit`
- boundary, file-name, and Flatpak packaging checks
- AppStream XML and `git diff --check`
