### PR TITLE
fix(release): canonicalize updater manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. After its remaining release gates pass,
-download [v2.0.0-beta.11 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.11)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.11.md) before
+download [v2.0.0-beta.12 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.12)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.12.md) before
 installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -149,7 +149,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.11'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.12'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。剩余发布门禁通过后，请从 GitHub Releases
-下载 [v2.0.0-beta.11](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.11)，
-并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.11.zh-CN.md)。
+下载 [v2.0.0-beta.12](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.12)，
+并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.12.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -143,7 +143,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.11'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.12'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.11.md
+++ b/docs/release-notes/2.0.0-beta.11.md
@@ -1,113 +1,32 @@
 # Motrix 2.0.0-beta.11
 
-English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.11/docs/release-notes/2.0.0-beta.11.zh-CN.md)
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.12/docs/release-notes/2.0.0-beta.11.zh-CN.md)
 
-Motrix 2.0.0-beta.11 is the next Motrix Turbo beta intended for public
-distribution after every protected release gate passes. It continues public
-validation of the rebuilt v2 desktop app and headless server, shared download
-core, MDXP integrations, and sandboxed plugin system.
+> Motrix 2.0.0-beta.11 was not published. This historical record was
+> backfilled for beta.12.
 
-Motrix 2.0.0-beta.10 was not published. All five desktop builds and all three
-Finalize jobs completed, but assembly rejected the real macOS updater manifest
-shape before a release bundle was created. The
+The protected release source gate passed, followed by all five desktop Build
+jobs. The explicitly unsigned Windows Finalize job and both macOS Finalize jobs
+also completed their full package verification and uploaded the five verified
+release inputs.
+
+Assembly advanced through the macOS updater normalization added in beta.11,
+then rejected `linux-x64/beta-linux.yml`. The real Electron Builder manifest
+listed the expected DEB once and the expected RPM twice with identical
+basename, size, and SHA-512 metadata, while the assembler still required
+exactly one entry for each Linux package. The corresponding arm64 release input
+contained the same duplicate-identical RPM shape. The failure occurred before
+a release bundle was created.
+
+The GitHub Release, R2 update feed, and Docker Hub/GHCR container publication
+did not run. The protected prerelease Snap workflow passed source validation
+and, as designed, skipped both architecture builds and Store publication.
+
+No GitHub Release, update feed, container image, or public Snap channel was
+created. External distribution remained zero.
+
+Motrix 2.0.0-beta.12 supersedes this unpublished attempt. See the
+[beta.12 release notes](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.12/docs/release-notes/2.0.0-beta.12.md)
+for the next planned beta.
+
 [beta.10 historical record](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.11/docs/release-notes/2.0.0-beta.10.md)
