### PR TITLE
fix(release): normalize macos updater manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. After its remaining release gates pass,
-download [v2.0.0-beta.10 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.10)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.10.md) before
+download [v2.0.0-beta.11 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.11)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.11.md) before
 installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -149,7 +149,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.10'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.11'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。剩余发布门禁通过后，请从 GitHub Releases
-下载 [v2.0.0-beta.10](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.10)，
-并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.10.zh-CN.md)。
+下载 [v2.0.0-beta.11](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.11)，
+并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.11.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -143,7 +143,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.10'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.11'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.10.md
+++ b/docs/release-notes/2.0.0-beta.10.md
@@ -1,121 +1,29 @@
 # Motrix 2.0.0-beta.10
 
-English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.10/docs/release-notes/2.0.0-beta.10.zh-CN.md)
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.11/docs/release-notes/2.0.0-beta.10.zh-CN.md)
 
-Motrix 2.0.0-beta.10 is the next Motrix Turbo beta intended for public
-distribution after every protected release gate passes. It continues public
-validation of the rebuilt v2 desktop app and headless server, shared download
-core, MDXP integrations, and sandboxed plugin system.
+> Motrix 2.0.0-beta.10 was not published. This historical record was
+> backfilled for beta.11.
 
-Motrix 2.0.0-beta.9 was not published. All five desktop builds completed, as
-did unsigned Windows and Apple Silicon finalization, but Intel macOS
-finalization stopped before the complete desktop package set was available.
-The
+All five desktop build jobs completed successfully. The explicitly unsigned
+Windows Finalize job and both macOS Finalize jobs also completed their full
+package verification and uploaded their verified final inputs.
+
+Assembly then rejected the real Electron Builder macOS updater manifest shape.
+Each architecture supplied its expected ZIP and DMG entries, including a
+metadata-identical duplicate DMG entry, while the assembler required the
+source manifest to contain only the updater ZIP. The failure occurred before a
+release bundle was created.
+
+The GitHub Release, R2 update feed, and Docker Hub/GHCR container publication
+did not run. The protected prerelease Snap workflow passed source validation
+and, as designed, skipped both architecture builds and Store publication.
+
+No GitHub Release, update feed, container image, or public Snap channel was
+created. External distribution remained zero.
+
+Motrix 2.0.0-beta.11 supersedes this unpublished attempt. See the
+[beta.11 release notes](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.11/docs/release-notes/2.0.0-beta.11.md)
+for the next planned beta.
+
 [beta.9 historical record](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.10/docs/release-notes/2.0.0-beta.9.md)
