### PR TITLE
fix(release): harden container attestation verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1723,23 +1723,44 @@ jobs:
       - name: Verify immutable signatures
         shell: bash
         env:
+          COSIGN_VERIFY_ERROR: ${{ runner.temp }}/cosign-verify-error.log
           DOCKER_CONFIG: ${{ runner.temp }}/anonymous-docker
           PUBLISHED_DIGEST: ${{ steps.immutable-publication.outputs.publication_digest }}
         run: |
           set -euo pipefail
           identity="https://github.com/agalwood/Motrix/.github/workflows/release.yml@refs/tags/${GITHUB_REF_NAME}"
+          verify_signature() {
+            local repository="$1"
+            local max_attempts=18
+            local retry_delay_seconds=10
+            local attempt
+            for (( attempt = 1; attempt <= max_attempts; attempt += 1 )); do
+              if cosign verify \
+                --certificate-identity "$identity" \
+                --certificate-oidc-issuer \
+                  'https://token.actions.githubusercontent.com' \
+                "${repository}@${PUBLISHED_DIGEST}" \
+                > /dev/null 2> "$COSIGN_VERIFY_ERROR"; then
+                return 0
+              fi
+              if (( attempt == max_attempts )); then
+                cat "$COSIGN_VERIFY_ERROR" >&2
+                return 1
+              fi
+              echo "Signature is not yet visible for ${repository}; retrying (${attempt}/${max_attempts})"
+              sleep "$retry_delay_seconds"
+            done
+          }
           for repository in "$DOCKERHUB_REPOSITORY" "$GHCR_REPOSITORY"; do
-            cosign verify \
-              --certificate-identity "$identity" \
-              --certificate-oidc-issuer \
-                'https://token.actions.githubusercontent.com' \
-              "${repository}@${PUBLISHED_DIGEST}" > /dev/null
+            verify_signature "$repository"
           done
 
       - name: Verify anonymous multi-architecture artifacts
         shell: bash
         env:
           DOCKER_CONFIG: ${{ runner.temp }}/anonymous-docker
+          EXPECTED_BUILDER_RUN: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          MAXIMUM_BUILDER_ATTEMPT: ${{ github.run_attempt }}
           PUBLISHED_DIGEST: ${{ steps.immutable-publication.outputs.publication_digest }}
           SNAPSHOT_DIRECTORY: ${{ runner.temp }}/container-publication
         run: |
@@ -1776,8 +1797,8 @@ jobs:
             --ghcr-index "$SNAPSHOT_DIRECTORY/ghcr-index.json" \
             --ghcr-sbom "$SNAPSHOT_DIRECTORY/ghcr-sbom.json" \
             --ghcr-provenance "$SNAPSHOT_DIRECTORY/ghcr-provenance.json" \
-            --builder-id-prefix \
-              'https://github.com/docker/buildx/actions/runs/' \
+            --builder-run-id "$EXPECTED_BUILDER_RUN" \
+            --maximum-builder-attempt "$MAXIMUM_BUILDER_ATTEMPT" \
             --version "$CONTAINER_VERSION" \
             --revision "$GITHUB_SHA"
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. After its remaining release gates pass,
-download [v2.0.0-beta.12 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.12)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.12.md) before
+download [v2.0.0-beta.13 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.13)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.13.md) before
 installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -149,7 +149,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.12'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.13'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。剩余发布门禁通过后，请从 GitHub Releases
-下载 [v2.0.0-beta.12](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.12)，
-并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.12.zh-CN.md)。
+下载 [v2.0.0-beta.13](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.13)，
+并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.13.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -143,7 +143,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.12'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.13'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.12.md
+++ b/docs/release-notes/2.0.0-beta.12.md
@@ -1,17 +1,39 @@
 # Motrix 2.0.0-beta.12
 
-English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.12/docs/release-notes/2.0.0-beta.12.zh-CN.md)
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.13/docs/release-notes/2.0.0-beta.12.zh-CN.md)
 
-Motrix 2.0.0-beta.12 is the next Motrix Turbo beta intended for public
-distribution after every protected release gate passes. It continues public
-validation of the rebuilt v2 desktop app and headless server, shared download
-core, MDXP integrations, and sandboxed plugin system.
+> Motrix 2.0.0-beta.12 was publicly distributed. This historical record was
+> finalized for beta.13 after the release workflow reached its terminal state.
 
 Motrix 2.0.0-beta.11 was not published. All five desktop builds and all three
 Finalize jobs completed, but assembly rejected the real Linux updater manifest
 shape before a release bundle was created. The
 [beta.11 historical record](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.12/docs/release-notes/2.0.0-beta.11.md)
 preserves the exact outcome.
+
+## Publication outcome
+
+- The protected source gate, all five desktop Build jobs, all three Finalize
+  jobs, release assembly, and final updater-manifest verification succeeded.
+- The GitHub prerelease published 21 assets. The recovered R2 job published 17
+  versioned assets and then the four beta updater manifests, with public
+  convergence checks passing for each manifest.
+- Docker Hub and GHCR received the same immutable multi-architecture Server
+  image at digest
+  `sha256:b91e329301087d0ce1b0fb25cb0103bb68ff21d13941eb39e797c3e283a9c5a8`.
+  Both registry digests were signed with the tag workflow identity.
+- Immediate anonymous signature lookup briefly reported no visible signature;
+  a later targeted retry verified both registries successfully. The remaining
+  failure came from the final provenance contract expecting an obsolete
+  Docker Buildx URL instead of the real repository workflow run and attempt.
+- The protected prerelease Snap workflow passed source validation and, as
+  designed, skipped both architecture builds and Store publication.
+
+The desktop release and immutable container images remain public, and the
+mutable beta update feeds advanced successfully to beta.12. Motrix
+2.0.0-beta.13 supersedes the incomplete workflow result while preserving
+beta.12 as a published prerelease. See the
+[beta.13 release notes](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.13/docs/release-notes/2.0.0-beta.13.md).
 
 ## Release reliability updates
 