-preserves the exact outcome.
-
-## Release reliability updates
-
-- Validates each architecture's real macOS updater source manifest against the
-  exact ZIP and DMG basenames produced for that target, including file size and
-  SHA-512 checks against the verified artifacts.
-- Accepts and collapses only metadata-identical duplicate manifest entries.
-  Unknown assets, casing changes, missing updater ZIPs, and duplicate entries
-  with conflicting metadata remain fail-closed.
-- Canonicalizes each macOS source manifest to its updater ZIP before merging
-  the architectures. The published macOS updater feed therefore contains one
-  verified ZIP for Intel and one for Apple Silicon, with the Intel ZIP retained
-  as the legacy path.
-- Adds a dual-architecture regression fixture matching Electron Builder's real
-  ZIP plus duplicated-DMG output, together with negative coverage for unknown
-  assets and conflicting duplicates.
-- Keeps Windows `x64` packages explicitly unsigned while retaining final
-  package verification before release.
-- Retains the complete desktop platform-set gate: every desktop target must
-  finalize before assembly and every assembled updater manifest must pass its
-  final verification before publication.
-
-## Snap beta policy
-
-Snap is not part of the beta.11 distribution. Protected prerelease Snap runs
-stop after source validation, so they do not build Snap artifacts, upload Store
-revisions, or change `latest/edge`. Stable Snap publication retains its
-complete two-architecture verification and protected Store gates.
-
-## Highlights
-
-- A ground-up desktop rebuild with Electron 43, React 19, and TypeScript 7,
-  including a customizable Dashboard, dark mode, a cross-platform application
-  menu, and clearer task-inspector feedback.
-- One host-neutral download core for both the desktop app and the Node/Web
-  Server, with SQLite session recovery, tracker management, UPnP/NAT-PMP, and
-  HTTP, FTP, BitTorrent, and magnet support.
-- MDXP-based integration for the official CLI and browser handoff, including
-  local discovery and device-code pairing for remote Server instances.
-- A QuickJS plugin sandbox with capability consent, bundled builtin plugins,
-  and an in-app plugin marketplace.
-- Persistent, multi-architecture Server containers for NAS and home-server
-  deployments, published to both Docker Hub and GHCR after the desktop release
-  succeeds.
-
-## Before testing
-
-This is prerelease software. Back up your existing Motrix application data and
-downloads before installing it. Migration from Motrix v1 data has not yet been
-validated, so do not use your only copy of v1 data with this beta.
-
-When practical, test v2 in parallel using a separate OS account, machine, or
-Docker data directory. Please do not rely on this beta for your only copy of
-important downloads.
-
-## What to test
-
-- HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
-  session recovery
-- Desktop integrations, browser and CLI handoff through MDXP, and sandboxed
-  plugins
-- Headless Server deployment, persistent storage, and remote pairing
-
-## Planned downloads after release gates pass
-
-| Distribution | Architectures | Planned output |
-|--------------|---------------|----------------|
-| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
-| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
-| Linux | `x64`, `arm64` | DEB and RPM |
-| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.11-linux-<arch>.tar.gz` |
-| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.11` tag in both registries |
-| Snap Store | — | Not published for this beta |
-
-After publication, container images use
-`docker.io/motrixapp/motrix-server:2.0.0-beta.11` and
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.11`. See the
-[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.11/docs/docker-server.md)
-for storage, networking, and upgrade guidance.
-
-## Known distribution limits
-
-- AppImage is not published for this beta.
-- Flatpak is validated separately and is not published by the release tag;
-  the GitHub Release includes its Native Host companion archives.
-- Windows `arm64` and all 32-bit packages are not available.
-- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
-  Download them only from the official GitHub Release after it is published.
-- Beta container tags are immutable and do not update `latest`, `stable`, or
-  other stable floating tags.
-- Snap is not published for this beta. Prerelease Snap runs stop after source
-  validation without building or publishing Snap artifacts.
-
-## Feedback
-
-Please report reproducible problems through
-[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
-operating system, architecture, package type, and the steps needed to reproduce
-the issue.

--- a/docs/release-notes/2.0.0-beta.11.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.11.zh-CN.md
@@ -1,92 +1,27 @@
 # Motrix 2.0.0-beta.11
 
-[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.11/docs/release-notes/2.0.0-beta.11.md) | 简体中文
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.12/docs/release-notes/2.0.0-beta.11.md) | 简体中文
 
-Motrix 2.0.0-beta.11 是下一次计划公开发布的 Motrix Turbo beta，但只有全部受保护
-发布门禁通过后才会进入分发。该版本继续验证重新开发的 v2 桌面应用与 Headless
-Server、共用下载内核、MDXP 集成和沙箱化插件系统。
+> Motrix 2.0.0-beta.11 未发布。本历史记录在 beta.12 中回填。
 
-Motrix 2.0.0-beta.10 未发布。5 个桌面构建与 3 个 Finalize job 均完成，但产物
-组装在 release bundle 创建前拒绝了真实的 macOS updater manifest 结构。
+受保护的发布 source gate 顺利通过，随后 5 个桌面 Build job 全部成功。明确采用
+未签名模式的 Windows Finalize job 与两个 macOS Finalize job 也都完成了完整安装包
+验证，并上传了 5 份经过验证的 release input。
+
+组装过程通过了 beta.11 新增的 macOS updater 规范化，随后拒绝了
+`linux-x64/beta-linux.yml`。Electron Builder 真实生成的 manifest 包含一条预期的
+DEB，以及两条 basename、大小和 SHA-512 元数据完全相同的预期 RPM；而组装器当时
+仍要求每种 Linux 安装包只能出现一次。对应的 arm64 release input 也具有相同的
+RPM 重复结构。失败发生在 release bundle 创建之前。
+
+GitHub Release、R2 更新数据源以及 Docker Hub/GHCR 容器发布均未执行。受保护的
+预发布 Snap workflow 通过 source validation 后，按设计跳过了两个架构构建与
+Store 发布。
+
+没有创建 GitHub Release、更新数据源、容器镜像或公开 Snap channel，外部分发
+为零。
+
+Motrix 2.0.0-beta.12 已取代这次未发布的尝试。下一版 beta 请参阅
+[beta.12 发布说明](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.12/docs/release-notes/2.0.0-beta.12.zh-CN.md)。
+
 [beta.10 历史记录](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.11/docs/release-notes/2.0.0-beta.10.zh-CN.md)
-保留了该次尝试的准确结果。
-
-## 发布可靠性更新
-
-- 按每个架构的精确 ZIP 与 DMG basename 验证真实 macOS updater 源 manifest，
-  并将其中每个条目的文件大小与 SHA-512 同经过验证的产物逐项核对。
-- 只接受并折叠元数据完全相同的重复 manifest 条目。未知产物、大小写变化、缺少
-  updater ZIP，以及元数据冲突的重复条目仍会以 fail-closed 方式停止发布。
-- 在合并两个架构前，将每个 macOS 源 manifest 规范化为 updater ZIP。最终发布的
-  macOS updater feed 因而只包含一个 Intel ZIP 与一个 Apple Silicon ZIP，并继续
-  使用 Intel ZIP 作为 legacy path。
-- 新增与 Electron Builder 真实 ZIP 加重复 DMG 输出一致的双架构回归 fixture，
-  同时覆盖未知产物与冲突重复条目的负向测试。
-- Windows `x64` 安装包继续明确采用未签名发布，同时保留发布前的最终安装包验证。
-- 继续执行完整桌面平台集合门禁：所有桌面目标必须完成 Finalize，组装后的每个
-  updater manifest 也必须通过最终验证后才能发布。
-
-## Snap beta 策略
-
-Snap 不属于 beta.11 的分发范围。受保护的预发布 Snap run 会在 source validation
-后停止，因此不会构建 Snap artifact、上传 Store revision 或修改 `latest/edge`。
-稳定版 Snap 发布仍保留完整的双架构验证与受保护 Store 门禁。
-
-## 主要变化
-
-- 使用 Electron 43、React 19 和 TypeScript 7 从头重建桌面应用，提供可自定义
-  Dashboard、深色模式、跨平台应用菜单，以及更清晰的任务检查器反馈。
-- 桌面应用和 Node/Web Server 共用与宿主无关的下载内核，支持 SQLite session
-  恢复、Tracker 管理、UPnP/NAT-PMP，以及 HTTP、FTP、BitTorrent 和磁力链接下载。
-- 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地发现及远程 Server 的
-  device-code 配对。
-- 提供带能力授权的 QuickJS 插件沙箱、内置插件和应用内插件市场。
-- 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器；桌面发布成功后，
-  容器会同时发布到 Docker Hub 与 GHCR。
-
-## 测试前须知
-
-这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1 数据的
-迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
-
-条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录与现有环境并行
-测试 v2。请勿让本 beta 成为重要下载文件的唯一存储位置。
-
-## 建议测试项
-
-- HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
-- 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
-- Headless Server 部署、数据持久化和远程配对
-
-## 发布门禁通过后的计划下载
-
-| 发布方式 | 架构 | 计划产物 |
-|----------|------|----------|
-| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
-| Windows | `x64` | 未签名的 NSIS 安装包（`.exe`）和 ZIP |
-| Linux | `x64`、`arm64` | DEB 和 RPM |
-| Flatpak Native Host 配套程序 | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.11-linux-<arch>.tar.gz` |
-| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中不可变的 `2.0.0-beta.11` tag |
-| Snap Store | — | 本 beta 不发布 |
-
-发布完成后，容器镜像地址为
-`docker.io/motrixapp/motrix-server:2.0.0-beta.11` 和
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.11`。数据持久化、网络和升级方法请参阅
-[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.11/docs/docker-server.zh-CN.md)。
-
-## 已知发布限制
-
-- 本 beta 不发布 AppImage。
-- Flatpak 会单独验证，不会随该版本 tag 发布；GitHub Release 会包含其 Native
-  Host 配套程序压缩包。
-- 不提供 Windows `arm64` 和任何 32 位安装包。
-- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅在正式发布后
-  从 GitHub 官方 Release 下载。
-- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
-- 本 beta 不发布 Snap。预发布 Snap run 会在 source validation 后停止，不会构建
-  或发布 Snap artifact。
-
-## 反馈
-
-请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现的问题，
-并附上操作系统、架构、安装包类型和复现步骤。

--- a/docs/release-notes/2.0.0-beta.12.md
+++ b/docs/release-notes/2.0.0-beta.12.md
@@ -1,0 +1,116 @@
+# Motrix 2.0.0-beta.12
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.12/docs/release-notes/2.0.0-beta.12.zh-CN.md)
+
+Motrix 2.0.0-beta.12 is the next Motrix Turbo beta intended for public
+distribution after every protected release gate passes. It continues public
+validation of the rebuilt v2 desktop app and headless server, shared download
+core, MDXP integrations, and sandboxed plugin system.
+
+Motrix 2.0.0-beta.11 was not published. All five desktop builds and all three
+Finalize jobs completed, but assembly rejected the real Linux updater manifest
+shape before a release bundle was created. The
+[beta.11 historical record](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.12/docs/release-notes/2.0.0-beta.11.md)
+preserves the exact outcome.
+
+## Release reliability updates
+
+- Validates every source updater manifest against the exact allowlisted
+  basenames, file sizes, and SHA-512 values of the verified platform artifacts.
+- Accepts and collapses only duplicate entries whose basename, size, and
+  SHA-512 metadata are identical. Unknown assets, casing changes, missing
+  packages, and conflicting duplicates remain fail-closed.
+- Regenerates the published Linux and Windows updater manifests from the
+  canonical verified package set instead of copying source metadata verbatim.
+  Each Linux feed therefore contains exactly one DEB and one RPM entry.
+- Retains the macOS canonicalization introduced in beta.11: source ZIP and DMG
+  entries are validated before the combined updater feed is reduced to one
+  verified ZIP for Intel and one for Apple Silicon.
+- Adds real-shape Linux regressions for duplicate-identical RPM entries on both
+  x64 and arm64, together with negative coverage for conflicting duplicates.
+- Exercises the complete beta.11 five-platform release inputs through local
+  assembly and final update-manifest verification: 17 release assets and four
+  beta updater manifests pass the recovered path.
+- Keeps Windows `x64` packages explicitly unsigned while retaining final
+  package verification before release.
+- Retains the complete desktop platform-set gate: every desktop target must
+  finalize before assembly and every canonical updater manifest must pass
+  final verification before publication.
+
+## Snap beta policy
+
+Snap is not part of the beta.12 distribution. Protected prerelease Snap runs
+stop after source validation, so they do not build Snap artifacts, upload Store
+revisions, or change `latest/edge`. Stable Snap publication retains its
+complete two-architecture verification and protected Store gates.
+
+## Highlights
+
+- A ground-up desktop rebuild with Electron 43, React 19, and TypeScript 7,
+  including a customizable Dashboard, dark mode, a cross-platform application
+  menu, and clearer task-inspector feedback.
+- One host-neutral download core for both the desktop app and the Node/Web
+  Server, with SQLite session recovery, tracker management, UPnP/NAT-PMP, and
+  HTTP, FTP, BitTorrent, and magnet support.
+- MDXP-based integration for the official CLI and browser handoff, including
+  local discovery and device-code pairing for remote Server instances.
+- A QuickJS plugin sandbox with capability consent, bundled builtin plugins,
+  and an in-app plugin marketplace.
+- Persistent, multi-architecture Server containers for NAS and home-server
+  deployments, published to both Docker Hub and GHCR after the desktop release
+  succeeds.
+
+## Before testing
+
+This is prerelease software. Back up your existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Please do not rely on this beta for your only copy of
+important downloads.
+
+## What to test
+
+- HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
+  session recovery
+- Desktop integrations, browser and CLI handoff through MDXP, and sandboxed
+  plugins
+- Headless Server deployment, persistent storage, and remote pairing
+
+## Planned downloads after release gates pass
+
+| Distribution | Architectures | Planned output |
+|--------------|---------------|----------------|
+| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | DEB and RPM |
+| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.12-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.12` tag in both registries |
+| Snap Store | — | Not published for this beta |
+
+After publication, container images use
+`docker.io/motrixapp/motrix-server:2.0.0-beta.12` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.12`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.12/docs/docker-server.md)
+for storage, networking, and upgrade guidance.
+
+## Known distribution limits
+
+- AppImage is not published for this beta.
+- Flatpak is validated separately and is not published by the release tag;
+  the GitHub Release includes its Native Host companion archives.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
+  Download them only from the official GitHub Release after it is published.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+- Snap is not published for this beta. Prerelease Snap runs stop after source
+  validation without building or publishing Snap artifacts.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.12.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.12.zh-CN.md
@@ -1,0 +1,96 @@
+# Motrix 2.0.0-beta.12
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.12/docs/release-notes/2.0.0-beta.12.md) | 简体中文
+
+Motrix 2.0.0-beta.12 是下一次计划公开发布的 Motrix Turbo beta，但只有全部受保护
+发布门禁通过后才会进入分发。该版本继续验证重新开发的 v2 桌面应用与 Headless
+Server、共用下载内核、MDXP 集成和沙箱化插件系统。
+
+Motrix 2.0.0-beta.11 未发布。5 个桌面构建与 3 个 Finalize job 均完成，但组装在
+release bundle 创建前拒绝了真实 Linux updater manifest 结构。
+[beta.11 历史记录](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.12/docs/release-notes/2.0.0-beta.11.zh-CN.md)
+保留了该次尝试的准确结果。
+
+## 发布可靠性更新
+
+- 根据经过验证的平台产物，按精确 allowlist basename、文件大小与 SHA-512 值验证
+  每一份 updater 源 manifest。
+- 只接受并折叠 basename、大小与 SHA-512 元数据完全相同的重复条目。未知产物、
+  大小写变化、缺失安装包与相互冲突的重复条目仍会 fail-closed。
+- 不再原样复制源元数据，而是根据规范化后的已验证安装包集合重新生成公开的 Linux
+  与 Windows updater manifest。因此每份 Linux 更新数据源都只包含一条 DEB 与
+  一条 RPM。
+- 保留 beta.11 引入的 macOS 规范化：验证源 ZIP 与 DMG 条目后，将合并后的 updater
+  数据源收敛为一条 Intel ZIP 与一条 Apple Silicon ZIP。
+- 新增与真实产物一致的 Linux 回归，覆盖 x64 与 arm64 中元数据相同的重复 RPM，
+  并补充冲突重复项的负向测试。
+- 使用 beta.11 的完整五平台 release input 演练本地组装与最终更新数据源验证：
+  17 个 Release 产物与 4 份 beta updater manifest 均通过恢复后的路径。
+- Windows `x64` 安装包继续明确采用未签名发布，同时保留发布前的最终安装包验证。
+- 继续执行完整桌面平台集合门禁：所有桌面目标完成 Finalize 后才能组装，且每份
+  规范 updater manifest 都必须通过最终验证后才能发布。
+
+## Snap beta 策略
+
+Snap 不属于 beta.12 的分发范围。受保护的预发布 Snap run 会在 source validation
+后停止，因此不会构建 Snap artifact、上传 Store revision 或修改 `latest/edge`。
+稳定版 Snap 发布仍保留完整的双架构验证与受保护 Store 门禁。
+
+## 主要变化
+
+- 使用 Electron 43、React 19 和 TypeScript 7 从头重建桌面应用，提供可自定义
+  Dashboard、深色模式、跨平台应用菜单，以及更清晰的任务检查器反馈。
+- 桌面应用和 Node/Web Server 共用与宿主无关的下载内核，支持 SQLite session
+  恢复、Tracker 管理、UPnP/NAT-PMP，以及 HTTP、FTP、BitTorrent 和磁力链接下载。
+- 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地发现及远程 Server 的
+  device-code 配对。
+- 提供带能力授权的 QuickJS 插件沙箱、内置插件和应用内插件市场。
+- 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器；桌面发布成功后，
+  容器会同时发布到 Docker Hub 与 GHCR。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1 数据的
+迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
+
+条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录与现有环境并行
+测试 v2。请勿让本 beta 成为重要下载文件的唯一存储位置。
+
+## 建议测试项
+
+- HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
+- 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
+- Headless Server 部署、数据持久化和远程配对
+
+## 发布门禁通过后的计划下载
+
+| 发布方式 | 架构 | 计划产物 |
+|----------|------|----------|
+| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
+| Windows | `x64` | 未签名的 NSIS 安装包（`.exe`）和 ZIP |
+| Linux | `x64`、`arm64` | DEB 和 RPM |
+| Flatpak Native Host 配套程序 | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.12-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中不可变的 `2.0.0-beta.12` tag |
+| Snap Store | — | 本 beta 不发布 |
+
+发布完成后，容器镜像地址为
+`docker.io/motrixapp/motrix-server:2.0.0-beta.12` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.12`。数据持久化、网络和升级方法请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.12/docs/docker-server.zh-CN.md)。
+
+## 已知发布限制
+
+- 本 beta 不发布 AppImage。
+- Flatpak 会单独验证，不会随该版本 tag 发布；GitHub Release 会包含其 Native
+  Host 配套程序压缩包。
+- 不提供 Windows `arm64` 和任何 32 位安装包。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅在正式发布后
+  从 GitHub 官方 Release 下载。
+- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
+- 本 beta 不发布 Snap。预发布 Snap run 会在 source validation 后停止，不会构建
+  或发布 Snap artifact。
+
+## 反馈
+
+请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现的问题，
+并附上操作系统、架构、安装包类型和复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -76,15 +76,28 @@
   <releases>
     <!-- Update this list on every release; Flathub linter requires the most
          recent version listed here to match the manifest's source tag. -->