-preserves the exact outcome.
-
-## Release reliability updates
-
-- Creates an isolated macOS keychain independently on every Finalize runner.
-  The validated signing identity is imported with its protected import value,
-  while keychain creation, unlock, and partition configuration use a separate
-  fresh per-job value.
-- Passes only the isolated keychain path to Electron Builder. Builder no
-  longer creates or imports the keychain itself, so Apple Silicon and Intel
-  finalization use the same explicit setup boundary.
-- Saves and restores the runner's original user-keychain search list, then
-  deletes the isolated keychain and its temporary directory immediately after
-  Builder. Any setup or cleanup failure prevents finalized-artifact upload.
-- Adds release contracts that lock the distinct import and unlock operations,
-  path-only Builder handoff, original search-list restoration, and cleanup
-  ordering against the pinned Electron Builder implementation.
-- Keeps Windows `x64` packages explicitly unsigned while retaining final
-  package verification before release.
-- Retains the complete desktop platform-set gate: every desktop target must
-  finalize before assembly. Protected prerelease Snap runs stop after source
-  validation.
-
-## Snap beta policy
-
-The Snap uses the `personal-files` interface only for the browser native
-messaging manifest paths verified by the build. Installing a Snap with this
-interface requires a Store declaration signed by Canonical whose
-`allow-installation` constraint permits installation. This is a Store-side
-review requirement; the project will not bypass or weaken it in code.
-
-Snap is not part of the beta.10 distribution. Protected prerelease Snap runs
-stop after source validation, so they do not build Snap artifacts, upload Store
-revisions, or change `latest/edge`. Stable Snap publication retains its
-complete two-architecture verification, Store declaration requirement, and
-protected Store gates.
-
-## Highlights
-
-- A ground-up desktop rebuild with Electron 43, React 19, and TypeScript 7,
-  including a customizable Dashboard, dark mode, a cross-platform application
-  menu, and clearer task-inspector feedback.
-- One host-neutral download core for both the desktop app and the Node/Web
-  Server, with SQLite session recovery, tracker management, UPnP/NAT-PMP, and
-  HTTP, FTP, BitTorrent, and magnet support.
-- MDXP-based integration for the official CLI and browser handoff, including
-  local discovery and device-code pairing for remote Server instances.
-- A QuickJS plugin sandbox with capability consent, bundled builtin plugins,
-  and an in-app plugin marketplace.
-- Persistent, multi-architecture Server containers for NAS and home-server
-  deployments, published to both Docker Hub and GHCR after the desktop release
-  succeeds.
-
-## Before testing
-
-This is prerelease software. Back up your existing Motrix application data and
-downloads before installing it. Migration from Motrix v1 data has not yet been
-validated, so do not use your only copy of v1 data with this beta.
-
-When practical, test v2 in parallel using a separate OS account, machine, or
-Docker data directory. Please do not rely on this beta for your only copy of
-important downloads.
-
-## What to test
-
-- HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
-  session recovery
-- Desktop integrations, browser and CLI handoff through MDXP, and sandboxed
-  plugins
-- Headless Server deployment, persistent storage, and remote pairing
-
-## Planned downloads after release gates pass
-
-| Distribution | Architectures | Planned output |
-|--------------|---------------|----------------|
-| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
-| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
-| Linux | `x64`, `arm64` | DEB and RPM |
-| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.10-linux-<arch>.tar.gz` |
-| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.10` tag in both registries |
-| Snap Store | — | Not published for this beta |
-
-After publication, container images use
-`docker.io/motrixapp/motrix-server:2.0.0-beta.10` and
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.10`. See the
-[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.10/docs/docker-server.md)
-for storage, networking, and upgrade guidance.
-
-## Known distribution limits
-
-- AppImage is not published for this beta.
-- Flatpak is validated separately and is not published by the release tag;
-  the GitHub Release includes its Native Host companion archives.
-- Windows `arm64` and all 32-bit packages are not available.
-- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
-  Download them only from the official GitHub Release after it is published.
-- Beta container tags are immutable and do not update `latest`, `stable`, or
-  other stable floating tags.
-- Snap is not published for this beta. Prerelease Snap runs stop after source
-  validation without building or publishing Snap artifacts.
-
-## Feedback
-
-Please report reproducible problems through
-[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
-operating system, architecture, package type, and the steps needed to reproduce
-the issue.

--- a/docs/release-notes/2.0.0-beta.10.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.10.zh-CN.md
@@ -1,99 +1,25 @@
 # Motrix 2.0.0-beta.10
 
-[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.10/docs/release-notes/2.0.0-beta.10.md) | 简体中文
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.11/docs/release-notes/2.0.0-beta.10.md) | 简体中文
 
-Motrix 2.0.0-beta.10 是下一次计划公开发布的 Motrix Turbo beta，但只有全部受保护
-发布门禁通过后才会进入分发。该版本继续验证重新开发的 v2 桌面应用与 Headless
-Server、共用下载内核、MDXP 集成和沙箱化插件系统。
+> Motrix 2.0.0-beta.10 未发布。本历史记录在 beta.11 中回填。
 
-Motrix 2.0.0-beta.9 未发布。5 个桌面构建、未签名 Windows Finalize 和 Apple
-Silicon Finalize 均完成，但 Intel macOS Finalize 在完整桌面安装包集合可用前停止。
+5 个桌面构建 job 均成功完成。明确采用未签名模式的 Windows Finalize job 与两个
+macOS Finalize job 也都完成了完整安装包验证，并上传了经过验证的最终输入。
+
+随后，产物组装拒绝了 Electron Builder 真实生成的 macOS updater manifest 结构。
+每个架构都提供了预期的 ZIP 与 DMG 条目，其中包含一条元数据完全相同的重复 DMG
+条目，而组装器要求源 manifest 只能包含 updater ZIP。失败发生在 release bundle
+创建之前。
+
+GitHub Release、R2 更新数据源以及 Docker Hub/GHCR 容器发布均未执行。受保护的
+预发布 Snap workflow 通过 source validation 后，按设计跳过了两个架构构建与
+Store 发布。
+
+没有创建 GitHub Release、更新数据源、容器镜像或公开 Snap channel，外部分发
+为零。
+
+Motrix 2.0.0-beta.11 已取代这次未发布的尝试。下一版 beta 请参阅
+[beta.11 发布说明](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.11/docs/release-notes/2.0.0-beta.11.zh-CN.md)。
+
 [beta.9 历史记录](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.10/docs/release-notes/2.0.0-beta.9.zh-CN.md)
-保留了该次尝试的准确结果。
-
-## 发布可靠性更新
-
-- 每个 macOS Finalize runner 都独立创建隔离 keychain。经过验证的签名 identity
-  使用受保护的导入值进行导入；keychain 创建、解锁与 partition 配置则使用另一
-  个每次 job 随机生成的值。
-- Electron Builder 只接收隔离 keychain 路径，不再自行创建或导入 keychain，
-  因此 Apple Silicon 与 Intel Finalize 使用相同的显式准备边界。
-- 保存并恢复 runner 原有的 user keychain 搜索列表，然后在 Builder 结束后立即
-  删除隔离 keychain 及其临时目录。任何准备或清理失败都会阻止 finalized
-  artifact 上传。
-- 新增发布契约，依据固定版本的 Electron Builder 实现锁定不同的导入与解锁
-  操作、仅路径的 Builder 交接、原搜索列表恢复以及清理顺序。
-- Windows `x64` 安装包继续明确采用未签名发布，同时保留发布前的最终安装包验证。
-- 继续执行完整桌面平台集合门禁：所有桌面目标完成 Finalize 后才能组装。受保护
-  的预发布 Snap run 会在 source validation 后停止。
-
-## Snap beta 策略
-
-Snap 只为构建时已验证的浏览器 native messaging manifest 路径使用
-`personal-files` interface。安装使用该 interface 的 Snap，需要由 Canonical
-签名的 Store declaration，并由其中的 `allow-installation` constraint 允许安装。
-这是 Store 侧的审核要求；项目不会通过代码绕过或弱化该要求。
-
-Snap 不属于 beta.10 的分发范围。受保护的预发布 Snap run 会在 source validation
-后停止，因此不会构建 Snap artifact、上传 Store revision 或修改 `latest/edge`。
-稳定版 Snap 发布仍保留完整的双架构验证、Store declaration 要求与受保护 Store
-门禁。
-
-## 主要变化
-
-- 使用 Electron 43、React 19 和 TypeScript 7 从头重建桌面应用，提供可自定义
-  Dashboard、深色模式、跨平台应用菜单，以及更清晰的任务检查器反馈。
-- 桌面应用和 Node/Web Server 共用与宿主无关的下载内核，支持 SQLite session
-  恢复、Tracker 管理、UPnP/NAT-PMP，以及 HTTP、FTP、BitTorrent 和磁力链接下载。
-- 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地发现及远程 Server 的
-  device-code 配对。
-- 提供带能力授权的 QuickJS 插件沙箱、内置插件和应用内插件市场。
-- 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器；桌面发布成功后，
-  容器会同时发布到 Docker Hub 与 GHCR。
-
-## 测试前须知
-
-这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1 数据的
-迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
-
-条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录与现有环境并行
-测试 v2。请勿让本 beta 成为重要下载文件的唯一存储位置。
-
-## 建议测试项
-
-- HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
-- 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
-- Headless Server 部署、数据持久化和远程配对
-
-## 发布门禁通过后的计划下载
-
-| 发布方式 | 架构 | 计划产物 |
-|----------|------|----------|
-| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
-| Windows | `x64` | 未签名的 NSIS 安装包（`.exe`）和 ZIP |
-| Linux | `x64`、`arm64` | DEB 和 RPM |
-| Flatpak Native Host 配套程序 | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.10-linux-<arch>.tar.gz` |
-| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中不可变的 `2.0.0-beta.10` tag |
-| Snap Store | — | 本 beta 不发布 |
-
-发布完成后，容器镜像地址为
-`docker.io/motrixapp/motrix-server:2.0.0-beta.10` 和
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.10`。数据持久化、网络和升级方法请参阅
-[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.10/docs/docker-server.zh-CN.md)。
-
-## 已知发布限制
-
-- 本 beta 不发布 AppImage。
-- Flatpak 会单独验证，不会随该版本 tag 发布；GitHub Release 会包含其 Native
-  Host 配套程序压缩包。
-- 不提供 Windows `arm64` 和任何 32 位安装包。
-- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅在正式发布后
-  从 GitHub 官方 Release 下载。
-- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
-- 本 beta 不发布 Snap。预发布 Snap run 会在 source validation 后停止，不会构建
-  或发布 Snap artifact。
-
-## 反馈
-
-请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现的问题，
-并附上操作系统、架构、安装包类型和复现步骤。

--- a/docs/release-notes/2.0.0-beta.11.md
+++ b/docs/release-notes/2.0.0-beta.11.md
@@ -1,0 +1,113 @@
+# Motrix 2.0.0-beta.11
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.11/docs/release-notes/2.0.0-beta.11.zh-CN.md)
+
+Motrix 2.0.0-beta.11 is the next Motrix Turbo beta intended for public
+distribution after every protected release gate passes. It continues public
+validation of the rebuilt v2 desktop app and headless server, shared download
+core, MDXP integrations, and sandboxed plugin system.
+
+Motrix 2.0.0-beta.10 was not published. All five desktop builds and all three
+Finalize jobs completed, but assembly rejected the real macOS updater manifest
+shape before a release bundle was created. The
+[beta.10 historical record](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.11/docs/release-notes/2.0.0-beta.10.md)
+preserves the exact outcome.
+
+## Release reliability updates
+
+- Validates each architecture's real macOS updater source manifest against the
+  exact ZIP and DMG basenames produced for that target, including file size and
+  SHA-512 checks against the verified artifacts.
+- Accepts and collapses only metadata-identical duplicate manifest entries.
+  Unknown assets, casing changes, missing updater ZIPs, and duplicate entries
+  with conflicting metadata remain fail-closed.
+- Canonicalizes each macOS source manifest to its updater ZIP before merging
+  the architectures. The published macOS updater feed therefore contains one
+  verified ZIP for Intel and one for Apple Silicon, with the Intel ZIP retained
+  as the legacy path.
+- Adds a dual-architecture regression fixture matching Electron Builder's real
+  ZIP plus duplicated-DMG output, together with negative coverage for unknown
+  assets and conflicting duplicates.
+- Keeps Windows `x64` packages explicitly unsigned while retaining final
+  package verification before release.
+- Retains the complete desktop platform-set gate: every desktop target must
+  finalize before assembly and every assembled updater manifest must pass its
+  final verification before publication.
+
+## Snap beta policy
+
+Snap is not part of the beta.11 distribution. Protected prerelease Snap runs
+stop after source validation, so they do not build Snap artifacts, upload Store
+revisions, or change `latest/edge`. Stable Snap publication retains its
+complete two-architecture verification and protected Store gates.
+
+## Highlights
+
+- A ground-up desktop rebuild with Electron 43, React 19, and TypeScript 7,
+  including a customizable Dashboard, dark mode, a cross-platform application
+  menu, and clearer task-inspector feedback.
+- One host-neutral download core for both the desktop app and the Node/Web
+  Server, with SQLite session recovery, tracker management, UPnP/NAT-PMP, and
+  HTTP, FTP, BitTorrent, and magnet support.
+- MDXP-based integration for the official CLI and browser handoff, including
+  local discovery and device-code pairing for remote Server instances.
+- A QuickJS plugin sandbox with capability consent, bundled builtin plugins,
+  and an in-app plugin marketplace.
+- Persistent, multi-architecture Server containers for NAS and home-server
+  deployments, published to both Docker Hub and GHCR after the desktop release
+  succeeds.
+
+## Before testing
+
+This is prerelease software. Back up your existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Please do not rely on this beta for your only copy of
+important downloads.
+
+## What to test
+
+- HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
+  session recovery
+- Desktop integrations, browser and CLI handoff through MDXP, and sandboxed
+  plugins
+- Headless Server deployment, persistent storage, and remote pairing
+
+## Planned downloads after release gates pass
+
+| Distribution | Architectures | Planned output |
+|--------------|---------------|----------------|
+| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | DEB and RPM |
+| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.11-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.11` tag in both registries |
+| Snap Store | — | Not published for this beta |
+
+After publication, container images use
+`docker.io/motrixapp/motrix-server:2.0.0-beta.11` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.11`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.11/docs/docker-server.md)
+for storage, networking, and upgrade guidance.
+
+## Known distribution limits
+
+- AppImage is not published for this beta.
+- Flatpak is validated separately and is not published by the release tag;
+  the GitHub Release includes its Native Host companion archives.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
+  Download them only from the official GitHub Release after it is published.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+- Snap is not published for this beta. Prerelease Snap runs stop after source
+  validation without building or publishing Snap artifacts.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.11.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.11.zh-CN.md
@@ -1,0 +1,92 @@
+# Motrix 2.0.0-beta.11
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.11/docs/release-notes/2.0.0-beta.11.md) | 简体中文
+
+Motrix 2.0.0-beta.11 是下一次计划公开发布的 Motrix Turbo beta，但只有全部受保护
+发布门禁通过后才会进入分发。该版本继续验证重新开发的 v2 桌面应用与 Headless
+Server、共用下载内核、MDXP 集成和沙箱化插件系统。
+
+Motrix 2.0.0-beta.10 未发布。5 个桌面构建与 3 个 Finalize job 均完成，但产物
+组装在 release bundle 创建前拒绝了真实的 macOS updater manifest 结构。
+[beta.10 历史记录](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.11/docs/release-notes/2.0.0-beta.10.zh-CN.md)
+保留了该次尝试的准确结果。
+
+## 发布可靠性更新
+
+- 按每个架构的精确 ZIP 与 DMG basename 验证真实 macOS updater 源 manifest，
+  并将其中每个条目的文件大小与 SHA-512 同经过验证的产物逐项核对。
+- 只接受并折叠元数据完全相同的重复 manifest 条目。未知产物、大小写变化、缺少
+  updater ZIP，以及元数据冲突的重复条目仍会以 fail-closed 方式停止发布。
+- 在合并两个架构前，将每个 macOS 源 manifest 规范化为 updater ZIP。最终发布的
+  macOS updater feed 因而只包含一个 Intel ZIP 与一个 Apple Silicon ZIP，并继续
+  使用 Intel ZIP 作为 legacy path。
+- 新增与 Electron Builder 真实 ZIP 加重复 DMG 输出一致的双架构回归 fixture，
+  同时覆盖未知产物与冲突重复条目的负向测试。
+- Windows `x64` 安装包继续明确采用未签名发布，同时保留发布前的最终安装包验证。
+- 继续执行完整桌面平台集合门禁：所有桌面目标必须完成 Finalize，组装后的每个
+  updater manifest 也必须通过最终验证后才能发布。
+
+## Snap beta 策略
+
+Snap 不属于 beta.11 的分发范围。受保护的预发布 Snap run 会在 source validation
+后停止，因此不会构建 Snap artifact、上传 Store revision 或修改 `latest/edge`。
+稳定版 Snap 发布仍保留完整的双架构验证与受保护 Store 门禁。
+
+## 主要变化
+
+- 使用 Electron 43、React 19 和 TypeScript 7 从头重建桌面应用，提供可自定义
+  Dashboard、深色模式、跨平台应用菜单，以及更清晰的任务检查器反馈。
+- 桌面应用和 Node/Web Server 共用与宿主无关的下载内核，支持 SQLite session
+  恢复、Tracker 管理、UPnP/NAT-PMP，以及 HTTP、FTP、BitTorrent 和磁力链接下载。
+- 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地发现及远程 Server 的
+  device-code 配对。
+- 提供带能力授权的 QuickJS 插件沙箱、内置插件和应用内插件市场。
+- 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器；桌面发布成功后，
+  容器会同时发布到 Docker Hub 与 GHCR。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1 数据的
+迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
+
+条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录与现有环境并行
+测试 v2。请勿让本 beta 成为重要下载文件的唯一存储位置。
+
+## 建议测试项
+
+- HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
+- 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
+- Headless Server 部署、数据持久化和远程配对
+
+## 发布门禁通过后的计划下载
+
+| 发布方式 | 架构 | 计划产物 |
+|----------|------|----------|
+| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
+| Windows | `x64` | 未签名的 NSIS 安装包（`.exe`）和 ZIP |
+| Linux | `x64`、`arm64` | DEB 和 RPM |
+| Flatpak Native Host 配套程序 | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.11-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中不可变的 `2.0.0-beta.11` tag |
+| Snap Store | — | 本 beta 不发布 |
+
+发布完成后，容器镜像地址为
+`docker.io/motrixapp/motrix-server:2.0.0-beta.11` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.11`。数据持久化、网络和升级方法请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.11/docs/docker-server.zh-CN.md)。
+
+## 已知发布限制
+
+- 本 beta 不发布 AppImage。
+- Flatpak 会单独验证，不会随该版本 tag 发布；GitHub Release 会包含其 Native
+  Host 配套程序压缩包。
+- 不提供 Windows `arm64` 和任何 32 位安装包。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅在正式发布后
+  从 GitHub 官方 Release 下载。
+- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
+- 本 beta 不发布 Snap。预发布 Snap run 会在 source validation 后停止，不会构建
+  或发布 Snap artifact。
+
+## 反馈
+
+请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现的问题，
+并附上操作系统、架构、安装包类型和复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -76,15 +76,27 @@
   <releases>
     <!-- Update this list on every release; Flathub linter requires the most
          recent version listed here to match the manifest's source tag. -->