@@ -78,9 +100,9 @@ important downloads.
   plugins
 - Headless Server deployment, persistent storage, and remote pairing
 
-## Planned downloads after release gates pass
+## Published distributions
 
-| Distribution | Architectures | Planned output |
+| Distribution | Architectures | Output |
 |--------------|---------------|----------------|
 | macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
 | Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |

--- a/docs/release-notes/2.0.0-beta.12.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.12.zh-CN.md
@@ -1,15 +1,34 @@
 # Motrix 2.0.0-beta.12
 
-[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.12/docs/release-notes/2.0.0-beta.12.md) | 简体中文
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.13/docs/release-notes/2.0.0-beta.12.md) | 简体中文
 
-Motrix 2.0.0-beta.12 是下一次计划公开发布的 Motrix Turbo beta，但只有全部受保护
-发布门禁通过后才会进入分发。该版本继续验证重新开发的 v2 桌面应用与 Headless
-Server、共用下载内核、MDXP 集成和沙箱化插件系统。
+> Motrix 2.0.0-beta.12 已公开分发。本历史记录在发布 workflow 进入终态后于
+> beta.13 中定稿。
 
 Motrix 2.0.0-beta.11 未发布。5 个桌面构建与 3 个 Finalize job 均完成，但组装在
 release bundle 创建前拒绝了真实 Linux updater manifest 结构。
 [beta.11 历史记录](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.12/docs/release-notes/2.0.0-beta.11.zh-CN.md)
 保留了该次尝试的准确结果。
+
+## 发布结果
+
+- 受保护 source gate、5 个桌面 Build job、3 个 Finalize job、release 组装与最终
+  updater manifest 验证均成功。
+- GitHub 预发布版发布了 21 个产物。恢复后的 R2 job 先发布 17 个带版本产物，
+  再发布 4 份 beta updater manifest；每份 manifest 的公开收敛检查均通过。
+- Docker Hub 与 GHCR 收到了相同的不可变多架构 Server 镜像，digest 为
+  `sha256:b91e329301087d0ce1b0fb25cb0103bb68ff21d13941eb39e797c3e283a9c5a8`。
+  两个 registry 的 digest 均使用该 tag workflow 身份完成签名。
+- 紧接签名后的匿名查询曾短暂报告尚未看到签名；稍后的定向重试成功验证了两个
+  registry。剩余失败来自最终 provenance 契约仍期待旧 Docker Buildx URL，而不
+  是真实的仓库 workflow run 与 attempt。
+- 受保护的预发布 Snap workflow 通过 source validation 后，按设计跳过了两个
+  架构构建与 Store 发布。
+
+桌面 Release 与不可变容器镜像均保持公开，可变 beta 更新数据源也已成功推进至
+beta.12。Motrix 2.0.0-beta.13 会取代 beta.12 未完整收敛的 workflow 结果，但
+beta.12 仍保留为已发布预发布版。
+请参阅 [beta.13 发布说明](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.13/docs/release-notes/2.0.0-beta.13.zh-CN.md)。
 
 ## 发布可靠性更新
 
@@ -62,9 +81,9 @@ Snap 不属于 beta.12 的分发范围。受保护的预发布 Snap run 会在 s
 - 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
 - Headless Server 部署、数据持久化和远程配对
 
-## 发布门禁通过后的计划下载
+## 已发布分发
 
-| 发布方式 | 架构 | 计划产物 |
+| 发布方式 | 架构 | 产物 |
 |----------|------|----------|
 | macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
 | Windows | `x64` | 未签名的 NSIS 安装包（`.exe`）和 ZIP |