+    <release version="2.0.0-beta.12" date="2026-08-16">
+      <description>
+        <p>
+          Release assembly update that validates and canonicalizes every
+          platform updater manifest, collapses only metadata-identical source
+          duplicates, and regenerates the Linux and Windows updater metadata
+          from the verified package set. Windows packages remain unsigned.
+          Prerelease Snap runs stop after source validation without building
+          or publishing artifacts.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.11" date="2026-08-16">
       <description>
         <p>
-          Release assembly update that validates the real macOS updater
-          manifest shape, accepts only metadata-identical duplicate entries,
-          and canonicalizes the combined updater feed to one ZIP per
-          architecture. Windows packages remain unsigned. Prerelease Snap
-          runs stop after source validation without building or publishing
-          artifacts.
+          Unpublished Motrix Turbo beta attempt. All five desktop builds and
+          all three Finalize jobs succeeded. Assembly then rejected a Linux
+          updater source manifest containing a metadata-identical duplicate
+          RPM entry before creating the release bundle. GitHub Release, R2,
+          and container publication did not run. The prerelease Snap workflow
+          stopped after source validation, and external distribution remained
+          zero.
         </p>
       </description>
     </release>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.11",
+  "version": "2.0.0-beta.12",
   "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1",
   "description": "A full-featured download manager",
   "keywords": [],