+    <release version="2.0.0-beta.11" date="2026-08-16">
+      <description>
+        <p>
+          Release assembly update that validates the real macOS updater
+          manifest shape, accepts only metadata-identical duplicate entries,
+          and canonicalizes the combined updater feed to one ZIP per
+          architecture. Windows packages remain unsigned. Prerelease Snap
+          runs stop after source validation without building or publishing
+          artifacts.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.10" date="2026-08-16">
       <description>
         <p>
-          Release finalization update with an isolated per-job macOS keychain,
-          distinct import and keychain-unlock values, path-only Builder
-          handoff, and fail-closed cleanup. Windows packages remain unsigned.
-          Prerelease Snap runs stop after source validation without building
-          or publishing artifacts; stable Snap publication retains its
-          personal-files Store declaration requirement.
+          Unpublished Motrix Turbo beta attempt. All five desktop builds and
+          all three Finalize jobs succeeded. Assembly rejected the real macOS
+          updater manifest shape before creating a release bundle. GitHub
+          Release, R2, and container publication did not run. The prerelease
+          Snap workflow stopped after source validation, and external
+          distribution remained zero.
         </p>
       </description>
     </release>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.10",
+  "version": "2.0.0-beta.11",
   "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1",
   "description": "A full-featured download manager",
   "keywords": [],