--- a/docs/release-notes/2.0.0-beta.13.md
+++ b/docs/release-notes/2.0.0-beta.13.md
@@ -1,0 +1,118 @@
+# Motrix 2.0.0-beta.13
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.13/docs/release-notes/2.0.0-beta.13.zh-CN.md)
+
+Motrix 2.0.0-beta.13 is the next Motrix Turbo beta intended for public
+distribution after every protected release gate passes. It continues public
+validation of the rebuilt v2 desktop app and headless server, shared download
+core, MDXP integrations, and sandboxed plugin system.
+
+Motrix 2.0.0-beta.12 published its desktop release, update feeds, and immutable
+Server images, but its final container verification job did not reach success.
+The [beta.12 historical record](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.13/docs/release-notes/2.0.0-beta.12.md)
+preserves the exact public outcome.
+
+## Release reliability updates
+
+- Retries anonymous signature verification for up to 18 attempts with a
+  10-second delay, allowing bounded registry convergence after signing while
+  still failing closed if either registry never exposes a valid signature.
+- Keeps the exact tag-workflow identity and GitHub OIDC issuer checks on every
+  retry; a visible signature from any other identity remains invalid.
+- Verifies BuildKit provenance against the exact current repository workflow
+  run. The builder attempt must be a positive integer no greater than the
+  current run attempt, which supports resumable failed-job retries without
+  accepting another repository, workflow run, future attempt, or path suffix.
+- Replaces the obsolete generic Docker Buildx builder prefix with the real
+  GitHub Actions builder form emitted by the beta.12 multi-architecture image.
+- Retains immutable cross-registry digest equality, amd64/arm64 image and
+  attestation checks, SPDX SBOM validation, exact source revision, provenance
+  completeness, and anonymous runtime smoke tests.
+- Publishes beta.13 under new immutable version tags. Existing beta.12 release
+  assets and container tags are never overwritten or reused; mutable beta
+  update feeds advance only after beta.13 versioned assets publish and their
+  public verification succeeds.
+- Keeps Windows `x64` packages explicitly unsigned while retaining final
+  package verification before release.
+- Retains the complete desktop platform-set gate: every desktop target must
+  finalize before assembly and every canonical updater manifest must pass
+  final verification before publication.
+
+## Snap beta policy
+
+Snap is not part of the beta.13 distribution. Protected prerelease Snap runs
+stop after source validation, so they do not build Snap artifacts, upload Store
+revisions, or change `latest/edge`. Stable Snap publication retains its
+complete two-architecture verification and protected Store gates.
+
+## Highlights
+
+- A ground-up desktop rebuild with Electron 43, React 19, and TypeScript 7,
+  including a customizable Dashboard, dark mode, a cross-platform application
+  menu, and clearer task-inspector feedback.
+- One host-neutral download core for both the desktop app and the Node/Web
+  Server, with SQLite session recovery, tracker management, UPnP/NAT-PMP, and
+  HTTP, FTP, BitTorrent, and magnet support.
+- MDXP-based integration for the official CLI and browser handoff, including
+  local discovery and device-code pairing for remote Server instances.
+- A QuickJS plugin sandbox with capability consent, bundled builtin plugins,
+  and an in-app plugin marketplace.
+- Persistent, multi-architecture Server containers for NAS and home-server
+  deployments, published to both Docker Hub and GHCR after the desktop release
+  succeeds.
+
+## Before testing
+
+This is prerelease software. Back up your existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Please do not rely on this beta for your only copy of
+important downloads.
+
+## What to test
+
+- HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
+  session recovery
+- Desktop integrations, browser and CLI handoff through MDXP, and sandboxed
+  plugins
+- Headless Server deployment, persistent storage, remote pairing, and both
+  amd64 and arm64 container images
+
+## Planned downloads after release gates pass
+
+| Distribution | Architectures | Planned output |
+|--------------|---------------|----------------|
+| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | DEB and RPM |
+| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.13-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.13` tag in both registries |
+| Snap Store | — | Not published for this beta |
+
+After publication, container images use
+`docker.io/motrixapp/motrix-server:2.0.0-beta.13` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.13`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.13/docs/docker-server.md)
+for storage, networking, and upgrade guidance.
+
+## Known distribution limits
+
+- AppImage is not published for this beta.
+- Flatpak is validated separately and is not published by the release tag;
+  the GitHub Release includes its Native Host companion archives.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
+  Download them only from the official GitHub Release after it is published.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+- Snap is not published for this beta. Prerelease Snap runs stop after source
+  validation without building or publishing Snap artifacts.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.13.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.13.zh-CN.md
@@ -1,0 +1,96 @@
+# Motrix 2.0.0-beta.13
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.13/docs/release-notes/2.0.0-beta.13.md) | 简体中文
+
+Motrix 2.0.0-beta.13 是下一次计划公开发布的 Motrix Turbo beta，但只有全部受保护
+发布门禁通过后才会进入分发。该版本继续验证重新开发的 v2 桌面应用与 Headless
+Server、共用下载内核、MDXP 集成和沙箱化插件系统。
+
+Motrix 2.0.0-beta.12 已发布桌面 Release、更新数据源和不可变 Server 镜像，但最终
+容器验证 job 未达到成功终态。[beta.12 历史记录](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.13/docs/release-notes/2.0.0-beta.12.zh-CN.md)
+保留了准确的公开结果。
+
+## 发布可靠性更新
+
+- 匿名签名验证最多执行 18 次，每次间隔 10 秒，为签名后的 registry 收敛提供有界
+  等待；如果任一 registry 始终没有公开有效签名，流程仍会 fail-closed。
+- 每次重试都保留精确的 tag workflow 身份与 GitHub OIDC issuer 校验；来自其他
+  身份的可见签名仍视为无效。
+- 根据当前仓库的精确 workflow run 验证 BuildKit provenance。builder attempt 必须
+  是不大于当前 run attempt 的正整数，因此失败 job 可以安全续跑，同时拒绝其他
+  仓库、其他 workflow run、未来 attempt 或附加路径后缀。
+- 将旧的通用 Docker Buildx builder prefix 替换为 beta.12 多架构镜像真实生成的
+  GitHub Actions builder 格式。
+- 保留两个 registry 的不可变 digest 一致性、amd64/arm64 镜像与 attestation、
+  SPDX SBOM、精确源码 revision、provenance 完整性以及匿名 runtime smoke 验证。
+- beta.13 使用新的不可变版本 tag 发布；不会覆盖或复用已有的 beta.12 Release
+  产物与容器 tag。只有 beta.13 带版本产物发布并通过公开验证后，才会推进可变 beta
+  更新数据源。
+- Windows `x64` 安装包继续明确采用未签名发布，同时保留发布前的最终安装包验证。
+- 继续执行完整桌面平台集合门禁：所有桌面目标完成 Finalize 后才能组装，且每份
+  规范 updater manifest 都必须通过最终验证后才能发布。
+
+## Snap beta 策略
+
+Snap 不属于 beta.13 的分发范围。受保护的预发布 Snap run 会在 source validation
+后停止，因此不会构建 Snap artifact、上传 Store revision 或修改 `latest/edge`。
+稳定版 Snap 发布仍保留完整的双架构验证与受保护 Store 门禁。
+
+## 主要变化
+
+- 使用 Electron 43、React 19 和 TypeScript 7 从头重建桌面应用，提供可自定义
+  Dashboard、深色模式、跨平台应用菜单，以及更清晰的任务检查器反馈。
+- 桌面应用和 Node/Web Server 共用与宿主无关的下载内核，支持 SQLite session
+  恢复、Tracker 管理、UPnP/NAT-PMP，以及 HTTP、FTP、BitTorrent 和磁力链接下载。
+- 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地发现及远程 Server 的
+  device-code 配对。
+- 提供带能力授权的 QuickJS 插件沙箱、内置插件和应用内插件市场。
+- 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器；桌面发布成功后，
+  容器会同时发布到 Docker Hub 与 GHCR。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1 数据的
+迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
+
+条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录与现有环境并行
+测试 v2。请勿让本 beta 成为重要下载文件的唯一存储位置。
+
+## 建议测试项
+
+- HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
+- 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
+- Headless Server 部署、数据持久化、远程配对，以及 amd64 与 arm64 容器镜像
+
+## 发布门禁通过后的计划下载
+
+| 发布方式 | 架构 | 计划产物 |
+|----------|------|----------|
+| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
+| Windows | `x64` | 未签名的 NSIS 安装包（`.exe`）和 ZIP |
+| Linux | `x64`、`arm64` | DEB 和 RPM |
+| Flatpak Native Host 配套程序 | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.13-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中不可变的 `2.0.0-beta.13` tag |
+| Snap Store | — | 本 beta 不发布 |
+
+发布完成后，容器镜像地址为
+`docker.io/motrixapp/motrix-server:2.0.0-beta.13` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.13`。数据持久化、网络和升级方法请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.13/docs/docker-server.zh-CN.md)。
+
+## 已知发布限制
+
+- 本 beta 不发布 AppImage。
+- Flatpak 会单独验证，不会随该版本 tag 发布；GitHub Release 会包含其 Native
+  Host 配套程序压缩包。
+- 不提供 Windows `arm64` 和任何 32 位安装包。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅在正式发布后
+  从 GitHub 官方 Release 下载。
+- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
+- 本 beta 不发布 Snap。预发布 Snap run 会在 source validation 后停止，不会构建
+  或发布 Snap artifact。
+
+## 反馈
+
+请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现的问题，
+并附上操作系统、架构、安装包类型和复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -76,15 +76,27 @@
   <releases>
     <!-- Update this list on every release; Flathub linter requires the most
          recent version listed here to match the manifest's source tag. -->
+    <release version="2.0.0-beta.13" date="2026-08-16">
+      <description>
+        <p>
+          Container publication recovery that waits for registry signature
+          visibility with a bounded fail-closed retry and verifies BuildKit
+          provenance against the exact repository workflow run and a valid
+          current-or-earlier attempt. Windows packages remain unsigned.
+          Prerelease Snap runs stop after source validation without building
+          or publishing artifacts.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.12" date="2026-08-16">
       <description>
         <p>
-          Release assembly update that validates and canonicalizes every
-          platform updater manifest, collapses only metadata-identical source
-          duplicates, and regenerates the Linux and Windows updater metadata
-          from the verified package set. Windows packages remain unsigned.
-          Prerelease Snap runs stop after source validation without building
-          or publishing artifacts.
+          Published Motrix Turbo beta. All five desktop builds, all three
+          Finalize jobs, assembly, the GitHub prerelease, and the R2 update
+          feed completed. Immutable amd64/arm64 Server images were published
+          to Docker Hub and GHCR. The overall workflow remained unsuccessful
+          because its final anonymous provenance check expected an obsolete
+          builder URL. Prerelease Snap stopped after source validation.
         </p>
       </description>
     </release>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.12",
+  "version": "2.0.0-beta.13",
   "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1",
   "description": "A full-featured download manager",
   "keywords": [],

--- a/scripts/verify-container-publication.mjs
+++ b/scripts/verify-container-publication.mjs
@@ -120,7 +120,46 @@ function verifySbom(sbom, repository) {
   }
 }
 
-function verifyProvenance(provenance, repository, revision, builderIdPrefix) {
+function positiveInteger(value, label) {
+  const text = typeof value === 'number' ? String(value) : string(value, label)
+  if (!/^[1-9][0-9]*$/.test(text)) {
+    throw new Error(`${label} must be a positive integer`)
+  }
+  const result = Number(text)
+  if (!Number.isSafeInteger(result)) {
+    throw new Error(`${label} must be a safe integer`)
+  }
+  return result
+}
+
+function verifyBuilderIdentity(
+  builderId,
+  repository,
+  platform,
+  builderRunId,
+  maximumBuilderAttempt
+) {
+  const expectedPrefix = `${builderRunId}/attempts/`
+  if (!builderId.startsWith(expectedPrefix)) {
+    throw new Error(`${repository} ${platform} builder identity conflicts`)
+  }
+  const attemptText = builderId.slice(expectedPrefix.length)
+  if (!/^[1-9][0-9]*$/.test(attemptText)) {
+    throw new Error(`${repository} ${platform} builder identity conflicts`)
+  }
+  const attempt = Number(attemptText)
+  if (!Number.isSafeInteger(attempt) || attempt > maximumBuilderAttempt) {
+    throw new Error(`${repository} ${platform} builder identity conflicts`)
+  }
+}
+
+function verifyProvenance(
+  provenance,
+  repository,
+  revision,
+  builderRunId,
+  maximumBuilderAttempt
+) {
   const document = record(provenance, `${repository} provenance result`)
   for (const platform of REQUIRED_CONTAINER_PLATFORMS) {
     const platformResult = record(
@@ -232,26 +271,55 @@ function verifyProvenance(provenance, repository, revision, builderIdPrefix) {
         }
       }
     }
-    if (builderIdPrefix && !builderId.startsWith(builderIdPrefix)) {
-      throw new Error(`${repository} ${platform} builder identity conflicts`)
-    }
+    verifyBuilderIdentity(
+      builderId,
+      repository,
+      platform,
+      builderRunId,
+      maximumBuilderAttempt
+    )
   }
 }
 
-function verifyArtifact(artifact, repository, revision, builderIdPrefix) {
+function verifyArtifact(
+  artifact,
+  repository,
+  revision,
+  builderRunId,
+  maximumBuilderAttempt
+) {
   const platformDigests = verifyIndex(artifact.index, repository)
   verifySbom(artifact.sbom, repository)
-  verifyProvenance(artifact.provenance, repository, revision, builderIdPrefix)
+  verifyProvenance(
+    artifact.provenance,
+    repository,
+    revision,
+    builderRunId,
+    maximumBuilderAttempt
+  )
   return platformDigests
 }
 
 export function verifyContainerPublication({
-  builderIdPrefix,
+  builderRunId,
   dockerHub,
   ghcr,
+  maximumBuilderAttempt,
   revision,
   version,
 }) {
+  const expectedBuilderRun = string(builderRunId, 'builder run id')
+  if (
+    !/^https:\/\/github\.com\/[^/]+\/[^/]+\/actions\/runs\/[1-9][0-9]*$/.test(
+      expectedBuilderRun
+    )
+  ) {
+    throw new Error('builder run id must be an exact GitHub Actions run URL')
+  }
+  const maximumAttempt = positiveInteger(
+    maximumBuilderAttempt,
+    'maximum builder attempt'
+  )
   const publication = resolveContainerPublicationState({
     dockerHubSnapshot: dockerHub.inspect,
     ghcrSnapshot: ghcr.inspect,
@@ -270,9 +338,16 @@ export function verifyContainerPublication({
       dockerHub,
       'Docker Hub',
       revision,
-      builderIdPrefix
+      expectedBuilderRun,
+      maximumAttempt
     ),
-    ghcr: verifyArtifact(ghcr, 'GHCR', revision, builderIdPrefix),
+    ghcr: verifyArtifact(
+      ghcr,
+      'GHCR',
+      revision,
+      expectedBuilderRun,
+      maximumAttempt
+    ),
     sbom: 'SPDX-2.x',
     provenance: 'SLSA BuildKit',
   }
@@ -289,7 +364,8 @@ function parseArgs(argv) {
     '--ghcr-index',
     '--ghcr-sbom',
     '--ghcr-provenance',
-    '--builder-id-prefix',
+    '--builder-run-id',
+    '--maximum-builder-attempt',
     '--version',
     '--revision',
   ])
@@ -319,10 +395,16 @@ function main() {
   const options = parseArgs(process.argv.slice(2))
   if (!options.version) throw new Error('--version is required')
   if (!options.revision) throw new Error('--revision is required')
+  if (!options['builder-run-id'])
+    throw new Error('--builder-run-id is required')
+  if (!options['maximum-builder-attempt']) {
+    throw new Error('--maximum-builder-attempt is required')
+  }
   const result = verifyContainerPublication({
-    builderIdPrefix: options['builder-id-prefix'],
+    builderRunId: options['builder-run-id'],
     dockerHub: readArtifact(options, 'docker-hub'),
     ghcr: readArtifact(options, 'ghcr'),
+    maximumBuilderAttempt: options['maximum-builder-attempt'],
     revision: options.revision,
     version: options.version,
   })

--- a/tests/scripts/release-version-contract.test.ts
+++ b/tests/scripts/release-version-contract.test.ts
@@ -486,7 +486,7 @@ describe('release version contract', () => {
     expect(beta11Metainfo).not.toMatch(secretLikeIdentifier)
   })
 
-  it('preserves beta.12 canonical manifest recovery and distribution limits', () => {
+  it('records beta.12 canonical manifest recovery and public outcome', () => {
     const english = read('docs/release-notes/2.0.0-beta.12.md')
     const chinese = read('docs/release-notes/2.0.0-beta.12.zh-CN.md')
     const normalizedEnglish = english.replace(/\s+/g, ' ')
@@ -525,6 +525,32 @@ describe('release version contract', () => {
     expect(normalizedChinese).toContain(
       '每份 Linux 更新数据源都只包含一条 DEB 与 一条 RPM'
     )
+    expect(normalizedEnglish).toContain(
+      'Motrix 2.0.0-beta.12 was publicly distributed'
+    )
+    expect(normalizedEnglish).toContain(
+      'The GitHub prerelease published 21 assets'
+    )
+    expect(normalizedEnglish).toContain(
+      'The recovered R2 job published 17 versioned assets and then the four beta updater manifests'
+    )
+    expect(normalizedEnglish).toContain(
+      'Both registry digests were signed with the tag workflow identity'
+    )
+    expect(normalizedEnglish).toContain(
+      'the final provenance contract expecting an obsolete Docker Buildx URL instead of the real repository workflow run and attempt'
+    )
+    expect(normalizedEnglish).toContain(
+      'The desktop release and immutable container images remain public, and the mutable beta update feeds advanced successfully to beta.12'
+    )
+    expect(normalizedChinese).toContain('Motrix 2.0.0-beta.12 已公开分发')
+    expect(normalizedChinese).toContain('GitHub 预发布版发布了 21 个产物')
+    expect(normalizedChinese).toContain(
+      '恢复后的 R2 job 先发布 17 个带版本产物， 再发布 4 份 beta updater manifest'
+    )
+    expect(normalizedChinese).toContain(
+      '剩余失败来自最终 provenance 契约仍期待旧 Docker Buildx URL'
+    )
     for (const source of [english, chinese]) {
       expect(source).toContain('Snap')
       expect(source).toContain('latest/edge')
@@ -545,16 +571,87 @@ describe('release version contract', () => {
       '<release version="2.0.0-beta.12" date="2026-08-16">'
     )
     expect(normalizedBeta12Metainfo).toContain(
-      'validates and canonicalizes every platform updater manifest'
+      'All five desktop builds, all three Finalize jobs, assembly, the GitHub prerelease, and the R2 update feed completed'
     )
     expect(normalizedBeta12Metainfo).toContain(
-      'regenerates the Linux and Windows updater metadata from the verified package set'
+      'Immutable amd64/arm64 Server images were published to Docker Hub and GHCR'
     )
     expect(normalizedBeta12Metainfo).toContain(
-      'Windows packages remain unsigned'
+      'The overall workflow remained unsuccessful because its final anonymous provenance check expected an obsolete builder URL'
     )
     expect(beta12Metainfo).not.toMatch(restrictedPublicLanguage)
     expect(beta12Metainfo).not.toMatch(secretLikeIdentifier)
+  })
+
+  it('preserves beta.13 container verification recovery and distribution limits', () => {
+    const english = read('docs/release-notes/2.0.0-beta.13.md')
+    const chinese = read('docs/release-notes/2.0.0-beta.13.zh-CN.md')
+    const normalizedEnglish = english.replace(/\s+/g, ' ')
+    const normalizedChinese = chinese.replace(/\s+/g, ' ')
+    const metainfo = read('flatpak/app.motrix.native.metainfo.xml')
+    const beta13Metainfo =
+      /<release version="2\.0\.0-beta\.13"[\s\S]*?<\/release>/.exec(
+        metainfo
+      )?.[0] ?? ''
+    const normalizedBeta13Metainfo = beta13Metainfo.replace(/\s+/g, ' ')
+
+    expect(normalizedEnglish).toContain(
+      'Retries anonymous signature verification for up to 18 attempts with a 10-second delay'
+    )
+    expect(normalizedEnglish).toContain(
+      'still failing closed if either registry never exposes a valid signature'
+    )
+    expect(normalizedEnglish).toContain(
+      'Verifies BuildKit provenance against the exact current repository workflow run'
+    )
+    expect(normalizedEnglish).toContain(
+      'The builder attempt must be a positive integer no greater than the current run attempt'
+    )
+    expect(normalizedEnglish).toContain(
+      'without accepting another repository, workflow run, future attempt, or path suffix'
+    )
+    expect(normalizedEnglish).toContain(
+      'Existing beta.12 release assets and container tags are never overwritten or reused; mutable beta update feeds advance only after beta.13 versioned assets publish'
+    )
+    expect(normalizedChinese).toContain(
+      '匿名签名验证最多执行 18 次，每次间隔 10 秒'
+    )
+    expect(normalizedChinese).toContain(
+      '根据当前仓库的精确 workflow run 验证 BuildKit provenance'
+    )
+    expect(normalizedChinese).toContain(
+      '拒绝其他 仓库、其他 workflow run、未来 attempt 或附加路径后缀'
+    )
+    for (const source of [english, chinese]) {
+      expect(source).toContain('Snap')
+      expect(source).toContain('latest/edge')
+      expect(source).toContain('AppImage')
+      expect(source).toContain('Flatpak')
+      expect(source).toContain(
+        'Motrix-Native-Host-2.0.0-beta.13-linux-<arch>.tar.gz'
+      )
+      expect(source).toContain('SmartScreen')
+      expect(source).toContain(
+        'docker.io/motrixapp/motrix-server:2.0.0-beta.13'
+      )
+      expect(source).toContain('ghcr.io/agalwood/motrix-server:2.0.0-beta.13')
+      expect(source).not.toMatch(restrictedPublicLanguage)
+      expect(source).not.toMatch(secretLikeIdentifier)
+    }
+    expect(metainfo).toContain(
+      '<release version="2.0.0-beta.13" date="2026-08-16">'
+    )
+    expect(normalizedBeta13Metainfo).toContain(
+      'waits for registry signature visibility with a bounded fail-closed retry'
+    )
+    expect(normalizedBeta13Metainfo).toContain(
+      'the exact repository workflow run and a valid current-or-earlier attempt'
+    )
+    expect(normalizedBeta13Metainfo).toContain(
+      'Windows packages remain unsigned'
+    )
+    expect(beta13Metainfo).not.toMatch(restrictedPublicLanguage)
+    expect(beta13Metainfo).not.toMatch(secretLikeIdentifier)
   })
 
   it('preserves beta.6 Snap recovery and canceled release history', () => {

--- a/tests/scripts/verify-container-publication.test.ts
+++ b/tests/scripts/verify-container-publication.test.ts
@@ -9,6 +9,9 @@ import { verifyContainerPublication } from '../../scripts/verify-container-publi
 
 const VERSION = '2.3.4'
 const REVISION = 'a'.repeat(40)
+const BUILDER_RUN_ID =
+  'https://github.com/agalwood/Motrix/actions/runs/31925284912'
+const MAXIMUM_BUILDER_ATTEMPT = 3
 const INDEX_DIGEST = `sha256:${'b'.repeat(64)}`
 const AMD64_DIGEST = `sha256:${'c'.repeat(64)}`
 const ARM64_DIGEST = `sha256:${'d'.repeat(64)}`
@@ -85,7 +88,7 @@ function provenance(options?: { incompleteArmMaterials?: boolean }) {
     SLSA: {
       buildConfig: {},
       buildType: 'https://mobyproject.org/buildkit@v1',
-      builder: { id: 'https://github.com/agalwood/Motrix/actions/runs/1' },
+      builder: { id: `${BUILDER_RUN_ID}/attempts/1` },
       invocation: {},
       materials: [{}],
       metadata: {
@@ -118,9 +121,7 @@ function currentProvenance(options?: {
       },
       runDetails: {
         builder: {
-          id:
-            options?.builderId ??
-            'https://github.com/docker/buildx/actions/runs/123',
+          id: options?.builderId ?? `${BUILDER_RUN_ID}/attempts/2`,
         },
         metadata: {
           buildkit_completeness: { request: true },
@@ -152,15 +153,18 @@ function artifact(overrides: Record<string, unknown> = {}) {
 
 function verify(
   overrides: {
-    builderIdPrefix?: string
+    builderRunId?: string
     dockerHub?: ReturnType<typeof artifact>
     ghcr?: ReturnType<typeof artifact>
+    maximumBuilderAttempt?: number
   } = {}
 ) {
   return verifyContainerPublication({
-    builderIdPrefix: overrides.builderIdPrefix,
+    builderRunId: overrides.builderRunId ?? BUILDER_RUN_ID,
     dockerHub: overrides.dockerHub ?? artifact(),
     ghcr: overrides.ghcr ?? artifact(),
+    maximumBuilderAttempt:
+      overrides.maximumBuilderAttempt ?? MAXIMUM_BUILDER_ATTEMPT,
     revision: REVISION,
     version: VERSION,
   })
@@ -188,7 +192,6 @@ describe('container publication verifier', () => {
     const current = artifact({ provenance: currentProvenance() })
     expect(
       verify({
-        builderIdPrefix: 'https://github.com/docker/buildx/actions/runs/',
         dockerHub: current,
         ghcr: current,
       }).provenance
@@ -202,6 +205,20 @@ describe('container publication verifier', () => {
       /builder identity conflicts/,
     ],
     [
+      'builder run suffix',
+      currentProvenance({
+        builderId: `${BUILDER_RUN_ID}/attempts/2/extra`,
+      }),
+      /builder identity conflicts/,
+    ],
+    [
+      'future builder attempt',
+      currentProvenance({
+        builderId: `${BUILDER_RUN_ID}/attempts/4`,
+      }),
+      /builder identity conflicts/,
+    ],
+    [
       'source revision',
       currentProvenance({ revision: '0'.repeat(40) }),
       /provenance revision conflicts/,
@@ -209,11 +226,17 @@ describe('container publication verifier', () => {
   ])('rejects a conflicting current SLSA %s', (_, document, error) => {
     expect(() =>
       verify({
-        builderIdPrefix: 'https://github.com/docker/buildx/actions/runs/',
         dockerHub: artifact({ provenance: document }),
         ghcr: artifact({ provenance: document }),
       })
     ).toThrow(error)
+  })
+
+  it.each([
+    ['an inexact builder run URL', `${BUILDER_RUN_ID}/attempts`, 3],
+    ['a zero maximum attempt', BUILDER_RUN_ID, 0],
+  ])('rejects %s', (_, builderRunId, maximumBuilderAttempt) => {
+    expect(() => verify({ builderRunId, maximumBuilderAttempt })).toThrow()
   })
 
   it.each([

--- a/tests/scripts/workflow-release-matrix.test.ts
+++ b/tests/scripts/workflow-release-matrix.test.ts
@@ -850,19 +850,57 @@ describe('release workflow publication contract', () => {
       stepIndex('Update Docker Hub description')
     )
 
+    const signatureVerification = steps[
+      stepIndex('Verify immutable signatures')
+    ] as LooseRecord
+    const signatureEnvironment = asRecord(
+      signatureVerification.env,
+      'signature verification environment'
+    )
+    expect(stringField(signatureEnvironment, 'DOCKER_CONFIG')).toContain(
+      'anonymous-docker'
+    )
+    expect(stringField(signatureEnvironment, 'COSIGN_VERIFY_ERROR')).toContain(
+      'runner.temp'
+    )
+    const signatureCommand = stringField(signatureVerification, 'run')
+    expect(signatureCommand).toContain('local max_attempts=18')
+    expect(signatureCommand).toContain('local retry_delay_seconds=10')
+    expect(signatureCommand).toContain('cosign verify')
+    expect(signatureCommand).toContain('--certificate-identity "$identity"')
+    expect(signatureCommand).toContain(
+      "'https://token.actions.githubusercontent.com'"
+    )
+    expect(signatureCommand).toContain('attempt == max_attempts')
+    expect(signatureCommand).toContain('return 1')
+    expect(signatureCommand).toContain('sleep "$retry_delay_seconds"')
+    expect(signatureCommand).not.toContain('|| true')
+
     const publicVerification = steps[
       stepIndex('Verify anonymous multi-architecture artifacts')
     ] as LooseRecord
-    expect(
-      stringField(
-        asRecord(publicVerification.env, 'anonymous env'),
-        'DOCKER_CONFIG'
-      )
-    ).toContain('anonymous-docker')
+    const publicEnvironment = asRecord(
+      publicVerification.env,
+      'anonymous verification environment'
+    )
+    expect(stringField(publicEnvironment, 'DOCKER_CONFIG')).toContain(
+      'anonymous-docker'
+    )
+    expect(stringField(publicEnvironment, 'EXPECTED_BUILDER_RUN')).toBe(
+      `https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}`
+    )
+    expect(stringField(publicEnvironment, 'MAXIMUM_BUILDER_ATTEMPT')).toBe(
+      `\${{ github.run_attempt }}`
+    )
     const publicCommand = stringField(publicVerification, 'run')
     expect(publicCommand).toContain("--format '{{json .SBOM}}'")
     expect(publicCommand).toContain("--format '{{json .Provenance}}'")
     expect(publicCommand).toContain('verify-container-publication.mjs')
+    expect(publicCommand).toContain('--builder-run-id "$EXPECTED_BUILDER_RUN"')
+    expect(publicCommand).toContain(
+      '--maximum-builder-attempt "$MAXIMUM_BUILDER_ATTEMPT"'
+    )
+    expect(publicCommand).not.toContain('--builder-id-prefix')
     const smokeCommand = stringField(
       steps[
         stepIndex('Smoke anonymous published architectures')
@@ -879,6 +917,78 @@ describe('release workflow publication contract', () => {
     )
     expect(JSON.stringify(allOtherJobs)).not.toContain('DOCKERHUB_TOKEN')
     expect(JSON.stringify(allOtherJobs)).not.toContain('packages":"write')
+  })
+
+  it('bounds anonymous signature visibility retries and still fails closed', () => {
+    const jobs = workflowJobs(releaseWorkflow)
+    const containerJob = asRecord(
+      jobs['publish-container'],
+      'publish-container job'
+    )
+    const signatureCommand = stringField(
+      jobSteps(containerJob).find(
+        (step) => step.name === 'Verify immutable signatures'
+      ) as LooseRecord,
+      'run'
+    )
+    const fixture = realpathSync(
+      mkdtempSync(path.join(tmpdir(), 'motrix-cosign-retry-'))
+    )
+    const binaryDirectory = path.join(fixture, 'bin')
+    const countPath = path.join(fixture, 'cosign-count')
+    const errorPath = path.join(fixture, 'cosign-error')
+    mkdirSync(binaryDirectory)
+    writeFileSync(
+      path.join(binaryDirectory, 'cosign'),
+      [
+        '#!/usr/bin/env bash',
+        'set -euo pipefail',
+        'count=0',
+        'if [[ -f "$MOTRIX_FAKE_COSIGN_COUNT" ]]; then',
+        '  read -r count < "$MOTRIX_FAKE_COSIGN_COUNT"',
+        'fi',
+        'count=$((count + 1))',
+        'printf \'%s\\n\' "$count" > "$MOTRIX_FAKE_COSIGN_COUNT"',
+        'if (( count <= MOTRIX_FAKE_COSIGN_FAILURES )); then',
+        '  echo "no signatures found" >&2',
+        '  exit 10',
+        'fi',
+      ].join('\n'),
+      { mode: 0o755 }
+    )
+    writeFileSync(path.join(binaryDirectory, 'sleep'), '#!/bin/sh\nexit 0\n', {
+      mode: 0o755,
+    })
+    const runVerification = (failures: number) => {
+      writeFileSync(countPath, '0\n')
+      return spawnSync('bash', ['-c', signatureCommand], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          COSIGN_VERIFY_ERROR: errorPath,
+          DOCKERHUB_REPOSITORY: 'docker.io/motrixapp/motrix-server',
+          GHCR_REPOSITORY: 'ghcr.io/agalwood/motrix-server',
+          GITHUB_REF_NAME: 'v2.0.0-beta.13',
+          MOTRIX_FAKE_COSIGN_COUNT: countPath,
+          MOTRIX_FAKE_COSIGN_FAILURES: String(failures),
+          PATH: `${binaryDirectory}:${process.env.PATH ?? ''}`,
+          PUBLISHED_DIGEST: `sha256:${'a'.repeat(64)}`,
+        },
+      })
+    }
+
+    try {
+      const converged = runVerification(2)
+      expect(converged.status).toBe(0)
+      expect(readFileSync(countPath, 'utf8').trim()).toBe('4')
+
+      const exhausted = runVerification(100)
+      expect(exhausted.status).toBe(1)
+      expect(readFileSync(countPath, 'utf8').trim()).toBe('18')
+      expect(exhausted.stderr).toContain('no signatures found')
+    } finally {
+      rmSync(fixture, { force: true, recursive: true })
+    }
   })
 
   it('assembles all target artifacts before publication', () => {


### PR DESCRIPTION
## Summary

- retry anonymous Cosign verification with a bounded fail-closed window while Docker Hub and GHCR converge
- bind BuildKit provenance to the exact repository workflow run and a valid current-or-earlier attempt, preserving resumable failed-job retries
- record the beta.12 public outcome and prepare the bilingual beta.13 release metadata and notes

## Root cause

The beta.12 image was published and signed, but signature visibility lagged briefly. The subsequent public provenance verifier compared the real repository run/attempt builder ID against an obsolete generic Docker Buildx prefix.

## Verification

- 40 release/packaging test files, 521 tests
- TypeScript type-check
- architecture boundary and file-name checks
- Biome checks for changed files and `src/`
- Actionlint for `release.yml`
- Flatpak packaging contract and AppStream XML validation
- staged diff check