--- a/scripts/assemble-release-artifacts.mjs
+++ b/scripts/assemble-release-artifacts.mjs
@@ -128,7 +128,6 @@ export async function assembleReleaseArtifacts({
     const assets = [...files.values()].filter((file) => file.kind === 'asset')
     assertRequiredAssets(target, assets, version)
     const manifests = new Map()
-    const manifestSources = new Map()
     for (const manifestName of manifestNames) {
       const manifestFile = files.get(manifestName.toLowerCase())
       if (!manifestFile) {
@@ -154,7 +153,6 @@ export async function assembleReleaseArtifacts({
         manifestName
       )
       manifests.set(manifestName, verifiedManifest)
-      manifestSources.set(manifestName, manifestFile.source)
     }
 
     targetResults.push({
@@ -162,7 +160,6 @@ export async function assembleReleaseArtifacts({
       directory,
       files,
       manifests,
-      manifestSources,
     })
   }
 
@@ -207,9 +204,14 @@ export async function assembleReleaseArtifacts({
   for (const target of targetResults) {
     if (target.name.startsWith('darwin-')) continue
     for (const manifestName of targetManifestNames(target, channel)) {
+      const manifest = target.manifests.get(manifestName)
       addOutputFile(outputFiles, manifestName, {
-        kind: 'copy',
-        source: target.manifestSources.get(manifestName),
+        kind: 'content',
+        content: dump(manifest.document, {
+          lineWidth: -1,
+          noRefs: true,
+          sortKeys: false,
+        }),
         target: target.name,
       })
     }
@@ -393,11 +395,6 @@ async function verifyManifestAssets(
       ) {
         throw new Error(
           `${target.name}/${manifestName}: duplicate manifest asset ${file.url} has conflicting metadata`
-        )
-      }
-      if (!target.sourceManifestAssetNames) {
-        throw new Error(
-          `${target.name}/${manifestName}: files[] must contain exactly ${expectedNames.join(', ')}`
         )
       }
     } else {

--- a/tests/scripts/assemble-release-artifacts.test.ts
+++ b/tests/scripts/assemble-release-artifacts.test.ts
@@ -81,6 +81,19 @@ describe('assembleReleaseArtifacts', () => {
     expect(macManifest.path).toBe(fixture.names.macX64Zip)
     expect(macManifest.sha512).toBe(macManifest.files[0].sha512)
 
+    for (const manifestName of [
+      'latest-linux.yml',
+      'beta-linux.yml',
+      'latest-linux-arm64.yml',
+      'beta-linux-arm64.yml',
+    ]) {
+      const linuxManifest = load(
+        await readFile(path.join(fixture.output, manifestName), 'utf8')
+      ) as { files: Array<{ url: string }> }
+      expect(linuxManifest.files).toHaveLength(2)
+      expect(new Set(linuxManifest.files.map((file) => file.url)).size).toBe(2)
+    }
+
     await expect(
       verifyUpdateArtifacts({
         directory: fixture.output,
@@ -131,6 +144,39 @@ describe('assembleReleaseArtifacts', () => {
       })
     ).rejects.toThrow(
       `darwin-arm64/latest-mac.yml: duplicate manifest asset ${fixture.names.macArm64Dmg} has conflicting metadata`
+    )
+  })
+
+  it('rejects conflicting duplicate Linux manifest entries', async () => {
+    const fixture = await createFixture()
+    await writeManifest(
+      fixture.paths.linuxX64BetaManifest,
+      VERSION,
+      [
+        {
+          name: fixture.names.linuxX64Deb,
+          content: fixture.contents.linuxX64Deb,
+        },
+        {
+          name: fixture.names.linuxX64Rpm,
+          content: fixture.contents.linuxX64Rpm,
+        },
+        {
+          name: fixture.names.linuxX64Rpm,
+          content: Buffer.from('conflicting Linux x64 RPM metadata'),
+        },
+      ],
+      fixture.names.linuxX64Deb
+    )
+
+    await expect(
+      assembleReleaseArtifacts({
+        inputDirectory: fixture.input,
+        outputDirectory: fixture.output,
+        version: VERSION,
+      })
+    ).rejects.toThrow(
+      `linux-x64/beta-linux.yml: duplicate manifest asset ${fixture.names.linuxX64Rpm} has conflicting metadata`
     )
   })
 
@@ -619,20 +665,23 @@ async function createFixture(version = VERSION) {
   )
   await writeAsset(linuxX64, names.linuxX64Rpm, contents.linuxX64Rpm)
   const linuxX64Manifest = path.join(linuxX64, 'latest-linux.yml')
+  const linuxX64BetaManifest = path.join(linuxX64, 'beta-linux.yml')
   await writeManifest(
     linuxX64Manifest,
     version,
     [
       { name: names.linuxX64Deb, content: contents.linuxX64Deb },
       { name: names.linuxX64Rpm, content: contents.linuxX64Rpm },
+      { name: names.linuxX64Rpm, content: contents.linuxX64Rpm },
     ],
     names.linuxX64Deb
   )
   await writeManifest(
-    path.join(linuxX64, 'beta-linux.yml'),
+    linuxX64BetaManifest,
     version,
     [
       { name: names.linuxX64Deb, content: contents.linuxX64Deb },
+      { name: names.linuxX64Rpm, content: contents.linuxX64Rpm },
       { name: names.linuxX64Rpm, content: contents.linuxX64Rpm },
     ],
     names.linuxX64Deb
@@ -661,6 +710,7 @@ async function createFixture(version = VERSION) {
     [
       { name: names.linuxArm64Deb, content: contents.linuxArm64Deb },
       { name: names.linuxArm64Rpm, content: contents.linuxArm64Rpm },
+      { name: names.linuxArm64Rpm, content: contents.linuxArm64Rpm },
     ],
     names.linuxArm64Deb
   )
@@ -669,6 +719,7 @@ async function createFixture(version = VERSION) {
     version,
     [
       { name: names.linuxArm64Deb, content: contents.linuxArm64Deb },
+      { name: names.linuxArm64Rpm, content: contents.linuxArm64Rpm },
       { name: names.linuxArm64Rpm, content: contents.linuxArm64Rpm },
     ],
     names.linuxArm64Deb
@@ -703,6 +754,7 @@ async function createFixture(version = VERSION) {
       linuxArm64Rpm: linuxArm64Rpm.path,
       linuxX64Deb: linuxX64Deb.path,
       linuxX64Companion: linuxX64Companion.path,
+      linuxX64BetaManifest,
       linuxX64Manifest,
       macArm64Manifest,
       macArm64Zip: macArm64Zip.path,

--- a/tests/scripts/release-version-contract.test.ts
+++ b/tests/scripts/release-version-contract.test.ts
@@ -423,7 +423,7 @@ describe('release version contract', () => {
     expect(beta10Metainfo).not.toMatch(secretLikeIdentifier)
   })
 
-  it('preserves beta.11 macOS manifest recovery and distribution limits', () => {
+  it('records beta.11 as an unpublished Linux manifest assembly attempt', () => {
     const english = read('docs/release-notes/2.0.0-beta.11.md')
     const chinese = read('docs/release-notes/2.0.0-beta.11.zh-CN.md')
     const normalizedEnglish = english.replace(/\s+/g, ' ')
@@ -435,26 +435,95 @@ describe('release version contract', () => {
       )?.[0] ?? ''
     const normalizedBeta11Metainfo = beta11Metainfo.replace(/\s+/g, ' ')
 
-    expect(normalizedEnglish).toContain(
-      "Validates each architecture's real macOS updater source manifest against the exact ZIP and DMG basenames"
+    expect(english).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.12/docs/release-notes/2.0.0-beta.11.zh-CN.md'
+    )
+    expect(chinese).toContain(
+      'https://github.com/agalwood/Motrix/blob/v2.0.0-beta.12/docs/release-notes/2.0.0-beta.11.md'
     )
     expect(normalizedEnglish).toContain(
-      'Accepts and collapses only metadata-identical duplicate manifest entries'
+      'Motrix 2.0.0-beta.11 was not published'
+    )
+    expect(normalizedEnglish).toContain('all five desktop Build jobs')
+    expect(normalizedEnglish).toContain(
+      'The explicitly unsigned Windows Finalize job and both macOS Finalize jobs also completed their full package verification'
     )
     expect(normalizedEnglish).toContain(
-      'Canonicalizes each macOS source manifest to its updater ZIP before merging the architectures'
+      'listed the expected DEB once and the expected RPM twice with identical basename, size, and SHA-512 metadata'
+    )
+    expect(normalizedChinese).toContain('Motrix 2.0.0-beta.11 未发布')
+    expect(normalizedChinese).toContain('5 个桌面 Build job 全部成功')
+    expect(normalizedChinese).toContain(
+      '两条 basename、大小和 SHA-512 元数据完全相同的预期 RPM'
+    )
+    for (const source of [english, chinese]) {
+      expect(source).toContain('Snap')
+      expect(source).toContain('2.0.0-beta.12')
+      expect(source).not.toMatch(restrictedPublicLanguage)
+      expect(source).not.toMatch(secretLikeIdentifier)
+    }
+    expect(normalizedEnglish).toContain(
+      'The GitHub Release, R2 update feed, and Docker Hub/GHCR container publication did not run'
+    )
+    expect(normalizedEnglish).toContain('External distribution remained zero')
+    expect(normalizedChinese).toContain(
+      'GitHub Release、R2 更新数据源以及 Docker Hub/GHCR 容器发布均未执行'
+    )
+    expect(normalizedChinese).toContain('外部分发 为零')
+    expect(metainfo).toContain(
+      '<release version="2.0.0-beta.11" date="2026-08-16">'
+    )
+    expect(normalizedBeta11Metainfo).toContain(
+      'All five desktop builds and all three Finalize jobs succeeded'
+    )
+    expect(normalizedBeta11Metainfo).toContain(
+      'a metadata-identical duplicate RPM entry'
+    )
+    expect(normalizedBeta11Metainfo).toContain(
+      'external distribution remained zero'
+    )
+    expect(beta11Metainfo).not.toMatch(restrictedPublicLanguage)
+    expect(beta11Metainfo).not.toMatch(secretLikeIdentifier)
+  })
+
+  it('preserves beta.12 canonical manifest recovery and distribution limits', () => {
+    const english = read('docs/release-notes/2.0.0-beta.12.md')
+    const chinese = read('docs/release-notes/2.0.0-beta.12.zh-CN.md')
+    const normalizedEnglish = english.replace(/\s+/g, ' ')
+    const normalizedChinese = chinese.replace(/\s+/g, ' ')
+    const metainfo = read('flatpak/app.motrix.native.metainfo.xml')
+    const beta12Metainfo =
+      /<release version="2\.0\.0-beta\.12"[\s\S]*?<\/release>/.exec(
+        metainfo
+      )?.[0] ?? ''
+    const normalizedBeta12Metainfo = beta12Metainfo.replace(/\s+/g, ' ')
+
+    expect(normalizedEnglish).toContain(
+      'Validates every source updater manifest against the exact allowlisted basenames, file sizes, and SHA-512 values'
     )
     expect(normalizedEnglish).toContain(
-      'one verified ZIP for Intel and one for Apple Silicon'
+      'Accepts and collapses only duplicate entries whose basename, size, and SHA-512 metadata are identical'
+    )
+    expect(normalizedEnglish).toContain(
+      'Regenerates the published Linux and Windows updater manifests from the canonical verified package set'
+    )
+    expect(normalizedEnglish).toContain(
+      'Each Linux feed therefore contains exactly one DEB and one RPM entry'
+    )
+    expect(normalizedEnglish).toContain(
+      '17 release assets and four beta updater manifests pass the recovered path'
     )
     expect(normalizedChinese).toContain(
-      '按每个架构的精确 ZIP 与 DMG basename 验证真实 macOS updater 源 manifest'
+      '按精确 allowlist basename、文件大小与 SHA-512 值验证 每一份 updater 源 manifest'
     )
     expect(normalizedChinese).toContain(
-      '只接受并折叠元数据完全相同的重复 manifest 条目'
+      '只接受并折叠 basename、大小与 SHA-512 元数据完全相同的重复条目'
     )
     expect(normalizedChinese).toContain(
-      '将每个 macOS 源 manifest 规范化为 updater ZIP'
+      '重新生成公开的 Linux 与 Windows updater manifest'
+    )
+    expect(normalizedChinese).toContain(
+      '每份 Linux 更新数据源都只包含一条 DEB 与 一条 RPM'
     )
     for (const source of [english, chinese]) {
       expect(source).toContain('Snap')
@@ -462,29 +531,30 @@ describe('release version contract', () => {
       expect(source).toContain('AppImage')
       expect(source).toContain('Flatpak')
       expect(source).toContain(
-        'Motrix-Native-Host-2.0.0-beta.11-linux-<arch>.tar.gz'
+        'Motrix-Native-Host-2.0.0-beta.12-linux-<arch>.tar.gz'
       )
       expect(source).toContain('SmartScreen')
       expect(source).toContain(
-        'docker.io/motrixapp/motrix-server:2.0.0-beta.11'
+        'docker.io/motrixapp/motrix-server:2.0.0-beta.12'
       )
-      expect(source).toContain('ghcr.io/agalwood/motrix-server:2.0.0-beta.11')
+      expect(source).toContain('ghcr.io/agalwood/motrix-server:2.0.0-beta.12')
       expect(source).not.toMatch(restrictedPublicLanguage)
       expect(source).not.toMatch(secretLikeIdentifier)
     }
     expect(metainfo).toContain(
-      '<release version="2.0.0-beta.11" date="2026-08-16">'
+      '<release version="2.0.0-beta.12" date="2026-08-16">'
     )
-    expect(normalizedBeta11Metainfo).toContain('real macOS updater')
-    expect(normalizedBeta11Metainfo).toContain(
-      'metadata-identical duplicate entries'
+    expect(normalizedBeta12Metainfo).toContain(
+      'validates and canonicalizes every platform updater manifest'
     )
-    expect(normalizedBeta11Metainfo).toContain('one ZIP per architecture')
-    expect(normalizedBeta11Metainfo).toContain(
+    expect(normalizedBeta12Metainfo).toContain(
+      'regenerates the Linux and Windows updater metadata from the verified package set'
+    )
+    expect(normalizedBeta12Metainfo).toContain(
       'Windows packages remain unsigned'
     )
-    expect(beta11Metainfo).not.toMatch(restrictedPublicLanguage)
-    expect(beta11Metainfo).not.toMatch(secretLikeIdentifier)
+    expect(beta12Metainfo).not.toMatch(restrictedPublicLanguage)
+    expect(beta12Metainfo).not.toMatch(secretLikeIdentifier)
   })
 
   it('preserves beta.6 Snap recovery and canceled release history', () => {


### PR DESCRIPTION
## What changed

- accept only metadata-identical duplicate updater entries across all release targets
- regenerate Linux and Windows updater manifests from the canonical verified package set
- add real-shape x64/arm64 Linux regressions and conflicting-duplicate coverage
- advance the release candidate to 2.0.0-beta.12 and preserve beta.11 as an unpublished, non-sensitive historical record

## Root cause

Electron Builder 26.15.7 emitted each Linux source manifest with the expected DEB plus an identical duplicate RPM entry. The assembler only allowed duplicate-identical source entries for macOS, so beta.11 stopped at linux-x64/beta-linux.yml after all builds and Finalize jobs succeeded.

## Impact

Every manifest entry remains bound to an exact allowlisted basename, file size, and SHA-512. Only fully identical duplicates are collapsed; unknown, missing, case-mismatched, or conflicting entries remain fail-closed. Linux feeds are regenerated with exactly one DEB and one RPM per architecture. Windows remains explicitly unsigned, and prerelease Snap runs remain source-validation-only.

## Verification

- full release-script suite: 40 files / 515 tests
- bridge release contracts: 5 files / 81 tests
- focused assembler/update/version contracts: 45 tests
- real beta.11 five-platform inputs: 17 release assets and 4 beta manifests assembled and verified
- TypeScript, Biome, boundaries, file-name, Flatpak packaging, AppStream XML, and diff checks