--- a/scripts/assemble-release-artifacts.mjs
+++ b/scripts/assemble-release-artifacts.mjs
@@ -24,6 +24,10 @@ export const RELEASE_TARGETS = [
       `Motrix-${version}-arm64.dmg`,
       `Motrix-${version}-arm64.zip`,
     ],
+    sourceManifestAssetNames: (version) => [
+      `Motrix-${version}-arm64.zip`,
+      `Motrix-${version}-arm64.dmg`,
+    ],
     manifestAssetNames: (version) => [`Motrix-${version}-arm64.zip`],
     legacyAssetName: (version) => `Motrix-${version}-arm64.zip`,
   },
@@ -34,6 +38,10 @@ export const RELEASE_TARGETS = [
     assetNames: (version) => [
       `Motrix-${version}-x64.dmg`,
       `Motrix-${version}-x64.zip`,
+    ],
+    sourceManifestAssetNames: (version) => [
+      `Motrix-${version}-x64.zip`,
+      `Motrix-${version}-x64.dmg`,
     ],
     manifestAssetNames: (version) => [`Motrix-${version}-x64.zip`],
     legacyAssetName: (version) => `Motrix-${version}-x64.zip`,
@@ -138,8 +146,14 @@ export async function assembleReleaseArtifacts({
           `${target.name}/${manifestName}: version ${manifest.version} does not match ${version}`
         )
       }
-      await verifyManifestAssets(target, manifest, files, version, manifestName)
-      manifests.set(manifestName, manifest)
+      const verifiedManifest = await verifyManifestAssets(
+        target,
+        manifest,
+        files,
+        version,
+        manifestName
+      )
+      manifests.set(manifestName, verifiedManifest)
       manifestSources.set(manifestName, manifestFile.source)
     }
 
@@ -347,15 +361,12 @@ async function verifyManifestAssets(
   manifestName
 ) {
   const expectedNames = target.manifestAssetNames(version)
-  const actualNames = manifest.files.map((file) => file.url)
-  if (
-    actualNames.length !== expectedNames.length ||
-    expectedNames.some((name) => !actualNames.includes(name))
-  ) {
-    throw new Error(
-      `${target.name}/${manifestName}: files[] must contain exactly ${expectedNames.join(', ')}`
-    )
-  }
+  const allowedSourceNames =
+    target.sourceManifestAssetNames?.(version) ?? expectedNames
+  const allowedByName = new Map(
+    allowedSourceNames.map((name) => [name.toLowerCase(), name])
+  )
+  const uniqueFiles = new Map()
 
   const expectedLegacyName = target.legacyAssetName(version)
   if (manifest.legacyFile.url !== expectedLegacyName) {
@@ -365,6 +376,34 @@ async function verifyManifestAssets(
   }
 
   for (const file of manifest.files) {
+    const key = file.url.toLowerCase()
+    const allowedName = allowedByName.get(key)
+    if (!allowedName || allowedName !== file.url) {
+      throw new Error(
+        `${target.name}/${manifestName}: files[] contains unexpected asset ${file.url}; expected only ${allowedSourceNames.join(', ')}`
+      )
+    }
+
+    const previous = uniqueFiles.get(key)
+    if (previous) {
+      if (
+        previous.url !== file.url ||
+        previous.sha512 !== file.sha512 ||
+        previous.size !== file.size
+      ) {
+        throw new Error(
+          `${target.name}/${manifestName}: duplicate manifest asset ${file.url} has conflicting metadata`
+        )
+      }
+      if (!target.sourceManifestAssetNames) {
+        throw new Error(
+          `${target.name}/${manifestName}: files[] must contain exactly ${expectedNames.join(', ')}`
+        )
+      }
+    } else {
+      uniqueFiles.set(key, file)
+    }
+
     const input = files.get(file.url.toLowerCase())
     if (input?.kind !== 'asset' || input.name !== file.url) {
       throw new Error(
@@ -383,6 +422,28 @@ async function verifyManifestAssets(
         `${target.name}/${manifestName}: ${file.url} sha512 does not match manifest`
       )
     }
+  }
+
+  const canonicalFiles = expectedNames.map((name) =>
+    uniqueFiles.get(name.toLowerCase())
+  )
+  if (canonicalFiles.some((file) => !file)) {
+    throw new Error(
+      `${target.name}/${manifestName}: files[] must contain ${expectedNames.join(', ')}`
+    )
+  }
+  const canonicalLegacy = uniqueFiles.get(expectedLegacyName.toLowerCase())
+
+  return {
+    ...manifest,
+    document: {
+      ...manifest.document,
+      files: canonicalFiles,
+      path: expectedLegacyName,
+      sha512: canonicalLegacy.sha512,
+    },
+    files: canonicalFiles,
+    legacyFile: canonicalLegacy,
   }
 }
 

--- a/tests/scripts/assemble-release-artifacts.test.ts
+++ b/tests/scripts/assemble-release-artifacts.test.ts
@@ -74,6 +74,10 @@ describe('assembleReleaseArtifacts', () => {
       fixture.names.macX64Zip,
       fixture.names.macArm64Zip,
     ])
+    expect(new Set(macManifest.files.map((file) => file.url)).size).toBe(2)
+    expect(macManifest.files.some((file) => file.url.endsWith('.dmg'))).toBe(
+      false
+    )
     expect(macManifest.path).toBe(fixture.names.macX64Zip)
     expect(macManifest.sha512).toBe(macManifest.files[0].sha512)
 
@@ -95,6 +99,66 @@ describe('assembleReleaseArtifacts', () => {
       ],
     })
     await expect(access(fixture.paths.macArm64Zip)).resolves.toBeUndefined()
+  })
+
+  it('rejects conflicting duplicate macOS manifest entries', async () => {
+    const fixture = await createFixture()
+    await writeManifest(
+      fixture.paths.macArm64Manifest,
+      VERSION,
+      [
+        {
+          name: fixture.names.macArm64Zip,
+          content: fixture.contents.macArm64Zip,
+        },
+        {
+          name: fixture.names.macArm64Dmg,
+          content: fixture.contents.macArm64Dmg,
+        },
+        {
+          name: fixture.names.macArm64Dmg,
+          content: Buffer.from('conflicting macOS arm64 DMG metadata'),
+        },
+      ],
+      fixture.names.macArm64Zip
+    )
+
+    await expect(
+      assembleReleaseArtifacts({
+        inputDirectory: fixture.input,
+        outputDirectory: fixture.output,
+        version: VERSION,
+      })
+    ).rejects.toThrow(
+      `darwin-arm64/latest-mac.yml: duplicate manifest asset ${fixture.names.macArm64Dmg} has conflicting metadata`
+    )
+  })
+
+  it('rejects unknown macOS manifest assets', async () => {
+    const fixture = await createFixture()
+    const unknownName = 'Motrix-2.0.0-arm64.pkg'
+    await writeManifest(
+      fixture.paths.macArm64Manifest,
+      VERSION,
+      [
+        {
+          name: fixture.names.macArm64Zip,
+          content: fixture.contents.macArm64Zip,
+        },
+        { name: unknownName, content: Buffer.from('unknown package') },
+      ],
+      fixture.names.macArm64Zip
+    )
+
+    await expect(
+      assembleReleaseArtifacts({
+        inputDirectory: fixture.input,
+        outputDirectory: fixture.output,
+        version: VERSION,
+      })
+    ).rejects.toThrow(
+      `darwin-arm64/latest-mac.yml: files[] contains unexpected asset ${unknownName}`
+    )
   })
 
   it('publishes beta manifests without creating stable channel metadata', async () => {
@@ -469,7 +533,9 @@ async function createFixture(version = VERSION) {
     linuxX64Deb: `Motrix_${version}_amd64.deb`,
     linuxX64Companion: `Motrix-Native-Host-${version}-linux-x64.tar.gz`,
     linuxX64Rpm: `Motrix-${version}.x86_64.rpm`,
+    macArm64Dmg: `Motrix-${version}-arm64.dmg`,
     macArm64Zip: `Motrix-${version}-arm64.zip`,
+    macX64Dmg: `Motrix-${version}-x64.dmg`,
     macX64Zip: `Motrix-${version}-x64.zip`,
     windowsExe: `Motrix-Setup-${version}.exe`,
   }
@@ -480,44 +546,63 @@ async function createFixture(version = VERSION) {
     linuxX64Deb: Buffer.from('Linux x64 deb'),
     linuxX64Companion: Buffer.from('Linux x64 Flatpak companion'),
     linuxX64Rpm: Buffer.from('Linux x64 rpm'),
+    macArm64Dmg: Buffer.from('macOS arm64 DMG'),
     macArm64Zip: Buffer.from('macOS arm64 ZIP'),
+    macX64Dmg: Buffer.from('macOS x64 DMG'),
     macX64Zip: Buffer.from('macOS x64 ZIP'),
     windowsExe: Buffer.from('Windows x64 installer'),
   }
 
   const darwinArm64 = await makeTarget(input, 'darwin-arm64')
-  await writeAsset(darwinArm64, `Motrix-${version}-arm64.dmg`)
+  await writeAsset(darwinArm64, names.macArm64Dmg, contents.macArm64Dmg)
   const macArm64Zip = await writeAsset(
     darwinArm64,
     names.macArm64Zip,
     contents.macArm64Zip
   )
+  const macArm64Manifest = path.join(darwinArm64, 'latest-mac.yml')
   await writeManifest(
-    path.join(darwinArm64, 'latest-mac.yml'),
+    macArm64Manifest,
     version,
-    [{ name: names.macArm64Zip, content: contents.macArm64Zip }],
+    [
+      { name: names.macArm64Zip, content: contents.macArm64Zip },
+      { name: names.macArm64Dmg, content: contents.macArm64Dmg },
+      { name: names.macArm64Dmg, content: contents.macArm64Dmg },
+    ],
     names.macArm64Zip
   )
   await writeManifest(
     path.join(darwinArm64, 'beta-mac.yml'),
     version,
-    [{ name: names.macArm64Zip, content: contents.macArm64Zip }],
+    [
+      { name: names.macArm64Zip, content: contents.macArm64Zip },
+      { name: names.macArm64Dmg, content: contents.macArm64Dmg },
+      { name: names.macArm64Dmg, content: contents.macArm64Dmg },
+    ],
     names.macArm64Zip
   )
 
   const darwinX64 = await makeTarget(input, 'darwin-x64')
-  await writeAsset(darwinX64, `Motrix-${version}-x64.dmg`)
+  await writeAsset(darwinX64, names.macX64Dmg, contents.macX64Dmg)
   await writeAsset(darwinX64, names.macX64Zip, contents.macX64Zip)
   await writeManifest(
     path.join(darwinX64, 'latest-mac.yml'),
     version,
-    [{ name: names.macX64Zip, content: contents.macX64Zip }],
+    [
+      { name: names.macX64Zip, content: contents.macX64Zip },
+      { name: names.macX64Dmg, content: contents.macX64Dmg },
+      { name: names.macX64Dmg, content: contents.macX64Dmg },
+    ],
     names.macX64Zip
   )
   await writeManifest(
     path.join(darwinX64, 'beta-mac.yml'),
     version,
-    [{ name: names.macX64Zip, content: contents.macX64Zip }],
+    [
+      { name: names.macX64Zip, content: contents.macX64Zip },
+      { name: names.macX64Dmg, content: contents.macX64Dmg },
+      { name: names.macX64Dmg, content: contents.macX64Dmg },
+    ],
     names.macX64Zip
   )
 
@@ -619,6 +704,7 @@ async function createFixture(version = VERSION) {
       linuxX64Deb: linuxX64Deb.path,
       linuxX64Companion: linuxX64Companion.path,
       linuxX64Manifest,
+      macArm64Manifest,
       macArm64Zip: macArm64Zip.path,
       windowsExe: path.join(windows, names.windowsExe),
       windowsManifest,

--- a/tests/scripts/release-version-contract.test.ts
+++ b/tests/scripts/release-version-contract.test.ts
@@ -351,7 +351,7 @@ describe('release version contract', () => {
     expect(beta9Metainfo).not.toMatch(secretLikeIdentifier)
   })
 
-  it('preserves beta.10 isolated-keychain and Snap disclosures', () => {
+  it('records beta.10 as an unpublished assembly attempt', () => {
     const english = read('docs/release-notes/2.0.0-beta.10.md')
     const chinese = read('docs/release-notes/2.0.0-beta.10.zh-CN.md')
     const normalizedEnglish = english.replace(/\s+/g, ' ')
@@ -364,71 +364,127 @@ describe('release version contract', () => {
     const normalizedBeta10Metainfo = beta10Metainfo.replace(/\s+/g, ' ')
 
     expect(english).toContain(
-      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.10/docs/release-notes/2.0.0-beta.9.md'
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.11/docs/release-notes/2.0.0-beta.10.zh-CN.md'
     )
     expect(chinese).toContain(
-      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.10/docs/release-notes/2.0.0-beta.9.zh-CN.md'
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.11/docs/release-notes/2.0.0-beta.10.md'
     )
     expect(normalizedEnglish).toContain(
-      'Creates an isolated macOS keychain independently on every Finalize runner'
+      'Motrix 2.0.0-beta.10 was not published'
     )
     expect(normalizedEnglish).toContain(
-      'keychain creation, unlock, and partition configuration use a separate fresh per-job value'
+      'All five desktop build jobs completed successfully'
     )
     expect(normalizedEnglish).toContain(
-      'Passes only the isolated keychain path to Electron Builder'
+      'The explicitly unsigned Windows Finalize job and both macOS Finalize jobs also completed their full package verification'
     )
     expect(normalizedEnglish).toContain(
-      "Saves and restores the runner's original user-keychain search list"
+      'Each architecture supplied its expected ZIP and DMG entries, including a metadata-identical duplicate DMG entry'
     )
     expect(normalizedEnglish).toContain(
-      'Any setup or cleanup failure prevents finalized-artifact upload'
+      'The failure occurred before a release bundle was created'
+    )
+    expect(normalizedChinese).toContain('Motrix 2.0.0-beta.10 未发布')
+    expect(normalizedChinese).toContain('5 个桌面构建 job 均成功完成')
+    expect(normalizedChinese).toContain(
+      'Windows Finalize job 与两个 macOS Finalize job 也都完成了完整安装包验证'
     )
     expect(normalizedChinese).toContain(
-      '每个 macOS Finalize runner 都独立创建隔离 keychain'
+      '其中包含一条元数据完全相同的重复 DMG 条目'
     )
-    expect(normalizedChinese).toContain(
-      'keychain 创建、解锁与 partition 配置则使用另一 个每次 job 随机生成的值'
-    )
-    expect(normalizedChinese).toContain(
-      'Electron Builder 只接收隔离 keychain 路径'
-    )
-    expect(normalizedChinese).toContain(
-      '保存并恢复 runner 原有的 user keychain 搜索列表'
-    )
-    expect(normalizedChinese).toContain(
-      '任何准备或清理失败都会阻止 finalized artifact 上传'
-    )
+    expect(normalizedChinese).toContain('失败发生在 release bundle 创建之前')
     for (const source of [english, chinese]) {
       expect(source).toContain('Snap')
-      expect(source).toContain('latest/edge')
-      expect(source).toContain('personal-files')
-      expect(source).toContain('allow-installation')
-      expect(source).toContain('AppImage')
-      expect(source).toContain('Flatpak')
-      expect(source).toContain(
-        'Motrix-Native-Host-2.0.0-beta.10-linux-<arch>.tar.gz'
-      )
-      expect(source).toContain('SmartScreen')
-      expect(source).toContain(
-        'docker.io/motrixapp/motrix-server:2.0.0-beta.10'
-      )
-      expect(source).toContain('ghcr.io/agalwood/motrix-server:2.0.0-beta.10')
+      expect(source).toContain('2.0.0-beta.11')
       expect(source).not.toMatch(restrictedPublicLanguage)
       expect(source).not.toMatch(secretLikeIdentifier)
     }
+    expect(normalizedEnglish).toContain(
+      'The GitHub Release, R2 update feed, and Docker Hub/GHCR container publication did not run'
+    )
+    expect(normalizedEnglish).toContain('External distribution remained zero')
+    expect(normalizedChinese).toContain(
+      'GitHub Release、R2 更新数据源以及 Docker Hub/GHCR 容器发布均未执行'
+    )
+    expect(normalizedChinese).toContain('外部分发 为零')
     expect(metainfo).toContain(
       '<release version="2.0.0-beta.10" date="2026-08-16">'
     )
     expect(normalizedBeta10Metainfo).toContain(
-      'isolated per-job macOS keychain'
+      'All five desktop builds and all three Finalize jobs succeeded'
     )
-    expect(normalizedBeta10Metainfo).toContain('path-only Builder handoff')
     expect(normalizedBeta10Metainfo).toContain(
-      'Windows packages remain unsigned'
+      'Assembly rejected the real macOS updater manifest shape'
+    )
+    expect(normalizedBeta10Metainfo).toContain(
+      'external distribution remained zero'
     )
     expect(beta10Metainfo).not.toMatch(restrictedPublicLanguage)
     expect(beta10Metainfo).not.toMatch(secretLikeIdentifier)
+  })
+
+  it('preserves beta.11 macOS manifest recovery and distribution limits', () => {
+    const english = read('docs/release-notes/2.0.0-beta.11.md')
+    const chinese = read('docs/release-notes/2.0.0-beta.11.zh-CN.md')
+    const normalizedEnglish = english.replace(/\s+/g, ' ')
+    const normalizedChinese = chinese.replace(/\s+/g, ' ')
+    const metainfo = read('flatpak/app.motrix.native.metainfo.xml')
+    const beta11Metainfo =
+      /<release version="2\.0\.0-beta\.11"[\s\S]*?<\/release>/.exec(
+        metainfo
+      )?.[0] ?? ''
+    const normalizedBeta11Metainfo = beta11Metainfo.replace(/\s+/g, ' ')
+
+    expect(normalizedEnglish).toContain(
+      "Validates each architecture's real macOS updater source manifest against the exact ZIP and DMG basenames"
+    )
+    expect(normalizedEnglish).toContain(
+      'Accepts and collapses only metadata-identical duplicate manifest entries'
+    )
+    expect(normalizedEnglish).toContain(
+      'Canonicalizes each macOS source manifest to its updater ZIP before merging the architectures'
+    )
+    expect(normalizedEnglish).toContain(
+      'one verified ZIP for Intel and one for Apple Silicon'
+    )
+    expect(normalizedChinese).toContain(
+      '按每个架构的精确 ZIP 与 DMG basename 验证真实 macOS updater 源 manifest'
+    )
+    expect(normalizedChinese).toContain(
+      '只接受并折叠元数据完全相同的重复 manifest 条目'
+    )
+    expect(normalizedChinese).toContain(
+      '将每个 macOS 源 manifest 规范化为 updater ZIP'
+    )
+    for (const source of [english, chinese]) {
+      expect(source).toContain('Snap')
+      expect(source).toContain('latest/edge')
+      expect(source).toContain('AppImage')
+      expect(source).toContain('Flatpak')
+      expect(source).toContain(
+        'Motrix-Native-Host-2.0.0-beta.11-linux-<arch>.tar.gz'
+      )
+      expect(source).toContain('SmartScreen')
+      expect(source).toContain(
+        'docker.io/motrixapp/motrix-server:2.0.0-beta.11'
+      )
+      expect(source).toContain('ghcr.io/agalwood/motrix-server:2.0.0-beta.11')
+      expect(source).not.toMatch(restrictedPublicLanguage)
+      expect(source).not.toMatch(secretLikeIdentifier)
+    }
+    expect(metainfo).toContain(
+      '<release version="2.0.0-beta.11" date="2026-08-16">'
+    )
+    expect(normalizedBeta11Metainfo).toContain('real macOS updater')
+    expect(normalizedBeta11Metainfo).toContain(
+      'metadata-identical duplicate entries'
+    )
+    expect(normalizedBeta11Metainfo).toContain('one ZIP per architecture')
+    expect(normalizedBeta11Metainfo).toContain(
+      'Windows packages remain unsigned'
+    )
+    expect(beta11Metainfo).not.toMatch(restrictedPublicLanguage)
+    expect(beta11Metainfo).not.toMatch(secretLikeIdentifier)
   })
 
   it('preserves beta.6 Snap recovery and canceled release history', () => {


### PR DESCRIPTION
## What changed

- validate the real per-architecture macOS updater manifest against the exact ZIP and DMG artifacts
- collapse only metadata-identical duplicate entries and reject unknown or conflicting entries
- canonicalize each macOS manifest to its updater ZIP before the x64/arm64 merge
- add a real-shape regression for ZIP plus duplicated DMG output and negative coverage
- advance the release candidate to 2.0.0-beta.11 and preserve beta.10 as an unpublished, non-sensitive historical record

## Root cause

Electron Builder 26.15.7 emitted each macOS source manifest with the updater ZIP plus an identical duplicate DMG entry. The release assembler required the source manifest to contain only the ZIP, so all builds and Finalize jobs succeeded but assembly stopped before creating the release bundle.

## Impact

The final macOS update feed remains ZIP-only: one verified x64 ZIP and one verified arm64 ZIP, with x64 retained as the legacy path. DMG artifacts remain downloadable release assets but are not added to the updater feed. Windows remains explicitly unsigned, and prerelease Snap runs remain source-validation-only.

## Verification

- 40 release-script test files, 513 tests
- focused assembler/update/version contracts, 43 tests
- boundary checks
- Biome on changed files and all src/
- TypeScript no-emit check
- file-name and Flatpak packaging contracts
- AppStream XML validation
- staged diff whitespace check
