### PR TITLE
fix(release): publish Server containers on native runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
           tests/scripts/assemble-release-artifacts.test.ts
           tests/scripts/before-pack-verify.test.ts
           tests/scripts/compose-server.test.ts
+          tests/scripts/container-platform-metadata.test.ts
           tests/scripts/container-publication-state.test.ts
           tests/scripts/container-release-metadata.test.ts
           tests/scripts/docker-server-docs.test.ts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1515,19 +1515,21 @@ jobs:
           prerelease: ${{ needs.preflight.outputs.prerelease }}
           files: release/*
 
-  publish-container:
-    name: Publish verified Server container
+  plan-container-publication:
+    name: Inspect Server container publication state
     needs: [preflight, publish]
     if: >-
       github.event_name == 'push' &&
       startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
-    environment: container-release
+    timeout-minutes: 10
     permissions:
       contents: read
-      id-token: write
-      packages: write
+    outputs:
+      action: ${{ steps.publication-state.outputs.publication_action }}
+      digest: ${{ steps.publication-state.outputs.publication_digest }}
+      copy_source: ${{ steps.publication-state.outputs.copy_source }}
+      copy_target: ${{ steps.publication-state.outputs.copy_target }}
     env:
       CONTAINER_VERSION: ${{ needs.preflight.outputs.container_version }}
       DOCKERHUB_REPOSITORY: ${{ needs.preflight.outputs.container_dockerhub_repository }}
@@ -1535,46 +1537,6 @@ jobs:
     steps:
       - name: Checkout release source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Validate container release credentials
-        shell: bash
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          missing=()
-          for name in DOCKERHUB_USERNAME DOCKERHUB_TOKEN; do
-            if [[ -z "${!name:-}" ]]; then
-              missing+=("$name")
-            fi
-          done
-          if (( ${#missing[@]} > 0 )); then
-            echo "Missing required container-release secrets: ${missing[*]}" >&2
-            exit 1
-          fi
-          curl --fail --silent --show-error \
-            https://hub.docker.com/v2/repositories/motrixapp/motrix-server/ \
-            > /dev/null
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to GHCR
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up pinned QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-        with:
-          image: tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
-          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -1624,31 +1586,398 @@ jobs:
           --revision "$GITHUB_SHA"
           --github-output "$GITHUB_OUTPUT"
 
-      - name: Build and stage immutable multi-architecture image
-        id: container-build
-        if: steps.publication-state.outputs.publication_action == 'build'
+  build-container-platform:
+    name: Build Server / ${{ matrix.platform }}
+    needs: [preflight, publish, plan-container-publication]
+    if: needs.plan-container-publication.outputs.action == 'build'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    environment: container-release
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            os: ubuntu-22.04
+            runner_arch: X64
+            artifact: container-build-linux-amd64
+            metadata_file: linux-amd64.json
+          - platform: linux/arm64
+            os: ubuntu-22.04-arm
+            runner_arch: ARM64
+            artifact: container-build-linux-arm64
+            metadata_file: linux-arm64.json
+    env:
+      CONTAINER_VERSION: ${{ needs.preflight.outputs.container_version }}
+      DOCKERHUB_REPOSITORY: ${{ needs.preflight.outputs.container_dockerhub_repository }}
+      GHCR_REPOSITORY: ${{ needs.preflight.outputs.container_ghcr_repository }}
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Require native GitHub-hosted Linux runner
+        shell: bash
+        env:
+          EXPECTED_RUNNER_ARCH: ${{ matrix.runner_arch }}
+          RUNNER_ARCH_VALUE: ${{ runner.arch }}
+          RUNNER_ENVIRONMENT_VALUE: ${{ runner.environment }}
+          RUNNER_OS_VALUE: ${{ runner.os }}
+        run: |
+          set -euo pipefail
+          [[ "$RUNNER_ENVIRONMENT_VALUE" == 'github-hosted' ]]
+          [[ "$RUNNER_OS_VALUE" == 'Linux' ]]
+          [[ "$RUNNER_ARCH_VALUE" == "$EXPECTED_RUNNER_ARCH" ]]
+
+      - name: Validate container release credentials
+        shell: bash
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in DOCKERHUB_USERNAME DOCKERHUB_TOKEN; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("$name")
+            fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            echo "Missing required container-release secrets: ${missing[*]}" >&2
+            exit 1
+          fi
+          curl --fail --silent --show-error \
+            https://hub.docker.com/v2/repositories/motrixapp/motrix-server/ \
+            > /dev/null
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Build and push native platform digest
+        id: platform-build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           target: runtime
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ needs.preflight.outputs.container_immutable_tags }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,"name=${{ env.DOCKERHUB_REPOSITORY }},${{ env.GHCR_REPOSITORY }}",oci-artifact=true,push-by-digest=true,name-canonical=true,push=true
           labels: ${{ needs.preflight.outputs.container_labels }}
           build-args: |
             OCI_REVISION=${{ github.sha }}
             OCI_VERSION=${{ needs.preflight.outputs.container_version }}
-          cache-from: type=gha,scope=motrix-server-release
-          cache-to: type=gha,mode=max,scope=motrix-server-release
+          cache-from: type=gha,scope=motrix-server-release-${{ matrix.runner_arch }}
+          cache-to: type=gha,mode=max,scope=motrix-server-release-${{ matrix.runner_arch }}
           provenance: mode=max
           sbom: true
 
-      - name: Repair partial immutable publication
-        if: steps.publication-state.outputs.publication_action == 'copy'
+      - name: Inspect staged platform digests
         shell: bash
         env:
-          COPY_SOURCE: ${{ steps.publication-state.outputs.copy_source }}
-          COPY_TARGET: ${{ steps.publication-state.outputs.copy_target }}
+          PLATFORM_DIGEST: ${{ steps.platform-build.outputs.digest }}
+          SNAPSHOT_DIRECTORY: ${{ runner.temp }}/container-platform
+        run: |
+          set -euo pipefail
+          [[ "$PLATFORM_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
+          mkdir -p "$SNAPSHOT_DIRECTORY"
+          snapshot_platform() {
+            local name="$1"
+            local repository="$2"
+            docker buildx imagetools inspect \
+              "${repository}@${PLATFORM_DIGEST}" \
+              --format '{{json .}}' \
+              > "$SNAPSHOT_DIRECTORY/${name}-inspect.json"
+            docker buildx imagetools inspect \
+              "${repository}@${PLATFORM_DIGEST}" --raw \
+              > "$SNAPSHOT_DIRECTORY/${name}-index.json"
+          }
+          snapshot_platform docker-hub "$DOCKERHUB_REPOSITORY"
+          snapshot_platform ghcr "$GHCR_REPOSITORY"
+
+      - name: Prepare anonymous registry client
+        shell: bash
+        env:
+          ANONYMOUS_DOCKER_CONFIG: ${{ runner.temp }}/anonymous-docker
+        run: |
+          set -euo pipefail
+          mkdir -p "$ANONYMOUS_DOCKER_CONFIG"
+          printf '{"auths":{}}\n' > "$ANONYMOUS_DOCKER_CONFIG/config.json"
+
+      - name: Smoke anonymous staged platform digests
+        shell: bash
+        env:
+          DOCKER_CONFIG: ${{ runner.temp }}/anonymous-docker
+          PLATFORM_DIGEST: ${{ steps.platform-build.outputs.digest }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          for repository in "$DOCKERHUB_REPOSITORY" "$GHCR_REPOSITORY"; do
+            node scripts/smoke-server-image.mjs \
+              --image "${repository}@${PLATFORM_DIGEST}" \
+              --platform "$PLATFORM" \
+              --timeout-ms 180000
+          done
+
+      - name: Write immutable platform build metadata
+        shell: bash
+        env:
+          BUILDER_RUN_ID: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          METADATA_FILE: ${{ runner.temp }}/${{ matrix.metadata_file }}
+          PLATFORM_DIGEST: ${{ steps.platform-build.outputs.digest }}
+          SNAPSHOT_DIRECTORY: ${{ runner.temp }}/container-platform
+        run: >-
+          node scripts/container-platform-metadata.mjs create
+          --platform "${{ matrix.platform }}"
+          --digest "$PLATFORM_DIGEST"
+          --version "$CONTAINER_VERSION"
+          --revision "$GITHUB_SHA"
+          --builder-run-id "$BUILDER_RUN_ID"
+          --builder-attempt "$GITHUB_RUN_ATTEMPT"
+          --runner-arch "${{ runner.arch }}"
+          --runner-environment "${{ runner.environment }}"
+          --runner-os "${{ runner.os }}"
+          --docker-hub-inspect "$SNAPSHOT_DIRECTORY/docker-hub-inspect.json"
+          --docker-hub-index "$SNAPSHOT_DIRECTORY/docker-hub-index.json"
+          --ghcr-inspect "$SNAPSHOT_DIRECTORY/ghcr-inspect.json"
+          --ghcr-index "$SNAPSHOT_DIRECTORY/ghcr-index.json"
+          --output "$METADATA_FILE"
+
+      - name: Upload immutable platform build metadata
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ runner.temp }}/${{ matrix.metadata_file }}
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 7
+
+  publish-container:
+    name: Finalize and publish verified Server index
+    needs:
+      [preflight, publish, plan-container-publication, build-container-platform]
+    if: >-
+      always() &&
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      needs.preflight.result == 'success' &&
+      needs.publish.result == 'success' &&
+      needs.plan-container-publication.result == 'success' &&
+      (
+        (
+          needs.plan-container-publication.outputs.action == 'build' &&
+          needs.build-container-platform.result == 'success'
+        ) ||
+        (
+          needs.plan-container-publication.outputs.action != 'build' &&
+          needs.build-container-platform.result == 'skipped'
+        )
+      )
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+    environment: container-release
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    outputs:
+      digest: ${{ steps.immutable-publication.outputs.publication_digest }}
+    env:
+      CONTAINER_VERSION: ${{ needs.preflight.outputs.container_version }}
+      DOCKERHUB_REPOSITORY: ${{ needs.preflight.outputs.container_dockerhub_repository }}
+      GHCR_REPOSITORY: ${{ needs.preflight.outputs.container_ghcr_repository }}
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate container release credentials
+        shell: bash
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in DOCKERHUB_USERNAME DOCKERHUB_TOKEN; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("$name")
+            fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            echo "Missing required container-release secrets: ${missing[*]}" >&2
+            exit 1
+          fi
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Download amd64 platform build metadata
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: container-build-linux-amd64
+          path: ${{ runner.temp }}/container-build-metadata/amd64
+
+      - name: Download arm64 platform build metadata
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: container-build-linux-arm64
+          path: ${{ runner.temp }}/container-build-metadata/arm64
+
+      - name: Verify complete platform build set
+        id: platform-builds
+        shell: bash
+        env:
+          BUILDER_RUN_ID: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          METADATA_DIRECTORY: ${{ runner.temp }}/container-build-metadata
+          VERIFIED_METADATA: ${{ runner.temp }}/verified-container-builds.json
+        run: >-
+          node scripts/container-platform-metadata.mjs verify-set
+          --metadata-dir "$METADATA_DIRECTORY"
+          --version "$CONTAINER_VERSION"
+          --revision "$GITHUB_SHA"
+          --builder-run-id "$BUILDER_RUN_ID"
+          --builder-attempt "$GITHUB_RUN_ATTEMPT"
+          --output "$VERIFIED_METADATA"
+          --github-output "$GITHUB_OUTPUT"
+
+      - name: Revalidate immutable tags before finalization
+        shell: bash
+        env:
+          DOCKERHUB_SNAPSHOT: ${{ runner.temp }}/dockerhub-immutable.json
+          GHCR_SNAPSHOT: ${{ runner.temp }}/ghcr-immutable.json
+        run: |
+          set -euo pipefail
+          inspect_tag() {
+            local ref="$1"
+            local target="$2"
+            local detail
+            if detail="$(docker buildx imagetools inspect \
+              "$ref" --format '{{json .}}' 2>&1)"; then
+              printf '%s\n' "$detail" > "$target"
+              return
+            fi
+            if grep -Eiq \
+              'not found|manifest unknown|name unknown|does not exist' \
+              <<< "$detail"; then
+              printf 'null\n' > "$target"
+              return
+            fi
+            printf '%s\n' "$detail" >&2
+            exit 1
+          }
+          inspect_tag \
+            "${DOCKERHUB_REPOSITORY}:${CONTAINER_VERSION}" \
+            "$DOCKERHUB_SNAPSHOT"
+          inspect_tag \
+            "${GHCR_REPOSITORY}:${CONTAINER_VERSION}" \
+            "$GHCR_SNAPSHOT"
+
+      - name: Resolve finalization state
+        id: finalization-state
+        env:
+          DOCKERHUB_SNAPSHOT: ${{ runner.temp }}/dockerhub-immutable.json
+          GHCR_SNAPSHOT: ${{ runner.temp }}/ghcr-immutable.json
+        run: >-
+          node scripts/container-publication-state.mjs
+          --docker-hub-snapshot "$DOCKERHUB_SNAPSHOT"
+          --ghcr-snapshot "$GHCR_SNAPSHOT"
+          --version "$CONTAINER_VERSION"
+          --revision "$GITHUB_SHA"
+          --github-output "$GITHUB_OUTPUT"
+
+      - name: Prepare anonymous registry client
+        shell: bash
+        env:
+          ANONYMOUS_DOCKER_CONFIG: ${{ runner.temp }}/anonymous-docker
+        run: |
+          set -euo pipefail
+          mkdir -p "$ANONYMOUS_DOCKER_CONFIG"
+          printf '{"auths":{}}\n' > "$ANONYMOUS_DOCKER_CONFIG/config.json"
+
+      - name: Verify partial immutable source before repair
+        if: steps.finalization-state.outputs.publication_action == 'copy'
+        shell: bash
+        env:
+          COPY_SOURCE: ${{ steps.finalization-state.outputs.copy_source }}
+          DOCKER_CONFIG: ${{ runner.temp }}/anonymous-docker
+          EXPECTED_BUILDER_RUN: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          MAXIMUM_BUILDER_ATTEMPT: ${{ github.run_attempt }}
+          SOURCE_SNAPSHOT_DIRECTORY: ${{ runner.temp }}/container-repair-source
+          VERIFIED_METADATA: ${{ runner.temp }}/verified-container-builds.json
+        run: |
+          set -euo pipefail
+          mkdir -p "$SOURCE_SNAPSHOT_DIRECTORY"
+          source_repository="${COPY_SOURCE%@*}"
+          docker buildx imagetools inspect "$COPY_SOURCE" \
+            --format '{{json .}}' \
+            > "$SOURCE_SNAPSHOT_DIRECTORY/inspect.json"
+          docker buildx imagetools inspect "$COPY_SOURCE" --raw \
+            > "$SOURCE_SNAPSHOT_DIRECTORY/index.json"
+          docker buildx imagetools inspect "$COPY_SOURCE" \
+            --format '{{json .SBOM}}' \
+            > "$SOURCE_SNAPSHOT_DIRECTORY/sbom.json"
+          docker buildx imagetools inspect "$COPY_SOURCE" \
+            --format '{{json .Provenance}}' \
+            > "$SOURCE_SNAPSHOT_DIRECTORY/provenance.json"
+          node scripts/verify-container-publication.mjs \
+            --repository "$source_repository" \
+            --inspect "$SOURCE_SNAPSHOT_DIRECTORY/inspect.json" \
+            --index "$SOURCE_SNAPSHOT_DIRECTORY/index.json" \
+            --sbom "$SOURCE_SNAPSHOT_DIRECTORY/sbom.json" \
+            --provenance "$SOURCE_SNAPSHOT_DIRECTORY/provenance.json" \
+            --platform-metadata "$VERIFIED_METADATA" \
+            --builder-run-id "$EXPECTED_BUILDER_RUN" \
+            --maximum-builder-attempt "$MAXIMUM_BUILDER_ATTEMPT" \
+            --version "$CONTAINER_VERSION" \
+            --revision "$GITHUB_SHA"
+
+      - name: Create immutable multi-platform indexes
+        if: steps.finalization-state.outputs.publication_action == 'build'
+        shell: bash
+        env:
+          AMD64_DIGEST: ${{ steps.platform-builds.outputs.amd64_digest }}
+          ARM64_DIGEST: ${{ steps.platform-builds.outputs.arm64_digest }}
+        run: |
+          set -euo pipefail
+          for repository in "$DOCKERHUB_REPOSITORY" "$GHCR_REPOSITORY"; do
+            docker buildx imagetools create \
+              --tag "${repository}:${CONTAINER_VERSION}" \
+              "${repository}@${AMD64_DIGEST}" \
+              "${repository}@${ARM64_DIGEST}"
+          done
+
+      - name: Repair partial immutable publication
+        if: steps.finalization-state.outputs.publication_action == 'copy'
+        shell: bash
+        env:
+          COPY_SOURCE: ${{ steps.finalization-state.outputs.copy_source }}
+          COPY_TARGET: ${{ steps.finalization-state.outputs.copy_target }}
         run: >-
           docker buildx imagetools create
           --tag "$COPY_TARGET"
@@ -1685,18 +2014,61 @@ jobs:
         shell: bash
         env:
           EXPECTED_ACTION: ${{ steps.immutable-publication.outputs.publication_action }}
-          PUBLISHED_DIGEST: ${{ steps.immutable-publication.outputs.publication_digest }}
-          BUILD_DIGEST: ${{ steps.container-build.outputs.digest }}
         run: |
           set -euo pipefail
           if [[ "$EXPECTED_ACTION" != 'resume' ]]; then
             echo "Immutable publication did not converge: $EXPECTED_ACTION" >&2
             exit 1
           fi
-          if [[ -n "$BUILD_DIGEST" && "$BUILD_DIGEST" != "$PUBLISHED_DIGEST" ]]; then
-            echo "Build digest differs from published digest" >&2
-            exit 1
-          fi
+
+      - name: Verify anonymous multi-platform index artifacts before signing
+        shell: bash
+        env:
+          DOCKER_CONFIG: ${{ runner.temp }}/anonymous-docker
+          EXPECTED_BUILDER_RUN: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          MAXIMUM_BUILDER_ATTEMPT: ${{ github.run_attempt }}
+          PUBLISHED_DIGEST: ${{ steps.immutable-publication.outputs.publication_digest }}
+          SNAPSHOT_DIRECTORY: ${{ runner.temp }}/container-publication
+          VERIFIED_METADATA: ${{ runner.temp }}/verified-container-builds.json
+        run: |
+          set -euo pipefail
+          mkdir -p "$SNAPSHOT_DIRECTORY"
+          snapshot_artifact() {
+            local name="$1"
+            local reference="$2"
+            docker buildx imagetools inspect "$reference" \
+              --format '{{json .}}' \
+              > "$SNAPSHOT_DIRECTORY/${name}-inspect.json"
+            docker buildx imagetools inspect "$reference" --raw \
+              > "$SNAPSHOT_DIRECTORY/${name}-index.json"
+            docker buildx imagetools inspect "$reference" \
+              --format '{{json .SBOM}}' \
+              > "$SNAPSHOT_DIRECTORY/${name}-sbom.json"
+            docker buildx imagetools inspect "$reference" \
+              --format '{{json .Provenance}}' \
+              > "$SNAPSHOT_DIRECTORY/${name}-provenance.json"
+          }
+          snapshot_artifact \
+            docker-hub "${DOCKERHUB_REPOSITORY}@${PUBLISHED_DIGEST}"
+          snapshot_artifact ghcr "${GHCR_REPOSITORY}@${PUBLISHED_DIGEST}"
+          node scripts/verify-container-publication.mjs \
+            --docker-hub-inspect \
+              "$SNAPSHOT_DIRECTORY/docker-hub-inspect.json" \
+            --docker-hub-index \
+              "$SNAPSHOT_DIRECTORY/docker-hub-index.json" \
+            --docker-hub-sbom \
+              "$SNAPSHOT_DIRECTORY/docker-hub-sbom.json" \
+            --docker-hub-provenance \
+              "$SNAPSHOT_DIRECTORY/docker-hub-provenance.json" \
+            --ghcr-inspect "$SNAPSHOT_DIRECTORY/ghcr-inspect.json" \
+            --ghcr-index "$SNAPSHOT_DIRECTORY/ghcr-index.json" \
+            --ghcr-sbom "$SNAPSHOT_DIRECTORY/ghcr-sbom.json" \
+            --ghcr-provenance "$SNAPSHOT_DIRECTORY/ghcr-provenance.json" \
+            --platform-metadata "$VERIFIED_METADATA" \
+            --builder-run-id "$EXPECTED_BUILDER_RUN" \
+            --maximum-builder-attempt "$MAXIMUM_BUILDER_ATTEMPT" \
+            --version "$CONTAINER_VERSION" \
+            --revision "$GITHUB_SHA"
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -1710,15 +2082,6 @@ jobs:
           for repository in "$DOCKERHUB_REPOSITORY" "$GHCR_REPOSITORY"; do
             cosign sign --yes "${repository}@${PUBLISHED_DIGEST}"
           done
-
-      - name: Prepare anonymous registry client
-        shell: bash
-        env:
-          ANONYMOUS_DOCKER_CONFIG: ${{ runner.temp }}/anonymous-docker
-        run: |
-          set -euo pipefail
-          mkdir -p "$ANONYMOUS_DOCKER_CONFIG"
-          printf '{"auths":{}}\n' > "$ANONYMOUS_DOCKER_CONFIG/config.json"
 
       - name: Verify immutable signatures
         shell: bash
@@ -1755,96 +2118,6 @@ jobs:
             verify_signature "$repository"
           done
 
-      - name: Verify anonymous multi-architecture artifacts
-        shell: bash
-        env:
-          DOCKER_CONFIG: ${{ runner.temp }}/anonymous-docker
-          EXPECTED_BUILDER_RUN: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          MAXIMUM_BUILDER_ATTEMPT: ${{ github.run_attempt }}
-          PUBLISHED_DIGEST: ${{ steps.immutable-publication.outputs.publication_digest }}
-          SNAPSHOT_DIRECTORY: ${{ runner.temp }}/container-publication
-        run: |
-          set -euo pipefail
-          mkdir -p "$SNAPSHOT_DIRECTORY"
-          snapshot_artifact() {
-            local name="$1"
-            local reference="$2"
-            docker buildx imagetools inspect "$reference" \
-              --format '{{json .}}' \
-              > "$SNAPSHOT_DIRECTORY/${name}-inspect.json"
-            docker buildx imagetools inspect "$reference" --raw \
-              > "$SNAPSHOT_DIRECTORY/${name}-index.json"
-            docker buildx imagetools inspect "$reference" \
-              --format '{{json .SBOM}}' \
-              > "$SNAPSHOT_DIRECTORY/${name}-sbom.json"
-            docker buildx imagetools inspect "$reference" \
-              --format '{{json .Provenance}}' \
-              > "$SNAPSHOT_DIRECTORY/${name}-provenance.json"
-          }
-          snapshot_artifact \
-            docker-hub "${DOCKERHUB_REPOSITORY}@${PUBLISHED_DIGEST}"
-          snapshot_artifact ghcr "${GHCR_REPOSITORY}@${PUBLISHED_DIGEST}"
-          node scripts/verify-container-publication.mjs \
-            --docker-hub-inspect \
-              "$SNAPSHOT_DIRECTORY/docker-hub-inspect.json" \
-            --docker-hub-index \
-              "$SNAPSHOT_DIRECTORY/docker-hub-index.json" \
-            --docker-hub-sbom \
-              "$SNAPSHOT_DIRECTORY/docker-hub-sbom.json" \
-            --docker-hub-provenance \
-              "$SNAPSHOT_DIRECTORY/docker-hub-provenance.json" \
-            --ghcr-inspect "$SNAPSHOT_DIRECTORY/ghcr-inspect.json" \
-            --ghcr-index "$SNAPSHOT_DIRECTORY/ghcr-index.json" \
-            --ghcr-sbom "$SNAPSHOT_DIRECTORY/ghcr-sbom.json" \
-            --ghcr-provenance "$SNAPSHOT_DIRECTORY/ghcr-provenance.json" \
-            --builder-run-id "$EXPECTED_BUILDER_RUN" \
-            --maximum-builder-attempt "$MAXIMUM_BUILDER_ATTEMPT" \
-            --version "$CONTAINER_VERSION" \
-            --revision "$GITHUB_SHA"
-
-      - name: Smoke anonymous published architectures
-        shell: bash
-        env:
-          DOCKER_CONFIG: ${{ runner.temp }}/anonymous-docker
-          PUBLISHED_DIGEST: ${{ steps.immutable-publication.outputs.publication_digest }}
-        run: |
-          set -euo pipefail
-          public_image="${DOCKERHUB_REPOSITORY}@${PUBLISHED_DIGEST}"
-          node scripts/smoke-server-image.mjs \
-            --image "$public_image" \
-            --platform linux/amd64 \
-            --timeout-ms 180000
-          node scripts/smoke-server-image.mjs \
-            --image "$public_image" \
-            --platform linux/arm64 \
-            --mode health \
-            --timeout-ms 180000
-
-      - name: Promote stable container aliases
-        if: needs.preflight.outputs.container_prerelease != 'true'
-        shell: bash
-        env:
-          FLOATING_TAGS: ${{ needs.preflight.outputs.container_floating_tags }}
-          PUBLISHED_DIGEST: ${{ steps.immutable-publication.outputs.publication_digest }}
-        run: |
-          set -euo pipefail
-          dockerhub_tags=()
-          ghcr_tags=()
-          while IFS= read -r tag; do
-            [[ -z "$tag" ]] && continue
-            case "$tag" in
-              docker.io/*) dockerhub_tags+=(--tag "$tag") ;;
-              ghcr.io/*) ghcr_tags+=(--tag "$tag") ;;
-              *) echo "Unexpected container tag: $tag" >&2; exit 1 ;;
-            esac
-          done <<< "$FLOATING_TAGS"
-          docker buildx imagetools create \
-            "${dockerhub_tags[@]}" \
-            "${DOCKERHUB_REPOSITORY}@${PUBLISHED_DIGEST}"
-          docker buildx imagetools create \
-            "${ghcr_tags[@]}" \
-            "${GHCR_REPOSITORY}@${PUBLISHED_DIGEST}"
-
       - name: Update Docker Hub description
         shell: bash
         env:
@@ -1872,6 +2145,173 @@ jobs:
             --data "$dockerhub_description" \
             https://hub.docker.com/v2/repositories/motrixapp/motrix-server/ \
             > /dev/null
+
+  verify-container-runtime:
+    name: Verify Server runtime / ${{ matrix.platform }}
+    needs: [preflight, publish-container]
+    if: >-
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/tags/v')
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            os: ubuntu-22.04
+            runner_arch: X64
+          - platform: linux/arm64
+            os: ubuntu-22.04-arm
+            runner_arch: ARM64
+    env:
+      DOCKERHUB_REPOSITORY: ${{ needs.preflight.outputs.container_dockerhub_repository }}
+      GHCR_REPOSITORY: ${{ needs.preflight.outputs.container_ghcr_repository }}
+      PUBLISHED_DIGEST: ${{ needs.publish-container.outputs.digest }}
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Require native GitHub-hosted Linux runner
+        shell: bash
+        env:
+          EXPECTED_RUNNER_ARCH: ${{ matrix.runner_arch }}
+          RUNNER_ARCH_VALUE: ${{ runner.arch }}
+          RUNNER_ENVIRONMENT_VALUE: ${{ runner.environment }}
+          RUNNER_OS_VALUE: ${{ runner.os }}
+        run: |
+          set -euo pipefail
+          [[ "$RUNNER_ENVIRONMENT_VALUE" == 'github-hosted' ]]
+          [[ "$RUNNER_OS_VALUE" == 'Linux' ]]
+          [[ "$RUNNER_ARCH_VALUE" == "$EXPECTED_RUNNER_ARCH" ]]
+
+      - name: Prepare anonymous registry client
+        shell: bash
+        env:
+          ANONYMOUS_DOCKER_CONFIG: ${{ runner.temp }}/anonymous-docker
+        run: |
+          set -euo pipefail
+          mkdir -p "$ANONYMOUS_DOCKER_CONFIG"
+          printf '{"auths":{}}\n' > "$ANONYMOUS_DOCKER_CONFIG/config.json"
+
+      - name: Smoke immutable public index on native platform
+        shell: bash
+        env:
+          DOCKER_CONFIG: ${{ runner.temp }}/anonymous-docker
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          [[ "$PUBLISHED_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
+          for repository in "$DOCKERHUB_REPOSITORY" "$GHCR_REPOSITORY"; do
+            node scripts/smoke-server-image.mjs \
+              --image "${repository}@${PUBLISHED_DIGEST}" \
+              --platform "$PLATFORM" \
+              --timeout-ms 180000
+          done
+
+  promote-container-aliases:
+    name: Promote verified stable Server aliases
+    needs: [preflight, publish-container, verify-container-runtime]
+    if: >-
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      needs.preflight.outputs.container_prerelease != 'true'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    environment: container-release
+    permissions:
+      contents: read
+      packages: write
+    env:
+      CONTAINER_VERSION: ${{ needs.preflight.outputs.container_version }}
+      DOCKERHUB_REPOSITORY: ${{ needs.preflight.outputs.container_dockerhub_repository }}
+      GHCR_REPOSITORY: ${{ needs.preflight.outputs.container_ghcr_repository }}
+      PUBLISHED_DIGEST: ${{ needs.publish-container.outputs.digest }}
+    steps:
+      - name: Validate container release credentials
+        shell: bash
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          [[ -n "$DOCKERHUB_USERNAME" ]]
+          [[ -n "$DOCKERHUB_TOKEN" ]]
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Revalidate immutable inputs before alias promotion
+        shell: bash
+        env:
+          ANONYMOUS_DOCKER_CONFIG: ${{ runner.temp }}/anonymous-docker
+        run: |
+          set -euo pipefail
+          mkdir -p "$ANONYMOUS_DOCKER_CONFIG"
+          printf '{"auths":{}}\n' > "$ANONYMOUS_DOCKER_CONFIG/config.json"
+          identity="https://github.com/agalwood/Motrix/.github/workflows/release.yml@refs/tags/${GITHUB_REF_NAME}"
+          for repository in "$DOCKERHUB_REPOSITORY" "$GHCR_REPOSITORY"; do
+            observed="$(DOCKER_CONFIG="$ANONYMOUS_DOCKER_CONFIG" \
+              docker buildx imagetools inspect \
+              "${repository}:${CONTAINER_VERSION}" \
+              --format '{{json .}}' | jq -er '.manifest.digest')"
+            [[ "$observed" == "$PUBLISHED_DIGEST" ]]
+            DOCKER_CONFIG="$ANONYMOUS_DOCKER_CONFIG" cosign verify \
+              --certificate-identity "$identity" \
+              --certificate-oidc-issuer \
+                'https://token.actions.githubusercontent.com' \
+              "${repository}@${PUBLISHED_DIGEST}" > /dev/null
+          done
+
+      - name: Promote and verify stable container aliases last
+        shell: bash
+        env:
+          FLOATING_TAGS: ${{ needs.preflight.outputs.container_floating_tags }}
+        run: |
+          set -euo pipefail
+          dockerhub_tags=()
+          ghcr_tags=()
+          all_tags=()
+          while IFS= read -r tag; do
+            [[ -z "$tag" ]] && continue
+            all_tags+=("$tag")
+            case "$tag" in
+              docker.io/*) dockerhub_tags+=(--tag "$tag") ;;
+              ghcr.io/*) ghcr_tags+=(--tag "$tag") ;;
+              *) echo "Unexpected container tag: $tag" >&2; exit 1 ;;
+            esac
+          done <<< "$FLOATING_TAGS"
+          (( ${#dockerhub_tags[@]} == 8 ))
+          (( ${#ghcr_tags[@]} == 8 ))
+          docker buildx imagetools create \
+            "${dockerhub_tags[@]}" \
+            "${DOCKERHUB_REPOSITORY}@${PUBLISHED_DIGEST}"
+          docker buildx imagetools create \
+            "${ghcr_tags[@]}" \
+            "${GHCR_REPOSITORY}@${PUBLISHED_DIGEST}"
+          for tag in "${all_tags[@]}"; do
+            observed="$(docker buildx imagetools inspect "$tag" \
+              --format '{{json .}}' | jq -er '.manifest.digest')"
+            [[ "$observed" == "$PUBLISHED_DIGEST" ]]
+          done
 
   publish-feed:
     name: Publish dl.motrix.app update feed

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. After its remaining release gates pass,
-download [v2.0.0-beta.13 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.13)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.13.md) before
+download [v2.0.0-beta.14 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.14)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.14.md) before
 installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -149,7 +149,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.13'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.14'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。剩余发布门禁通过后，请从 GitHub Releases
-下载 [v2.0.0-beta.13](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.13)，
-并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.13.zh-CN.md)。
+下载 [v2.0.0-beta.14](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.14)，
+并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.14.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -143,7 +143,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.13'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.14'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.13.md
+++ b/docs/release-notes/2.0.0-beta.13.md
@@ -1,49 +1,47 @@
 # Motrix 2.0.0-beta.13
 
-English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.13/docs/release-notes/2.0.0-beta.13.zh-CN.md)
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.14/docs/release-notes/2.0.0-beta.13.zh-CN.md)
 
-Motrix 2.0.0-beta.13 is the next Motrix Turbo beta intended for public
-distribution after every protected release gate passes. It continues public
-validation of the rebuilt v2 desktop app and headless server, shared download
-core, MDXP integrations, and sandboxed plugin system.
+> Motrix 2.0.0-beta.13 was partially distributed. In [Build/Release run
+> 31932206203](https://github.com/agalwood/Motrix/actions/runs/31932206203),
+> all five desktop builds, all three Finalize jobs, assembly, the GitHub
+> prerelease, and the R2 update feed completed successfully. Windows `x64`
+> packages were published unsigned as documented.
+>
+> The Server container did not complete. Its x64 runner used QEMU for the
+> `linux/arm64` half of one combined Buildx build. At 57.27 seconds in the ARM
+> `pnpm install` layer, QEMU exited with target signal 4 (`Illegal
+> instruction`). The build action then remained active until the container job
+> was canceled about 33 minutes later. The remaining container steps did not
+> run: neither immutable beta.13 tag was published, no final index was signed,
+> and anonymous platform, provenance, SBOM, or runtime verification did not
+> occur.
+>
+> The protected prerelease Snap run passed source validation and, as designed,
+> skipped architecture builds and Store publication. No Snap revision was
+> uploaded or released, and `latest/edge` did not change.
+>
+> The GitHub prerelease and R2 feed remain public. Container publication is a
+> separately gated channel, so this result must not be described as atomic
+> across distribution channels. The `v2.0.0-beta.13` tag remains immutable and
+> is not moved or reused. [Motrix 2.0.0-beta.14](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.14/docs/release-notes/2.0.0-beta.14.md)
+> supersedes the incomplete container result.
 
-Motrix 2.0.0-beta.12 published its desktop release, update feeds, and immutable
-Server images, but its final container verification job did not reach success.
-The [beta.12 historical record](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.13/docs/release-notes/2.0.0-beta.12.md)
-preserves the exact public outcome.
+## Release reliability changes included in beta.13
 
-## Release reliability updates
-
-- Retries anonymous signature verification for up to 18 attempts with a
-  10-second delay, allowing bounded registry convergence after signing while
-  still failing closed if either registry never exposes a valid signature.
-- Keeps the exact tag-workflow identity and GitHub OIDC issuer checks on every
-  retry; a visible signature from any other identity remains invalid.
-- Verifies BuildKit provenance against the exact current repository workflow
-  run. The builder attempt must be a positive integer no greater than the
-  current run attempt, which supports resumable failed-job retries without
-  accepting another repository, workflow run, future attempt, or path suffix.
-- Replaces the obsolete generic Docker Buildx builder prefix with the real
-  GitHub Actions builder form emitted by the beta.12 multi-architecture image.
-- Retains immutable cross-registry digest equality, amd64/arm64 image and
+- Added a bounded wait for anonymous registry visibility after Cosign signing,
+  while still failing closed if either registry never exposed a valid
+  signature.
+- Bound BuildKit provenance to the exact repository workflow run and a valid
+  current-or-earlier attempt.
+- Retained immutable cross-registry digest equality, amd64/arm64 image and
   attestation checks, SPDX SBOM validation, exact source revision, provenance
-  completeness, and anonymous runtime smoke tests.
-- Publishes beta.13 under new immutable version tags. Existing beta.12 release
-  assets and container tags are never overwritten or reused; mutable beta
-  update feeds advance only after beta.13 versioned assets publish and their
-  public verification succeeds.
-- Keeps Windows `x64` packages explicitly unsigned while retaining final
+  completeness, and runtime smoke gates.
+- Kept Windows `x64` packages explicitly unsigned while retaining final
   package verification before release.
-- Retains the complete desktop platform-set gate: every desktop target must
-  finalize before assembly and every canonical updater manifest must pass
-  final verification before publication.
-
-## Snap beta policy
-
-Snap is not part of the beta.13 distribution. Protected prerelease Snap runs
-stop after source validation, so they do not build Snap artifacts, upload Store
-revisions, or change `latest/edge`. Stable Snap publication retains its
-complete two-architecture verification and protected Store gates.
+- Kept the complete desktop platform-set gate: every desktop target finalized
+  before assembly, and every canonical updater manifest passed final
+  verification before publication.
 
 ## Highlights
 
@@ -57,9 +55,6 @@ complete two-architecture verification and protected Store gates.
   local discovery and device-code pairing for remote Server instances.
 - A QuickJS plugin sandbox with capability consent, bundled builtin plugins,
   and an in-app plugin marketplace.
-- Persistent, multi-architecture Server containers for NAS and home-server
-  deployments, published to both Docker Hub and GHCR after the desktop release
-  succeeds.
 
 ## Before testing
 
@@ -68,47 +63,38 @@ downloads before installing it. Migration from Motrix v1 data has not yet been
 validated, so do not use your only copy of v1 data with this beta.
 
 When practical, test v2 in parallel using a separate OS account, machine, or
-Docker data directory. Please do not rely on this beta for your only copy of
-important downloads.
+Docker data directory. Do not rely on this beta for your only copy of important
+downloads.
 
-## What to test
+## Published distribution
 
-- HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
-  session recovery
-- Desktop integrations, browser and CLI handoff through MDXP, and sandboxed
-  plugins
-- Headless Server deployment, persistent storage, remote pairing, and both
-  amd64 and arm64 container images
-
-## Planned downloads after release gates pass
-
-| Distribution | Architectures | Planned output |
-|--------------|---------------|----------------|
-| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
-| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
-| Linux | `x64`, `arm64` | DEB and RPM |
-| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.13-linux-<arch>.tar.gz` |
-| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.13` tag in both registries |
+| Distribution | Architectures | Outcome |
+|--------------|---------------|---------|
+| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP published |
+| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP published |
+| Linux | `x64`, `arm64` | DEB and RPM published |
+| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.13-linux-<arch>.tar.gz` published with the GitHub prerelease |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | `2.0.0-beta.13` was not published in either registry |
 | Snap Store | — | Not published for this beta |
 
-After publication, container images use
+The planned container references were
 `docker.io/motrixapp/motrix-server:2.0.0-beta.13` and
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.13`. See the
-[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.13/docs/docker-server.md)
-for storage, networking, and upgrade guidance.
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.13`; neither reference is a beta.13
+release image. Use a later successfully verified version from the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.14/docs/docker-server.md).
 
 ## Known distribution limits
 
-- AppImage is not published for this beta.
-- Flatpak is validated separately and is not published by the release tag;
-  the GitHub Release includes its Native Host companion archives.
+- AppImage was not published for this beta.
+- Flatpak was validated separately and was not published by the release tag;
+  the GitHub prerelease includes its Native Host companion archives.
 - Windows `arm64` and all 32-bit packages are not available.
 - Windows packages are unsigned and may trigger a Windows SmartScreen warning.
-  Download them only from the official GitHub Release after it is published.
-- Beta container tags are immutable and do not update `latest`, `stable`, or
-  other stable floating tags.
-- Snap is not published for this beta. Prerelease Snap runs stop after source
-  validation without building or publishing Snap artifacts.
+  Download them only from the official GitHub prerelease.
+- No beta container tag updates `latest`, `stable`, or another stable floating
+  tag.
+- Snap was not published. Its prerelease run stopped after source validation
+  without building or publishing Snap artifacts.
 
 ## Feedback
 

--- a/docs/release-notes/2.0.0-beta.13.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.13.zh-CN.md
@@ -1,40 +1,38 @@
 # Motrix 2.0.0-beta.13
 
-[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.13/docs/release-notes/2.0.0-beta.13.md) | 简体中文
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.14/docs/release-notes/2.0.0-beta.13.md) | 简体中文
 
-Motrix 2.0.0-beta.13 是下一次计划公开发布的 Motrix Turbo beta，但只有全部受保护
-发布门禁通过后才会进入分发。该版本继续验证重新开发的 v2 桌面应用与 Headless
-Server、共用下载内核、MDXP 集成和沙箱化插件系统。
+> Motrix 2.0.0-beta.13 完成了部分渠道分发。在 [Build/Release run
+> 31932206203](https://github.com/agalwood/Motrix/actions/runs/31932206203) 中，
+> 5 个桌面构建、3 个 Finalize job、assemble、GitHub 预发布版以及 R2 更新数据源
+> 均成功完成。Windows `x64` 安装包按发布说明以未签名形式发布。
+>
+> Server 容器没有完成。该 job 在 x64 runner 上使用 QEMU 执行合并 Buildx 构建
+> 中的 `linux/arm64` 部分。ARM `pnpm install` 层运行到 57.27 秒时，QEMU 因目标
+> signal 4（`Illegal instruction`）退出。此后 build action 一直保持运行状态，
+> 约 33 分钟后容器 job 被取消。剩余容器步骤均未执行：两个 registry 都没有发布
+> beta.13 不可变 tag，没有签名最终 index，也没有完成匿名平台、provenance、SBOM
+> 或 runtime 验证。
+>
+> 受保护的预发布 Snap run 通过了 source validation，并按设计跳过架构构建和 Store
+> 发布。没有上传或发布 Snap revision，`latest/edge` 也没有变化。
+>
+> GitHub 预发布版和 R2 更新数据源保持公开。容器发布是独立门禁的分发渠道，因此
+> 不能把该结果描述为跨分发渠道的原子发布。`v2.0.0-beta.13` tag 保持不可变，
+> 不会移动或复用。[Motrix 2.0.0-beta.14](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.14/docs/release-notes/2.0.0-beta.14.zh-CN.md)
+> 将取代未完成的容器发布结果。
 
-Motrix 2.0.0-beta.12 已发布桌面 Release、更新数据源和不可变 Server 镜像，但最终
-容器验证 job 未达到成功终态。[beta.12 历史记录](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.13/docs/release-notes/2.0.0-beta.12.zh-CN.md)
-保留了准确的公开结果。
+## beta.13 已包含的发布可靠性变化
 
-## 发布可靠性更新
-
-- 匿名签名验证最多执行 18 次，每次间隔 10 秒，为签名后的 registry 收敛提供有界
-  等待；如果任一 registry 始终没有公开有效签名，流程仍会 fail-closed。
-- 每次重试都保留精确的 tag workflow 身份与 GitHub OIDC issuer 校验；来自其他
-  身份的可见签名仍视为无效。
-- 根据当前仓库的精确 workflow run 验证 BuildKit provenance。builder attempt 必须
-  是不大于当前 run attempt 的正整数，因此失败 job 可以安全续跑，同时拒绝其他
-  仓库、其他 workflow run、未来 attempt 或附加路径后缀。
-- 将旧的通用 Docker Buildx builder prefix 替换为 beta.12 多架构镜像真实生成的
-  GitHub Actions builder 格式。
-- 保留两个 registry 的不可变 digest 一致性、amd64/arm64 镜像与 attestation、
-  SPDX SBOM、精确源码 revision、provenance 完整性以及匿名 runtime smoke 验证。
-- beta.13 使用新的不可变版本 tag 发布；不会覆盖或复用已有的 beta.12 Release
-  产物与容器 tag。只有 beta.13 带版本产物发布并通过公开验证后，才会推进可变 beta
-  更新数据源。
+- Cosign 签名后会有界等待匿名 registry 可见性；如果任一 registry 始终没有公开
+  有效签名，流程仍会 fail-closed。
+- BuildKit provenance 必须匹配当前仓库的精确 workflow run，以及当前或更早的
+  有效 attempt。
+- 保留跨 registry 不可变 digest 一致性、amd64/arm64 镜像与 attestation、SPDX
+  SBOM、精确源码 revision、provenance 完整性以及 runtime smoke 门禁。
 - Windows `x64` 安装包继续明确采用未签名发布，同时保留发布前的最终安装包验证。
 - 继续执行完整桌面平台集合门禁：所有桌面目标完成 Finalize 后才能组装，且每份
-  规范 updater manifest 都必须通过最终验证后才能发布。
-
-## Snap beta 策略
-
-Snap 不属于 beta.13 的分发范围。受保护的预发布 Snap run 会在 source validation
-后停止，因此不会构建 Snap artifact、上传 Store revision 或修改 `latest/edge`。
-稳定版 Snap 发布仍保留完整的双架构验证与受保护 Store 门禁。
+  规范 updater manifest 都在发布前通过最终验证。
 
 ## 主要变化
 
@@ -45,8 +43,6 @@ Snap 不属于 beta.13 的分发范围。受保护的预发布 Snap run 会在 s
 - 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地发现及远程 Server 的
   device-code 配对。
 - 提供带能力授权的 QuickJS 插件沙箱、内置插件和应用内插件市场。
-- 面向 NAS 和家庭服务器提供持久化、多架构 Server 容器；桌面发布成功后，
-  容器会同时发布到 Docker Hub 与 GHCR。
 
 ## 测试前须知
 
@@ -56,39 +52,33 @@ Snap 不属于 beta.13 的分发范围。受保护的预发布 Snap run 会在 s
 条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录与现有环境并行
 测试 v2。请勿让本 beta 成为重要下载文件的唯一存储位置。
 
-## 建议测试项
+## 实际分发结果
 
-- HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
-- 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
-- Headless Server 部署、数据持久化、远程配对，以及 amd64 与 arm64 容器镜像
+| 发布方式 | 架构 | 结果 |
+|----------|------|------|
+| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | 已发布 DMG 和 ZIP |
+| Windows | `x64` | 已发布未签名的 NSIS 安装包（`.exe`）和 ZIP |
+| Linux | `x64`、`arm64` | 已发布 DEB 和 RPM |
+| Flatpak Native Host 配套程序 | `linux/x64`、`linux/arm64` | GitHub 预发布版已包含 `Motrix-Native-Host-2.0.0-beta.13-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 都没有发布 `2.0.0-beta.13` |
+| Snap Store | — | 本 beta 未发布 |
 
-## 发布门禁通过后的计划下载
-
-| 发布方式 | 架构 | 计划产物 |
-|----------|------|----------|
-| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
-| Windows | `x64` | 未签名的 NSIS 安装包（`.exe`）和 ZIP |
-| Linux | `x64`、`arm64` | DEB 和 RPM |
-| Flatpak Native Host 配套程序 | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.13-linux-<arch>.tar.gz` |
-| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中不可变的 `2.0.0-beta.13` tag |
-| Snap Store | — | 本 beta 不发布 |
-
-发布完成后，容器镜像地址为
-`docker.io/motrixapp/motrix-server:2.0.0-beta.13` 和
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.13`。数据持久化、网络和升级方法请参阅
-[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.13/docs/docker-server.zh-CN.md)。
+原计划的容器引用为 `docker.io/motrixapp/motrix-server:2.0.0-beta.13` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.13`；两者都不是可用的 beta.13 发布镜像。
+请从 [Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.14/docs/docker-server.zh-CN.md)
+选择后续已成功验证的版本。
 
 ## 已知发布限制
 
-- 本 beta 不发布 AppImage。
-- Flatpak 会单独验证，不会随该版本 tag 发布；GitHub Release 会包含其 Native
+- 本 beta 未发布 AppImage。
+- Flatpak 单独完成验证，但没有随该版本 tag 发布；GitHub 预发布版包含其 Native
   Host 配套程序压缩包。
 - 不提供 Windows `arm64` 和任何 32 位安装包。
-- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅在正式发布后
-  从 GitHub 官方 Release 下载。
-- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
-- 本 beta 不发布 Snap。预发布 Snap run 会在 source validation 后停止，不会构建
-  或发布 Snap artifact。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅从官方 GitHub
+  预发布版下载。
+- Beta 容器 tag 不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
+- 本 beta 未发布 Snap。预发布 Snap run 在 source validation 后停止，没有构建或
+  发布 Snap artifact。
 
 ## 反馈
 

--- a/docs/release-notes/2.0.0-beta.14.md
+++ b/docs/release-notes/2.0.0-beta.14.md
@@ -1,0 +1,131 @@
+# Motrix 2.0.0-beta.14
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.14/docs/release-notes/2.0.0-beta.14.zh-CN.md)
+
+Motrix 2.0.0-beta.14 is the next Motrix Turbo beta intended for public
+distribution after every protected release gate passes. It supersedes the
+incomplete beta.13 container result without moving or reusing the immutable
+`v2.0.0-beta.13` tag.
+
+The [beta.13 historical record](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.14/docs/release-notes/2.0.0-beta.13.md)
+documents the successful desktop and R2 publication and the container failure.
+
+## Native container publication recovery
+
+- Builds `linux/amd64` on `ubuntu-22.04` and `linux/arm64` on
+  `ubuntu-22.04-arm`. Each job verifies the GitHub-hosted Linux runner and its
+  native architecture before Buildx starts. The container release path no
+  longer installs or invokes QEMU.
+- Pushes each successful platform only by its untagged, content-addressed OCI
+  digest to Docker Hub and GHCR. A single architecture never receives the
+  public version tag and cannot become the official release on its own.
+- Inspects the raw per-platform OCI index in both registries, hashes it back to
+  the Buildx digest, validates the exact version, source commit, non-root user,
+  image manifest, and attestation manifest, and records immutable build
+  metadata tied to the exact workflow run and attempt.
+- Anonymously pulls the exact staged digest from both registries and runs the
+  full Server runtime smoke on its native runner before that platform metadata
+  can leave the job.
+- Allows one finalize job to proceed only after the complete amd64/arm64 build
+  set succeeds. It rejects missing, duplicate, unexpected, cross-wired, or
+  future-attempt records before creating the versioned multi-platform index.
+- Rechecks both immutable version tags immediately before finalization. A clean
+  run creates both indexes from the verified platform digests; a rerun resumes
+  an identical complete result or repairs one missing registry from the
+  verified existing index. Any conflicting immutable tag fails closed.
+- Requires Docker Hub and GHCR to expose the same final index digest, platform
+  manifests, and attestation manifests. It also validates max-level BuildKit
+  provenance, the exact source revision and builder run, and a non-empty SPDX
+  SBOM for both architectures.
+- Signs each final index digest with the exact protected tag-workflow identity,
+  then verifies both signatures anonymously with a bounded fail-closed wait.
+- Runs the full anonymous runtime smoke for the final public index on native
+  amd64 and arm64 runners and against both registries. Stable floating aliases
+  are handled by a final recovery-safe job only after every build, index,
+  signature, provenance, SBOM, anonymous pull, and runtime gate succeeds.
+- Beta releases still publish only their immutable version tag; beta.14 does
+  not update `latest`, `stable`, or another stable floating alias.
+
+The GitHub prerelease, R2 update feed, container registries, and Snap Store
+remain independently gated publication channels. Their individual safety
+checks and recovery rules are strict, but this release does not claim
+cross-channel atomicity.
+
+## Snap beta policy
+
+Snap is not part of the beta.14 distribution. Protected prerelease Snap runs
+stop after source validation, so they do not build Snap artifacts, upload Store
+revisions, or change `latest/edge`. Stable Snap publication retains its
+complete two-architecture verification and protected Store gates.
+
+## Highlights
+
+- A ground-up desktop rebuild with Electron 43, React 19, and TypeScript 7,
+  including a customizable Dashboard, dark mode, a cross-platform application
+  menu, and clearer task-inspector feedback.
+- One host-neutral download core for both the desktop app and the Node/Web
+  Server, with SQLite session recovery, tracker management, UPnP/NAT-PMP, and
+  HTTP, FTP, BitTorrent, and magnet support.
+- MDXP-based integration for the official CLI and browser handoff, including
+  local discovery and device-code pairing for remote Server instances.
+- A QuickJS plugin sandbox with capability consent, bundled builtin plugins,
+  and an in-app plugin marketplace.
+- Persistent, verified multi-platform Server containers for NAS and
+  home-server deployments, published to both Docker Hub and GHCR after the
+  complete native architecture set passes.
+
+## Before testing
+
+This is prerelease software. Back up your existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Do not rely on this beta for your only copy of important
+downloads.
+
+## What to test
+
+- HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
+  session recovery
+- Desktop integrations, browser and CLI handoff through MDXP, and sandboxed
+  plugins
+- Headless Server deployment, persistent storage, remote pairing, and native
+  amd64 and arm64 container images
+
+## Planned downloads after release gates pass
+
+| Distribution | Architectures | Planned output |
+|--------------|---------------|----------------|
+| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | DEB and RPM |
+| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.14-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.14` tag in both registries |
+| Snap Store | — | Not published for this beta |
+
+After every container gate passes, the versioned image references will be
+`docker.io/motrixapp/motrix-server:2.0.0-beta.14` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.14`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.14/docs/docker-server.md)
+for storage, networking, and upgrade guidance.
+
+## Known distribution limits
+
+- AppImage is not published for this beta.
+- Flatpak is validated separately and is not published by the release tag;
+  the GitHub prerelease includes its Native Host companion archives.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
+  Download them only from the official GitHub prerelease after it is published.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+- Snap is not published for this beta. Prerelease Snap runs stop after source
+  validation without building or publishing Snap artifacts.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.14.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.14.zh-CN.md
@@ -1,0 +1,108 @@
+# Motrix 2.0.0-beta.14
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.14/docs/release-notes/2.0.0-beta.14.md) | 简体中文
+
+Motrix 2.0.0-beta.14 是下一次计划公开发布的 Motrix Turbo beta，但只有全部受保护
+发布门禁通过后才会进入分发。它会取代 beta.13 未完成的容器结果，但不会移动或
+复用不可变的 `v2.0.0-beta.13` tag。
+
+[beta.13 历史记录](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.14/docs/release-notes/2.0.0-beta.13.zh-CN.md)
+准确记录了成功的桌面/R2 发布和容器失败结果。
+
+## 原生容器发布恢复
+
+- `linux/amd64` 固定在 `ubuntu-22.04` 构建，`linux/arm64` 固定在
+  `ubuntu-22.04-arm` 构建。每个 job 都会在 Buildx 启动前验证 GitHub-hosted
+  Linux runner 及其原生架构；容器发布路径不再安装或调用 QEMU。
+- 每个平台成功后只按无 tag、内容寻址的 OCI digest 推送到 Docker Hub 和 GHCR。
+  单一架构不会获得公开版本 tag，因此不能独立成为正式发布版本。
+- 在两个 registry 中检查原始的单平台 OCI index，将其哈希回 Buildx digest，
+  校验精确版本、源码 commit、非 root 用户、image manifest 和 attestation
+  manifest，并生成绑定精确 workflow run 与 attempt 的不可变构建元数据。
+- 在该架构的原生 runner 上，从两个 registry 匿名拉取准确的暂存 digest 并运行
+  完整 Server runtime smoke；只有成功后，该平台元数据才能离开 job。
+- 只有 amd64/arm64 完整构建集合成功后，唯一的 finalize job 才能继续。创建带版本
+  multi-platform index 前，它会拒绝缺失、重复、意外、架构串线或未来 attempt
+  元数据。
+- Finalize 前立即重新检查两个不可变版本 tag。全新发布从已验证平台 digest 创建
+  两个 index；续跑可以接受完全一致的已有结果，或把单 registry 已有的验证 index
+  修复到缺失的 registry。任何冲突的不可变 tag 都会 fail-closed。
+- Docker Hub 和 GHCR 必须公开相同的最终 index digest、平台 manifest 与
+  attestation manifest；同时校验两个架构的 max-level BuildKit provenance、精确
+  源码 revision 与 builder run，以及非空 SPDX SBOM。
+- 使用精确的受保护 tag-workflow 身份签名两个最终 index digest，并通过有界、
+  fail-closed 的等待匿名验证两个签名。
+- 最终公开 index 会在原生 amd64 和 arm64 runner 上、针对两个 registry 完成匿名
+  完整 runtime smoke。只有全部构建、index、签名、provenance、SBOM、匿名拉取和
+  runtime 门禁通过后，最后一个可恢复 job 才能推进稳定版浮动 alias。
+- Beta 仍只发布不可变版本 tag；beta.14 不会更新 `latest`、`stable` 或其他稳定版
+  浮动 alias。
+
+GitHub 预发布版、R2 更新数据源、容器 registry 与 Snap Store 仍是各自独立门禁的
+发布渠道。每个渠道都有严格的安全检查和恢复规则，但本版本不宣称跨渠道原子性。
+
+## Snap beta 策略
+
+Snap 不属于 beta.14 的分发范围。受保护的预发布 Snap run 会在 source validation
+后停止，因此不会构建 Snap artifact、上传 Store revision 或修改 `latest/edge`。
+稳定版 Snap 发布仍保留完整的双架构验证与受保护 Store 门禁。
+
+## 主要变化
+
+- 使用 Electron 43、React 19 和 TypeScript 7 从头重建桌面应用，提供可自定义
+  Dashboard、深色模式、跨平台应用菜单，以及更清晰的任务检查器反馈。
+- 桌面应用和 Node/Web Server 共用与宿主无关的下载内核，支持 SQLite session
+  恢复、Tracker 管理、UPnP/NAT-PMP，以及 HTTP、FTP、BitTorrent 和磁力链接下载。
+- 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地发现及远程 Server 的
+  device-code 配对。
+- 提供带能力授权的 QuickJS 插件沙箱、内置插件和应用内插件市场。
+- 面向 NAS 和家庭服务器提供持久化、经过验证的多平台 Server 容器；完整原生架构
+  集合通过后，才会同时发布到 Docker Hub 与 GHCR。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1 数据的
+迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
+
+条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录与现有环境并行
+测试 v2。请勿让本 beta 成为重要下载文件的唯一存储位置。
+
+## 建议测试项
+
+- HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
+- 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
+- Headless Server 部署、数据持久化、远程配对，以及原生 amd64 与 arm64 容器
+  镜像
+
+## 发布门禁通过后的计划下载
+
+| 发布方式 | 架构 | 计划产物 |
+|----------|------|----------|
+| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
+| Windows | `x64` | 未签名的 NSIS 安装包（`.exe`）和 ZIP |
+| Linux | `x64`、`arm64` | DEB 和 RPM |
+| Flatpak Native Host 配套程序 | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.14-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中不可变的 `2.0.0-beta.14` tag |
+| Snap Store | — | 本 beta 不发布 |
+
+全部容器门禁通过后，带版本镜像引用为
+`docker.io/motrixapp/motrix-server:2.0.0-beta.14` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.14`。数据持久化、网络和升级方法请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.14/docs/docker-server.zh-CN.md)。
+
+## 已知发布限制
+
+- 本 beta 不发布 AppImage。
+- Flatpak 会单独验证，不会随该版本 tag 发布；GitHub 预发布版会包含其 Native Host
+  配套程序压缩包。
+- 不提供 Windows `arm64` 和任何 32 位安装包。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅在正式发布后
+  从 GitHub 官方预发布版下载。
+- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
+- 本 beta 不发布 Snap。预发布 Snap run 会在 source validation 后停止，不会构建
+  或发布 Snap artifact。
+
+## 反馈
+
+请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现的问题，
+并附上操作系统、架构、安装包类型和复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -76,15 +76,29 @@
   <releases>
     <!-- Update this list on every release; Flathub linter requires the most
          recent version listed here to match the manifest's source tag. -->
+    <release version="2.0.0-beta.14" date="2026-08-16">
+      <description>
+        <p>
+          Container publication now builds amd64 and arm64 independently on
+          native GitHub-hosted runners without QEMU. Untagged platform digests
+          must pass cross-registry metadata and native runtime checks before a
+          single job creates, signs, and anonymously verifies the final index.
+          Stable aliases advance only after final native public smoke tests.
+          Windows packages remain unsigned. Prerelease Snap runs stop after
+          source validation without building or publishing artifacts.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.13" date="2026-08-16">
       <description>
         <p>
-          Container publication recovery that waits for registry signature
-          visibility with a bounded fail-closed retry and verifies BuildKit
-          provenance against the exact repository workflow run and a valid
-          current-or-earlier attempt. Windows packages remain unsigned.
-          Prerelease Snap runs stop after source validation without building
-          or publishing artifacts.
+          Partially distributed Motrix Turbo beta. All desktop builds,
+          Finalize jobs, assembly, the GitHub prerelease, and the R2 update
+          feed completed. The combined container build failed in the emulated
+          arm64 dependency-install layer and remained active until canceled;
+          no beta.13 container tag, signature, public artifact verification,
+          or runtime smoke completed. Windows packages were published
+          unsigned. Prerelease Snap stopped after source validation.
         </p>
       </description>
     </release>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.13",
+  "version": "2.0.0-beta.14",
   "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1",
   "description": "A full-featured download manager",
   "keywords": [],

--- a/scripts/container-platform-metadata.mjs
+++ b/scripts/container-platform-metadata.mjs
@@ -1,0 +1,679 @@
+import { createHash } from 'node:crypto'
+import { appendFileSync } from 'node:fs'
+import { lstat, readdir, readFile, realpath, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import {
+  CONTAINER_REPOSITORIES,
+  resolveContainerLabels,
+  resolveContainerReleaseMetadata,
+} from './container-release-metadata.mjs'
+
+const DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/
+const REVISION_PATTERN = /^[0-9a-f]{40}$/
+const BUILDER_RUN_PATTERN =
+  /^https:\/\/github\.com\/agalwood\/Motrix\/actions\/runs\/[1-9][0-9]*$/
+const MEDIA_TYPE =
+  'application/vnd.motrix.container-platform-build-metadata.v1+json'
+
+export const CONTAINER_PLATFORM_MATRIX = Object.freeze({
+  'linux/amd64': Object.freeze({
+    artifact: 'container-build-linux-amd64',
+    metadataFile: 'linux-amd64.json',
+    runner: 'ubuntu-22.04',
+    runnerArch: 'X64',
+  }),
+  'linux/arm64': Object.freeze({
+    artifact: 'container-build-linux-arm64',
+    metadataFile: 'linux-arm64.json',
+    runner: 'ubuntu-22.04-arm',
+    runnerArch: 'ARM64',
+  }),
+})
+
+const REQUIRED_PLATFORMS = Object.freeze(Object.keys(CONTAINER_PLATFORM_MATRIX))
+const REQUIRED_REPOSITORIES = Object.freeze(
+  Object.values(CONTAINER_REPOSITORIES)
+)
+
+function requireRecord(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`)
+  }
+  return value
+}
+
+function requireExactKeys(value, expected, label) {
+  const actual = Object.keys(requireRecord(value, label)).sort()
+  const wanted = [...expected].sort()
+  if (
+    actual.length !== wanted.length ||
+    actual.some((key, i) => key !== wanted[i])
+  ) {
+    throw new Error(`${label} fields must be exactly ${wanted.join(',')}`)
+  }
+}
+
+function requireString(value, label) {
+  if (typeof value !== 'string' || !value) {
+    throw new Error(`${label} must be a non-empty string`)
+  }
+  return value
+}
+
+function requireDigest(value, label) {
+  const result = requireString(value, label)
+  if (!DIGEST_PATTERN.test(result)) {
+    throw new Error(`${label} must be a sha256 digest`)
+  }
+  return result
+}
+
+function requirePositiveInteger(value, label) {
+  const text =
+    typeof value === 'number' ? String(value) : requireString(value, label)
+  if (!/^[1-9][0-9]*$/.test(text)) {
+    throw new Error(`${label} must be a positive integer`)
+  }
+  const result = Number(text)
+  if (!Number.isSafeInteger(result)) {
+    throw new Error(`${label} must be a safe integer`)
+  }
+  return result
+}
+
+function validateIdentity({ builderAttempt, builderRunId, revision, version }) {
+  resolveContainerReleaseMetadata(requireString(version, 'container version'))
+  if (!REVISION_PATTERN.test(requireString(revision, 'container revision'))) {
+    throw new Error('container revision must be a full lowercase SHA')
+  }
+  if (
+    !BUILDER_RUN_PATTERN.test(requireString(builderRunId, 'builder run id'))
+  ) {
+    throw new Error(
+      'builder run id must be the exact Motrix GitHub Actions run URL'
+    )
+  }
+  return {
+    builderAttempt: requirePositiveInteger(builderAttempt, 'builder attempt'),
+    builderRunId,
+    revision,
+    version,
+  }
+}
+
+function platformParts(platform) {
+  const [os, architecture] = platform.split('/')
+  return { architecture, os }
+}
+
+function inspectPlatformIndex(bytes, repository, platform, sourceDigest) {
+  const candidates = [bytes]
+  if (bytes.at(-1) === 0x0a) candidates.push(bytes.subarray(0, -1))
+  const manifestBytes = candidates.find(
+    (candidate) =>
+      `sha256:${createHash('sha256').update(candidate).digest('hex')}` ===
+      sourceDigest
+  )
+  if (!manifestBytes) {
+    throw new Error(`${repository} raw index digest conflicts`)
+  }
+  const index = requireRecord(
+    JSON.parse(manifestBytes.toString('utf8')),
+    `${repository} platform index`
+  )
+  if (
+    index.schemaVersion !== 2 ||
+    ![
+      'application/vnd.docker.distribution.manifest.list.v2+json',
+      'application/vnd.oci.image.index.v1+json',
+    ].includes(index.mediaType)
+  ) {
+    throw new Error(`${repository} platform build must be an OCI image index`)
+  }
+  if (!Array.isArray(index.manifests) || index.manifests.length !== 2) {
+    throw new Error(
+      `${repository} platform index must contain one image and one attestation`
+    )
+  }
+  let image
+  let attestation
+  for (const value of index.manifests) {
+    const descriptor = requireRecord(value, `${repository} descriptor`)
+    const descriptorPlatform = requireRecord(
+      descriptor.platform,
+      `${repository} descriptor platform`
+    )
+    const key = `${descriptorPlatform.os}/${descriptorPlatform.architecture}`
+    if (
+      descriptor.annotations?.['vnd.docker.reference.type'] ===
+      'attestation-manifest'
+    ) {
+      if (attestation) {
+        throw new Error(`${repository} has duplicate attestation manifests`)
+      }
+      attestation = descriptor
+    } else if (key === platform) {
+      if (image)
+        throw new Error(`${repository} has duplicate ${platform} images`)
+      image = descriptor
+    } else {
+      throw new Error(`${repository} platform index contains unexpected ${key}`)
+    }
+  }
+  if (!image || !attestation) {
+    throw new Error(`${repository} platform index is incomplete`)
+  }
+  const imageDigest = requireDigest(
+    image.digest,
+    `${repository} ${platform} image digest`
+  )
+  const attestationDigest = requireDigest(
+    attestation.digest,
+    `${repository} ${platform} attestation digest`
+  )
+  if (
+    attestation.annotations?.['vnd.docker.reference.digest'] !== imageDigest
+  ) {
+    throw new Error(`${repository} attestation subject conflicts`)
+  }
+  return { attestationDigest, imageDigest }
+}
+
+function inspectPlatformConfig(
+  snapshot,
+  repository,
+  platform,
+  sourceDigest,
+  labels
+) {
+  const document = requireRecord(snapshot, `${repository} inspection`)
+  if (document.manifest?.digest !== sourceDigest) {
+    throw new Error(`${repository} inspected digest conflicts`)
+  }
+  const images = requireRecord(document.image, `${repository} inspected images`)
+  const expectedKeys = Object.keys(images).filter(
+    (key) => key !== 'unknown/unknown'
+  )
+  if (expectedKeys.length !== 1 || expectedKeys[0] !== platform) {
+    throw new Error(`${repository} inspection must contain exactly ${platform}`)
+  }
+  const image = requireRecord(
+    images[platform],
+    `${repository} ${platform} image`
+  )
+  const config = requireRecord(image.config, `${repository} ${platform} config`)
+  if (config.User !== 'node') {
+    throw new Error(`${repository} ${platform} default user is not node`)
+  }
+  const actualLabels = requireRecord(
+    config.Labels,
+    `${repository} ${platform} labels`
+  )
+  for (const [key, expected] of Object.entries(labels)) {
+    if (actualLabels[key] !== expected) {
+      throw new Error(`${repository} ${platform} label ${key} conflicts`)
+    }
+  }
+  const observedPlatform = image.platform
+  if (observedPlatform !== undefined) {
+    const { architecture, os } = platformParts(platform)
+    if (
+      observedPlatform.architecture !== architecture ||
+      observedPlatform.os !== os
+    ) {
+      throw new Error(`${repository} inspected platform conflicts`)
+    }
+  }
+}
+
+export function inspectContainerPlatformPublication({
+  digest: sourceDigest,
+  dockerHubIndex,
+  dockerHubInspect,
+  ghcrIndex,
+  ghcrInspect,
+  platform,
+  revision,
+  version,
+}) {
+  if (!CONTAINER_PLATFORM_MATRIX[platform]) {
+    throw new Error(`unsupported container platform: ${platform}`)
+  }
+  requireDigest(sourceDigest, 'platform source digest')
+  const labels = resolveContainerLabels({ revision, version })
+  const artifacts = [
+    [CONTAINER_REPOSITORIES.dockerHub, dockerHubIndex, dockerHubInspect],
+    [CONTAINER_REPOSITORIES.ghcr, ghcrIndex, ghcrInspect],
+  ].map(([repository, index, inspect]) => {
+    const manifests = inspectPlatformIndex(
+      index,
+      repository,
+      platform,
+      sourceDigest
+    )
+    inspectPlatformConfig(inspect, repository, platform, sourceDigest, labels)
+    return { repository, ...manifests }
+  })
+  if (
+    artifacts[0].imageDigest !== artifacts[1].imageDigest ||
+    artifacts[0].attestationDigest !== artifacts[1].attestationDigest
+  ) {
+    throw new Error('platform manifests disagree across registries')
+  }
+  return {
+    imageDigest: artifacts[0].imageDigest,
+    attestationDigest: artifacts[0].attestationDigest,
+  }
+}
+
+export function createContainerPlatformMetadata({
+  attestationDigest,
+  builderAttempt,
+  builderRunId,
+  digest,
+  imageDigest,
+  platform,
+  revision,
+  runnerArch,
+  runnerEnvironment,
+  runnerOs,
+  version,
+}) {
+  const expected = CONTAINER_PLATFORM_MATRIX[platform]
+  if (!expected) {
+    throw new Error(`unsupported container platform: ${platform}`)
+  }
+  const identity = validateIdentity({
+    builderAttempt,
+    builderRunId,
+    revision,
+    version,
+  })
+  const sourceDigest = requireDigest(digest, 'platform source digest')
+  if (runnerEnvironment !== 'github-hosted') {
+    throw new Error('container builds require a GitHub-hosted runner')
+  }
+  if (runnerOs !== 'Linux') {
+    throw new Error('container builds require a Linux runner')
+  }
+  if (runnerArch !== expected.runnerArch) {
+    throw new Error(
+      `${platform} requires native runner architecture ${expected.runnerArch}, got ${runnerArch}`
+    )
+  }
+
+  return {
+    schemaVersion: 1,
+    mediaType: MEDIA_TYPE,
+    platform,
+    digest: sourceDigest,
+    manifests: {
+      image: requireDigest(imageDigest, 'image manifest digest'),
+      attestation: requireDigest(
+        attestationDigest,
+        'attestation manifest digest'
+      ),
+    },
+    version: identity.version,
+    revision: identity.revision,
+    builder: {
+      runId: identity.builderRunId,
+      attempt: identity.builderAttempt,
+      runner: expected.runner,
+      runnerArch,
+      runnerEnvironment,
+      runnerOs,
+    },
+    repositories: Object.fromEntries(
+      REQUIRED_REPOSITORIES.map((repository) => [repository, sourceDigest])
+    ),
+    verification: {
+      anonymousPull: [...REQUIRED_REPOSITORIES],
+      smoke: 'full',
+    },
+  }
+}
+
+function validateContainerPlatformMetadata(
+  value,
+  { builderRunId, maximumBuilderAttempt, revision, version }
+) {
+  const metadata = requireRecord(value, 'platform metadata')
+  requireExactKeys(
+    metadata,
+    [
+      'builder',
+      'digest',
+      'manifests',
+      'mediaType',
+      'platform',
+      'repositories',
+      'revision',
+      'schemaVersion',
+      'verification',
+      'version',
+    ],
+    'platform metadata'
+  )
+  if (metadata.schemaVersion !== 1 || metadata.mediaType !== MEDIA_TYPE) {
+    throw new Error('platform metadata schema conflicts')
+  }
+  const platform = requireString(metadata.platform, 'platform')
+  const expected = CONTAINER_PLATFORM_MATRIX[platform]
+  if (!expected) throw new Error(`unexpected container platform: ${platform}`)
+  const sourceDigest = requireDigest(metadata.digest, `${platform} digest`)
+  const manifests = requireRecord(metadata.manifests, `${platform} manifests`)
+  requireExactKeys(manifests, ['attestation', 'image'], `${platform} manifests`)
+  requireDigest(manifests.image, `${platform} image manifest digest`)
+  requireDigest(
+    manifests.attestation,
+    `${platform} attestation manifest digest`
+  )
+  if (metadata.version !== version || metadata.revision !== revision) {
+    throw new Error(`${platform} version or revision conflicts`)
+  }
+
+  const builder = requireRecord(metadata.builder, `${platform} builder`)
+  requireExactKeys(
+    builder,
+    [
+      'attempt',
+      'runId',
+      'runner',
+      'runnerArch',
+      'runnerEnvironment',
+      'runnerOs',
+    ],
+    `${platform} builder`
+  )
+  if (
+    builder.runId !== builderRunId ||
+    builder.runner !== expected.runner ||
+    builder.runnerArch !== expected.runnerArch ||
+    builder.runnerEnvironment !== 'github-hosted' ||
+    builder.runnerOs !== 'Linux'
+  ) {
+    throw new Error(`${platform} builder identity conflicts`)
+  }
+  const attempt = requirePositiveInteger(
+    builder.attempt,
+    `${platform} builder attempt`
+  )
+  if (attempt > maximumBuilderAttempt) {
+    throw new Error(`${platform} builder attempt is from the future`)
+  }
+
+  const repositories = requireRecord(
+    metadata.repositories,
+    `${platform} repositories`
+  )
+  requireExactKeys(
+    repositories,
+    REQUIRED_REPOSITORIES,
+    `${platform} repositories`
+  )
+  for (const repository of REQUIRED_REPOSITORIES) {
+    if (repositories[repository] !== sourceDigest) {
+      throw new Error(`${platform} ${repository} digest conflicts`)
+    }
+  }
+
+  const verification = requireRecord(
+    metadata.verification,
+    `${platform} verification`
+  )
+  requireExactKeys(
+    verification,
+    ['anonymousPull', 'smoke'],
+    `${platform} verification`
+  )
+  if (verification.smoke !== 'full') {
+    throw new Error(`${platform} did not complete the full runtime smoke`)
+  }
+  if (
+    !Array.isArray(verification.anonymousPull) ||
+    verification.anonymousPull.length !== REQUIRED_REPOSITORIES.length ||
+    verification.anonymousPull.some(
+      (repository, index) => repository !== REQUIRED_REPOSITORIES[index]
+    )
+  ) {
+    throw new Error(`${platform} anonymous registry pulls are incomplete`)
+  }
+  return metadata
+}
+
+async function listMetadataFiles(root) {
+  const resolvedRoot = await realpath(root)
+  const rootStat = await lstat(resolvedRoot)
+  if (!rootStat.isDirectory())
+    throw new Error('metadata directory is not a directory')
+  const files = []
+  async function visit(directory) {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const target = path.join(directory, entry.name)
+      if (entry.isSymbolicLink()) {
+        throw new Error(
+          `metadata directory contains a symbolic link: ${entry.name}`
+        )
+      }
+      if (entry.isDirectory()) await visit(target)
+      else if (entry.isFile()) files.push(target)
+      else
+        throw new Error(
+          `metadata directory contains a non-regular entry: ${entry.name}`
+        )
+    }
+  }
+  await visit(resolvedRoot)
+  return files.sort()
+}
+
+export async function verifyContainerPlatformMetadataSet({
+  builderRunId,
+  directory,
+  maximumBuilderAttempt,
+  revision,
+  version,
+}) {
+  const identity = validateIdentity({
+    builderAttempt: maximumBuilderAttempt,
+    builderRunId,
+    revision,
+    version,
+  })
+  const files = await listMetadataFiles(directory)
+  if (files.length !== REQUIRED_PLATFORMS.length) {
+    throw new Error(
+      `container platform metadata must contain exactly ${REQUIRED_PLATFORMS.length} files`
+    )
+  }
+  const platforms = new Map()
+  for (const file of files) {
+    if (path.extname(file) !== '.json') {
+      throw new Error(
+        `unexpected container metadata file: ${path.basename(file)}`
+      )
+    }
+    const metadata = validateContainerPlatformMetadata(
+      JSON.parse(await readFile(file, 'utf8')),
+      {
+        builderRunId: identity.builderRunId,
+        maximumBuilderAttempt: identity.builderAttempt,
+        revision: identity.revision,
+        version: identity.version,
+      }
+    )
+    const expectedFile =
+      CONTAINER_PLATFORM_MATRIX[metadata.platform].metadataFile
+    if (path.basename(file) !== expectedFile) {
+      throw new Error(
+        `${metadata.platform} metadata file must be ${expectedFile}`
+      )
+    }
+    if (platforms.has(metadata.platform)) {
+      throw new Error(`duplicate container metadata for ${metadata.platform}`)
+    }
+    platforms.set(metadata.platform, metadata)
+  }
+  for (const platform of REQUIRED_PLATFORMS) {
+    if (!platforms.has(platform)) {
+      throw new Error(`missing container metadata for ${platform}`)
+    }
+  }
+  const digests = REQUIRED_PLATFORMS.map(
+    (platform) => platforms.get(platform).digest
+  )
+  if (new Set(digests).size !== digests.length) {
+    throw new Error('container platforms must not share an image digest')
+  }
+  return {
+    schemaVersion: 1,
+    version: identity.version,
+    revision: identity.revision,
+    builderRunId: identity.builderRunId,
+    maximumBuilderAttempt: identity.builderAttempt,
+    platforms: Object.fromEntries(
+      REQUIRED_PLATFORMS.map((platform) => [
+        platform,
+        {
+          digest: platforms.get(platform).digest,
+          manifests: platforms.get(platform).manifests,
+        },
+      ])
+    ),
+  }
+}
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv
+  if (!['create', 'verify-set'].includes(command)) {
+    throw new Error('Expected create or verify-set command')
+  }
+  const options = { command, githubOutput: process.env.GITHUB_OUTPUT }
+  const allowed = new Set([
+    '--builder-attempt',
+    '--builder-run-id',
+    '--digest',
+    '--docker-hub-index',
+    '--docker-hub-inspect',
+    '--github-output',
+    '--ghcr-index',
+    '--ghcr-inspect',
+    '--metadata-dir',
+    '--output',
+    '--platform',
+    '--revision',
+    '--runner-arch',
+    '--runner-environment',
+    '--runner-os',
+    '--version',
+  ])
+  for (let index = 0; index < rest.length; index += 2) {
+    const argument = rest[index]
+    const value = rest[index + 1]
+    if (!allowed.has(argument)) throw new Error(`Unknown argument: ${argument}`)
+    if (!value || value.startsWith('--'))
+      throw new Error(`${argument} requires a value`)
+    const key = argument
+      .slice(2)
+      .replace(/-([a-z])/g, (_, letter) => letter.toUpperCase())
+    options[key] = value
+  }
+  return options
+}
+
+function requireOptions(options, keys) {
+  for (const key of keys) {
+    if (!options[key])
+      throw new Error(
+        `--${key.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`)} is required`
+      )
+  }
+}
+
+function appendOutput(target, key, value) {
+  appendFileSync(target, `${key}=${value}\n`, 'utf8')
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  if (options.command === 'create') {
+    requireOptions(options, [
+      'builderAttempt',
+      'builderRunId',
+      'digest',
+      'dockerHubIndex',
+      'dockerHubInspect',
+      'ghcrIndex',
+      'ghcrInspect',
+      'output',
+      'platform',
+      'revision',
+      'runnerArch',
+      'runnerEnvironment',
+      'runnerOs',
+      'version',
+    ])
+    const publication = inspectContainerPlatformPublication({
+      digest: options.digest,
+      dockerHubIndex: await readFile(options.dockerHubIndex),
+      dockerHubInspect: JSON.parse(
+        await readFile(options.dockerHubInspect, 'utf8')
+      ),
+      ghcrIndex: await readFile(options.ghcrIndex),
+      ghcrInspect: JSON.parse(await readFile(options.ghcrInspect, 'utf8')),
+      platform: options.platform,
+      revision: options.revision,
+      version: options.version,
+    })
+    const metadata = createContainerPlatformMetadata({
+      ...options,
+      ...publication,
+    })
+    await writeFile(options.output, `${JSON.stringify(metadata, null, 2)}\n`, {
+      encoding: 'utf8',
+      flag: 'wx',
+    })
+    return
+  }
+
+  requireOptions(options, [
+    'builderAttempt',
+    'builderRunId',
+    'metadataDir',
+    'output',
+    'revision',
+    'version',
+  ])
+  const metadata = await verifyContainerPlatformMetadataSet({
+    builderRunId: options.builderRunId,
+    directory: options.metadataDir,
+    maximumBuilderAttempt: options.builderAttempt,
+    revision: options.revision,
+    version: options.version,
+  })
+  await writeFile(options.output, `${JSON.stringify(metadata, null, 2)}\n`, {
+    encoding: 'utf8',
+    flag: 'wx',
+  })
+  if (options.githubOutput) {
+    appendOutput(
+      options.githubOutput,
+      'amd64_digest',
+      metadata.platforms['linux/amd64'].digest
+    )
+    appendOutput(
+      options.githubOutput,
+      'arm64_digest',
+      metadata.platforms['linux/arm64'].digest
+    )
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main()
+}

--- a/scripts/verify-container-publication.mjs
+++ b/scripts/verify-container-publication.mjs
@@ -1,9 +1,11 @@
+import { createHash } from 'node:crypto'
 import { readFileSync } from 'node:fs'
 import { pathToFileURL } from 'node:url'
 import {
   REQUIRED_CONTAINER_PLATFORMS,
   resolveContainerPublicationState,
 } from './container-publication-state.mjs'
+import { CONTAINER_REPOSITORIES } from './container-release-metadata.mjs'
 
 const DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/
 const INDEX_MEDIA_TYPES = new Set([
@@ -41,6 +43,24 @@ function digest(value, label) {
   return result
 }
 
+function verifyRawIndexDigest(bytes, expectedDigest, repository) {
+  if (bytes === undefined) return
+  if (!Buffer.isBuffer(bytes)) {
+    throw new Error(`${repository} raw index must be bytes`)
+  }
+  const candidates = [bytes]
+  if (bytes.at(-1) === 0x0a) candidates.push(bytes.subarray(0, -1))
+  if (
+    !candidates.some(
+      (candidate) =>
+        `sha256:${createHash('sha256').update(candidate).digest('hex')}` ===
+        expectedDigest
+    )
+  ) {
+    throw new Error(`${repository} raw index digest conflicts`)
+  }
+}
+
 function verifyIndex(index, repository) {
   const document = record(index, `${repository} index`)
   if (document.schemaVersion !== 2) {
@@ -51,6 +71,7 @@ function verifyIndex(index, repository) {
   }
   const descriptors = array(document.manifests, `${repository} manifests`)
   const platformDigests = new Map()
+  const attestationDigests = new Map()
   for (const descriptorValue of descriptors) {
     const descriptor = record(descriptorValue, `${repository} descriptor`)
     const platform = record(
@@ -58,7 +79,31 @@ function verifyIndex(index, repository) {
       `${repository} descriptor platform`
     )
     const key = `${platform.os}/${platform.architecture}`
-    if (!REQUIRED_CONTAINER_PLATFORMS.includes(key)) continue
+    if (
+      descriptor.annotations?.['vnd.docker.reference.type'] ===
+      'attestation-manifest'
+    ) {
+      if (key !== 'unknown/unknown') {
+        throw new Error(`${repository} attestation has unexpected ${key}`)
+      }
+      const subject = digest(
+        descriptor.annotations?.['vnd.docker.reference.digest'],
+        `${repository} attestation subject digest`
+      )
+      if (attestationDigests.has(subject)) {
+        throw new Error(
+          `${repository} has duplicate attestation manifests for ${subject}`
+        )
+      }
+      attestationDigests.set(
+        subject,
+        digest(descriptor.digest, `${repository} attestation digest`)
+      )
+      continue
+    }
+    if (!REQUIRED_CONTAINER_PLATFORMS.includes(key)) {
+      throw new Error(`${repository} has unexpected image platform ${key}`)
+    }
     if (platformDigests.has(key)) {
       throw new Error(`${repository} has duplicate ${key} image manifests`)
     }
@@ -73,25 +118,24 @@ function verifyIndex(index, repository) {
     if (!subjectDigest) {
       throw new Error(`${repository} index is missing ${platform}`)
     }
-    const attestations = descriptors.filter((descriptorValue) => {
-      const descriptor = record(descriptorValue, `${repository} descriptor`)
-      const annotations = descriptor.annotations
-      return (
-        annotations?.['vnd.docker.reference.type'] === 'attestation-manifest' &&
-        annotations?.['vnd.docker.reference.digest'] === subjectDigest
-      )
-    })
-    if (attestations.length !== 1) {
+    if (!attestationDigests.has(subjectDigest)) {
       throw new Error(
         `${repository} ${platform} must have exactly one attestation manifest`
       )
     }
-    digest(
-      attestations[0].digest,
-      `${repository} ${platform} attestation digest`
-    )
   }
-  return Object.fromEntries(platformDigests)
+  if (attestationDigests.size !== REQUIRED_CONTAINER_PLATFORMS.length) {
+    throw new Error(`${repository} has an unattached attestation manifest`)
+  }
+  return {
+    images: Object.fromEntries(platformDigests),
+    attestations: Object.fromEntries(
+      REQUIRED_CONTAINER_PLATFORMS.map((platform) => {
+        const subjectDigest = platformDigests.get(platform)
+        return [platform, attestationDigests.get(subjectDigest)]
+      })
+    ),
+  }
 }
 
 function verifySbom(sbom, repository) {
@@ -288,7 +332,12 @@ function verifyArtifact(
   builderRunId,
   maximumBuilderAttempt
 ) {
-  const platformDigests = verifyIndex(artifact.index, repository)
+  const expectedDigest = digest(
+    artifact.inspect?.manifest?.digest,
+    `${repository} inspected index digest`
+  )
+  verifyRawIndexDigest(artifact.indexBytes, expectedDigest, repository)
+  const manifests = verifyIndex(artifact.index, repository)
   verifySbom(artifact.sbom, repository)
   verifyProvenance(
     artifact.provenance,
@@ -297,17 +346,10 @@ function verifyArtifact(
     builderRunId,
     maximumBuilderAttempt
   )
-  return platformDigests
+  return manifests
 }
 
-export function verifyContainerPublication({
-  builderRunId,
-  dockerHub,
-  ghcr,
-  maximumBuilderAttempt,
-  revision,
-  version,
-}) {
+function verificationIdentity(builderRunId, maximumBuilderAttempt) {
   const expectedBuilderRun = string(builderRunId, 'builder run id')
   if (
     !/^https:\/\/github\.com\/[^/]+\/[^/]+\/actions\/runs\/[1-9][0-9]*$/.test(
@@ -316,10 +358,84 @@ export function verifyContainerPublication({
   ) {
     throw new Error('builder run id must be an exact GitHub Actions run URL')
   }
-  const maximumAttempt = positiveInteger(
-    maximumBuilderAttempt,
-    'maximum builder attempt'
+  return {
+    builderRunId: expectedBuilderRun,
+    maximumBuilderAttempt: positiveInteger(
+      maximumBuilderAttempt,
+      'maximum builder attempt'
+    ),
+  }
+}
+
+function exactPlatformMap(value, label) {
+  const result = record(value, label)
+  const keys = Object.keys(result).sort()
+  const expected = [...REQUIRED_CONTAINER_PLATFORMS].sort()
+  if (
+    keys.length !== expected.length ||
+    keys.some((key, index) => key !== expected[index])
+  ) {
+    throw new Error(`${label} must contain exactly ${expected.join(',')}`)
+  }
+  return result
+}
+
+function verifyExpectedPlatformMetadata(
+  metadata,
+  version,
+  revision,
+  manifests
+) {
+  const document = record(metadata, 'platform build metadata')
+  if (
+    document.schemaVersion !== 1 ||
+    document.version !== version ||
+    document.revision !== revision
+  ) {
+    throw new Error('platform build metadata identity conflicts')
+  }
+  const platforms = exactPlatformMap(
+    document.platforms,
+    'platform build metadata platforms'
   )
+  for (const platform of REQUIRED_CONTAINER_PLATFORMS) {
+    const expected = record(platforms[platform], `${platform} build metadata`)
+    digest(expected.digest, `${platform} source index digest`)
+    const expectedManifests = record(
+      expected.manifests,
+      `${platform} build manifests`
+    )
+    const expectedKeys = Object.keys(expectedManifests).sort().join(',')
+    if (expectedKeys !== 'attestation,image') {
+      throw new Error(`${platform} build manifests are incomplete`)
+    }
+    if (
+      digest(expectedManifests.image, `${platform} expected image digest`) !==
+      manifests.images[platform]
+    ) {
+      throw new Error(`${platform} published image digest conflicts`)
+    }
+    if (
+      digest(
+        expectedManifests.attestation,
+        `${platform} expected attestation digest`
+      ) !== manifests.attestations[platform]
+    ) {
+      throw new Error(`${platform} published attestation digest conflicts`)
+    }
+  }
+}
+
+export function verifyContainerPublication({
+  builderRunId,
+  dockerHub,
+  ghcr,
+  maximumBuilderAttempt,
+  platformMetadata,
+  revision,
+  version,
+}) {
+  const identity = verificationIdentity(builderRunId, maximumBuilderAttempt)
   const publication = resolveContainerPublicationState({
     dockerHubSnapshot: dockerHub.inspect,
     ghcrSnapshot: ghcr.inspect,
@@ -331,23 +447,93 @@ export function verifyContainerPublication({
       `Container publication is incomplete: ${publication.action}`
     )
   }
+  const dockerHubManifests = verifyArtifact(
+    dockerHub,
+    'Docker Hub',
+    revision,
+    identity.builderRunId,
+    identity.maximumBuilderAttempt
+  )
+  const ghcrManifests = verifyArtifact(
+    ghcr,
+    'GHCR',
+    revision,
+    identity.builderRunId,
+    identity.maximumBuilderAttempt
+  )
+  for (const field of ['images', 'attestations']) {
+    for (const platform of REQUIRED_CONTAINER_PLATFORMS) {
+      if (
+        dockerHubManifests[field][platform] !== ghcrManifests[field][platform]
+      ) {
+        throw new Error(
+          `${platform} ${field} disagree across Docker Hub and GHCR`
+        )
+      }
+    }
+  }
+  if (platformMetadata !== undefined) {
+    verifyExpectedPlatformMetadata(
+      platformMetadata,
+      version,
+      revision,
+      dockerHubManifests
+    )
+  }
   return {
     digest: publication.digest,
     platforms: REQUIRED_CONTAINER_PLATFORMS,
-    dockerHub: verifyArtifact(
-      dockerHub,
-      'Docker Hub',
+    dockerHub: dockerHubManifests.images,
+    ghcr: ghcrManifests.images,
+    sbom: 'SPDX-2.x',
+    provenance: 'SLSA BuildKit',
+  }
+}
+
+export function verifyContainerArtifact({
+  artifact,
+  builderRunId,
+  maximumBuilderAttempt,
+  platformMetadata,
+  repository,
+  revision,
+  version,
+}) {
+  if (!Object.values(CONTAINER_REPOSITORIES).includes(repository)) {
+    throw new Error(`unexpected container repository: ${repository}`)
+  }
+  const identity = verificationIdentity(builderRunId, maximumBuilderAttempt)
+  const publication = resolveContainerPublicationState({
+    dockerHubSnapshot:
+      repository === CONTAINER_REPOSITORIES.dockerHub ? artifact.inspect : null,
+    ghcrSnapshot:
+      repository === CONTAINER_REPOSITORIES.ghcr ? artifact.inspect : null,
+    revision,
+    version,
+  })
+  if (publication.action !== 'copy') {
+    throw new Error('single-registry container artifact is incomplete')
+  }
+  const manifests = verifyArtifact(
+    artifact,
+    repository,
+    revision,
+    identity.builderRunId,
+    identity.maximumBuilderAttempt
+  )
+  if (platformMetadata !== undefined) {
+    verifyExpectedPlatformMetadata(
+      platformMetadata,
+      version,
       revision,
-      expectedBuilderRun,
-      maximumAttempt
-    ),
-    ghcr: verifyArtifact(
-      ghcr,
-      'GHCR',
-      revision,
-      expectedBuilderRun,
-      maximumAttempt
-    ),
+      manifests
+    )
+  }
+  return {
+    digest: publication.digest,
+    platforms: REQUIRED_CONTAINER_PLATFORMS,
+    repository,
+    manifests,
     sbom: 'SPDX-2.x',
     provenance: 'SLSA BuildKit',
   }
@@ -366,6 +552,12 @@ function parseArgs(argv) {
     '--ghcr-provenance',
     '--builder-run-id',
     '--maximum-builder-attempt',
+    '--platform-metadata',
+    '--repository',
+    '--inspect',
+    '--index',
+    '--sbom',
+    '--provenance',
     '--version',
     '--revision',
   ])
@@ -384,9 +576,12 @@ function parseArgs(argv) {
 function readArtifact(options, prefix) {
   const artifact = {}
   for (const field of ['inspect', 'index', 'sbom', 'provenance']) {
-    const path = options[`${prefix}-${field}`]
-    if (!path) throw new Error(`--${prefix}-${field} is required`)
-    artifact[field] = JSON.parse(readFileSync(path, 'utf8'))
+    const option = prefix ? `${prefix}-${field}` : field
+    const target = options[option]
+    if (!target) throw new Error(`--${option} is required`)
+    const bytes = readFileSync(target)
+    artifact[field] = JSON.parse(bytes.toString('utf8'))
+    if (field === 'index') artifact.indexBytes = bytes
   }
   return artifact
 }
@@ -400,14 +595,26 @@ function main() {
   if (!options['maximum-builder-attempt']) {
     throw new Error('--maximum-builder-attempt is required')
   }
-  const result = verifyContainerPublication({
+  const common = {
     builderRunId: options['builder-run-id'],
-    dockerHub: readArtifact(options, 'docker-hub'),
-    ghcr: readArtifact(options, 'ghcr'),
     maximumBuilderAttempt: options['maximum-builder-attempt'],
+    platformMetadata: options['platform-metadata']
+      ? JSON.parse(readFileSync(options['platform-metadata'], 'utf8'))
+      : undefined,
     revision: options.revision,
     version: options.version,
-  })
+  }
+  const result = options.repository
+    ? verifyContainerArtifact({
+        ...common,
+        artifact: readArtifact(options, ''),
+        repository: options.repository,
+      })
+    : verifyContainerPublication({
+        ...common,
+        dockerHub: readArtifact(options, 'docker-hub'),
+        ghcr: readArtifact(options, 'ghcr'),
+      })
   process.stdout.write(`${JSON.stringify(result)}\n`)
 }
 

--- a/tests/scripts/container-platform-metadata.test.ts
+++ b/tests/scripts/container-platform-metadata.test.ts
@@ -1,0 +1,330 @@
+import { createHash } from 'node:crypto'
+import { mkdir, mkdtemp, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+// @ts-expect-error -- JavaScript release script intentionally has no declarations
+import {
+  CONTAINER_PLATFORM_MATRIX,
+  createContainerPlatformMetadata,
+  inspectContainerPlatformPublication,
+  verifyContainerPlatformMetadataSet,
+} from '../../scripts/container-platform-metadata.mjs'
+// @ts-expect-error -- JavaScript release script intentionally has no declarations
+import { CONTAINER_LABELS } from '../../scripts/container-release-metadata.mjs'
+
+const VERSION = '2.3.4-beta.5'
+const REVISION = 'a'.repeat(40)
+const BUILDER_RUN_ID =
+  'https://github.com/agalwood/Motrix/actions/runs/31932206203'
+const DIGESTS = {
+  'linux/amd64': `sha256:${'b'.repeat(64)}`,
+  'linux/arm64': `sha256:${'c'.repeat(64)}`,
+} as const
+const IMAGE_DIGESTS = {
+  'linux/amd64': `sha256:${'d'.repeat(64)}`,
+  'linux/arm64': `sha256:${'e'.repeat(64)}`,
+} as const
+const ATTESTATION_DIGESTS = {
+  'linux/amd64': `sha256:${'f'.repeat(64)}`,
+  'linux/arm64': `sha256:${'0'.repeat(64)}`,
+} as const
+
+function metadata(
+  platform: keyof typeof CONTAINER_PLATFORM_MATRIX,
+  overrides: Record<string, unknown> = {}
+) {
+  const matrix = CONTAINER_PLATFORM_MATRIX[platform]
+  return createContainerPlatformMetadata({
+    attestationDigest: ATTESTATION_DIGESTS[platform],
+    builderAttempt: 2,
+    builderRunId: BUILDER_RUN_ID,
+    digest: DIGESTS[platform],
+    imageDigest: IMAGE_DIGESTS[platform],
+    platform,
+    revision: REVISION,
+    runnerArch: matrix.runnerArch,
+    runnerEnvironment: 'github-hosted',
+    runnerOs: 'Linux',
+    version: VERSION,
+    ...overrides,
+  })
+}
+
+async function fixture(
+  entries: Array<{
+    file?: string
+    platform: keyof typeof CONTAINER_PLATFORM_MATRIX
+    value?: unknown
+  }> = [{ platform: 'linux/amd64' }, { platform: 'linux/arm64' }]
+) {
+  const root = await mkdtemp(path.join(tmpdir(), 'motrix-container-metadata-'))
+  for (const entry of entries) {
+    const matrix = CONTAINER_PLATFORM_MATRIX[entry.platform]
+    const directory = path.join(root, matrix.artifact)
+    await mkdir(directory)
+    await writeFile(
+      path.join(directory, entry.file ?? matrix.metadataFile),
+      `${JSON.stringify(entry.value ?? metadata(entry.platform))}\n`
+    )
+  }
+  return root
+}
+
+function verify(directory: string, maximumBuilderAttempt = 3) {
+  return verifyContainerPlatformMetadataSet({
+    builderRunId: BUILDER_RUN_ID,
+    directory,
+    maximumBuilderAttempt,
+    revision: REVISION,
+    version: VERSION,
+  })
+}
+
+function platformPublication(platform: 'linux/amd64' | 'linux/arm64') {
+  const architecture = platform.split('/')[1]
+  const imageDigest = IMAGE_DIGESTS[platform]
+  const attestationDigest = ATTESTATION_DIGESTS[platform]
+  const index = Buffer.from(
+    JSON.stringify({
+      schemaVersion: 2,
+      mediaType: 'application/vnd.oci.image.index.v1+json',
+      manifests: [
+        {
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          digest: imageDigest,
+          size: 1024,
+          platform: { architecture, os: 'linux' },
+        },
+        {
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          digest: attestationDigest,
+          size: 512,
+          annotations: {
+            'vnd.docker.reference.digest': imageDigest,
+            'vnd.docker.reference.type': 'attestation-manifest',
+          },
+          platform: { architecture: 'unknown', os: 'unknown' },
+        },
+      ],
+    })
+  )
+  const digest = `sha256:${createHash('sha256').update(index).digest('hex')}`
+  const inspect = {
+    manifest: { digest },
+    image: {
+      [platform]: {
+        config: {
+          User: 'node',
+          Labels: {
+            ...CONTAINER_LABELS,
+            'org.opencontainers.image.revision': REVISION,
+            'org.opencontainers.image.version': VERSION,
+          },
+        },
+        platform: { architecture, os: 'linux' },
+      },
+    },
+  }
+  return { attestationDigest, digest, imageDigest, index, inspect }
+}
+
+describe('container platform metadata', () => {
+  it('maps every platform to its required native GitHub runner', () => {
+    expect(CONTAINER_PLATFORM_MATRIX).toEqual({
+      'linux/amd64': {
+        artifact: 'container-build-linux-amd64',
+        metadataFile: 'linux-amd64.json',
+        runner: 'ubuntu-22.04',
+        runnerArch: 'X64',
+      },
+      'linux/arm64': {
+        artifact: 'container-build-linux-arm64',
+        metadataFile: 'linux-arm64.json',
+        runner: 'ubuntu-22.04-arm',
+        runnerArch: 'ARM64',
+      },
+    })
+  })
+
+  it('records one cross-registry digest after native anonymous smoke', () => {
+    expect(metadata('linux/arm64')).toMatchObject({
+      schemaVersion: 1,
+      platform: 'linux/arm64',
+      digest: DIGESTS['linux/arm64'],
+      manifests: {
+        image: IMAGE_DIGESTS['linux/arm64'],
+        attestation: ATTESTATION_DIGESTS['linux/arm64'],
+      },
+      version: VERSION,
+      revision: REVISION,
+      builder: {
+        runId: BUILDER_RUN_ID,
+        attempt: 2,
+        runner: 'ubuntu-22.04-arm',
+        runnerArch: 'ARM64',
+        runnerEnvironment: 'github-hosted',
+        runnerOs: 'Linux',
+      },
+      repositories: {
+        'docker.io/motrixapp/motrix-server': DIGESTS['linux/arm64'],
+        'ghcr.io/agalwood/motrix-server': DIGESTS['linux/arm64'],
+      },
+      verification: {
+        anonymousPull: [
+          'docker.io/motrixapp/motrix-server',
+          'ghcr.io/agalwood/motrix-server',
+        ],
+        smoke: 'full',
+      },
+    })
+  })
+
+  it('verifies raw digest, platform, labels, and manifests in both registries', () => {
+    const artifact = platformPublication('linux/arm64')
+    const cliIndex = Buffer.concat([artifact.index, Buffer.from('\n')])
+    expect(
+      inspectContainerPlatformPublication({
+        digest: artifact.digest,
+        dockerHubIndex: cliIndex,
+        dockerHubInspect: artifact.inspect,
+        ghcrIndex: cliIndex,
+        ghcrInspect: artifact.inspect,
+        platform: 'linux/arm64',
+        revision: REVISION,
+        version: VERSION,
+      })
+    ).toEqual({
+      imageDigest: artifact.imageDigest,
+      attestationDigest: artifact.attestationDigest,
+    })
+  })
+
+  it('rejects a platform inspection with a conflicting source revision', () => {
+    const artifact = platformPublication('linux/amd64')
+    const conflicting = structuredClone(artifact.inspect)
+    conflicting.image['linux/amd64'].config.Labels[
+      'org.opencontainers.image.revision'
+    ] = '1'.repeat(40)
+    expect(() =>
+      inspectContainerPlatformPublication({
+        digest: artifact.digest,
+        dockerHubIndex: artifact.index,
+        dockerHubInspect: artifact.inspect,
+        ghcrIndex: artifact.index,
+        ghcrInspect: conflicting,
+        platform: 'linux/amd64',
+        revision: REVISION,
+        version: VERSION,
+      })
+    ).toThrow(/label .* conflicts/)
+  })
+
+  it.each([
+    ['emulated arm64', 'linux/arm64', { runnerArch: 'X64' }, /requires native/],
+    [
+      'self-hosted runner',
+      'linux/amd64',
+      { runnerEnvironment: 'self-hosted' },
+      /GitHub-hosted/,
+    ],
+    ['non-Linux runner', 'linux/amd64', { runnerOs: 'Windows' }, /Linux/],
+  ] as const)('rejects %s metadata', (_, platform, overrides, error) => {
+    expect(() => metadata(platform, overrides)).toThrow(error)
+  })
+
+  it('accepts exactly one verified record for each required platform', async () => {
+    await expect(verify(await fixture())).resolves.toEqual({
+      schemaVersion: 1,
+      version: VERSION,
+      revision: REVISION,
+      builderRunId: BUILDER_RUN_ID,
+      maximumBuilderAttempt: 3,
+      platforms: {
+        'linux/amd64': {
+          digest: DIGESTS['linux/amd64'],
+          manifests: {
+            image: IMAGE_DIGESTS['linux/amd64'],
+            attestation: ATTESTATION_DIGESTS['linux/amd64'],
+          },
+        },
+        'linux/arm64': {
+          digest: DIGESTS['linux/arm64'],
+          manifests: {
+            image: IMAGE_DIGESTS['linux/arm64'],
+            attestation: ATTESTATION_DIGESTS['linux/arm64'],
+          },
+        },
+      },
+    })
+  })
+
+  it.each([
+    [
+      'missing architecture',
+      [{ platform: 'linux/amd64' }] as Parameters<typeof fixture>[0],
+      /exactly 2 files/,
+    ],
+    [
+      'duplicate architecture',
+      [
+        { platform: 'linux/amd64' },
+        {
+          file: 'linux-arm64.json',
+          platform: 'linux/arm64',
+          value: metadata('linux/amd64'),
+        },
+      ] as Parameters<typeof fixture>[0],
+      /metadata file must be|duplicate/,
+    ],
+    [
+      'wrong architecture filename',
+      [
+        { platform: 'linux/amd64' },
+        { file: 'wrong.json', platform: 'linux/arm64' },
+      ] as Parameters<typeof fixture>[0],
+      /metadata file must be/,
+    ],
+    [
+      'wrong revision',
+      [
+        { platform: 'linux/amd64' },
+        {
+          platform: 'linux/arm64',
+          value: metadata('linux/arm64', { revision: 'd'.repeat(40) }),
+        },
+      ] as Parameters<typeof fixture>[0],
+      /version or revision conflicts/,
+    ],
+  ])('fails closed for a %s', async (_, entries, error) => {
+    await expect(verify(await fixture(entries))).rejects.toThrow(error)
+  })
+
+  it('rejects a future build attempt', async () => {
+    await expect(verify(await fixture(), 1)).rejects.toThrow(/future/)
+  })
+
+  it('rejects identical digests for different architectures', async () => {
+    const root = await fixture([
+      { platform: 'linux/amd64' },
+      {
+        platform: 'linux/arm64',
+        value: metadata('linux/arm64', { digest: DIGESTS['linux/amd64'] }),
+      },
+    ])
+    await expect(verify(root)).rejects.toThrow(/must not share/)
+  })
+
+  it('rejects symbolic-link metadata inputs', async () => {
+    const root = await fixture([{ platform: 'linux/amd64' }])
+    await symlink(
+      path.join(
+        root,
+        CONTAINER_PLATFORM_MATRIX['linux/amd64'].artifact,
+        CONTAINER_PLATFORM_MATRIX['linux/amd64'].metadataFile
+      ),
+      path.join(root, 'linux-arm64.json')
+    )
+    await expect(verify(root)).rejects.toThrow(/symbolic link/)
+  })
+})

--- a/tests/scripts/release-version-contract.test.ts
+++ b/tests/scripts/release-version-contract.test.ts
@@ -280,8 +280,12 @@ describe('release version contract', () => {
   it('records beta.9 as an unpublished finalization attempt', () => {
     const english = read('docs/release-notes/2.0.0-beta.9.md')
     const chinese = read('docs/release-notes/2.0.0-beta.9.zh-CN.md')
-    const normalizedEnglish = english.replace(/\s+/g, ' ')
-    const normalizedChinese = chinese.replace(/\s+/g, ' ')
+    const normalizedEnglish = english
+      .replace(/^>\s?/gm, '')
+      .replace(/\s+/g, ' ')
+    const normalizedChinese = chinese
+      .replace(/^>\s?/gm, '')
+      .replace(/\s+/g, ' ')
     const metainfo = read('flatpak/app.motrix.native.metainfo.xml')
     const beta9Metainfo =
       /<release version="2\.0\.0-beta\.9"[\s\S]*?<\/release>/.exec(
@@ -354,8 +358,12 @@ describe('release version contract', () => {
   it('records beta.10 as an unpublished assembly attempt', () => {
     const english = read('docs/release-notes/2.0.0-beta.10.md')
     const chinese = read('docs/release-notes/2.0.0-beta.10.zh-CN.md')
-    const normalizedEnglish = english.replace(/\s+/g, ' ')
-    const normalizedChinese = chinese.replace(/\s+/g, ' ')
+    const normalizedEnglish = english
+      .replace(/^>\s?/gm, '')
+      .replace(/\s+/g, ' ')
+    const normalizedChinese = chinese
+      .replace(/^>\s?/gm, '')
+      .replace(/\s+/g, ' ')
     const metainfo = read('flatpak/app.motrix.native.metainfo.xml')
     const beta10Metainfo =
       /<release version="2\.0\.0-beta\.10"[\s\S]*?<\/release>/.exec(
@@ -583,11 +591,92 @@ describe('release version contract', () => {
     expect(beta12Metainfo).not.toMatch(secretLikeIdentifier)
   })
 
-  it('preserves beta.13 container verification recovery and distribution limits', () => {
+  it('ships beta.14 native container recovery without cross-channel atomicity claims', () => {
+    const english = read('docs/release-notes/2.0.0-beta.14.md')
+    const chinese = read('docs/release-notes/2.0.0-beta.14.zh-CN.md')
+    const normalizedEnglish = english
+      .replace(/^>\s?/gm, '')
+      .replace(/\s+/g, ' ')
+    const normalizedChinese = chinese
+      .replace(/^>\s?/gm, '')
+      .replace(/\s+/g, ' ')
+    const metainfo = read('flatpak/app.motrix.native.metainfo.xml')
+    const beta14Metainfo =
+      /<release version="2\.0\.0-beta\.14"[\s\S]*?<\/release>/.exec(
+        metainfo
+      )?.[0] ?? ''
+    const normalizedBeta14Metainfo = beta14Metainfo.replace(/\s+/g, ' ')
+
+    expect(normalizedEnglish).toContain(
+      'Builds `linux/amd64` on `ubuntu-22.04` and `linux/arm64` on `ubuntu-22.04-arm`'
+    )
+    expect(normalizedEnglish).toContain(
+      'The container release path no longer installs or invokes QEMU'
+    )
+    expect(normalizedEnglish).toContain(
+      'A single architecture never receives the public version tag and cannot become the official release on its own'
+    )
+    expect(normalizedEnglish).toContain(
+      'Anonymously pulls the exact staged digest from both registries and runs the full Server runtime smoke on its native runner'
+    )
+    expect(normalizedEnglish).toContain(
+      'rejects missing, duplicate, unexpected, cross-wired, or future-attempt records'
+    )
+    expect(normalizedEnglish).toContain(
+      'a rerun resumes an identical complete result or repairs one missing registry'
+    )
+    expect(normalizedEnglish).toContain(
+      'Stable floating aliases are handled by a final recovery-safe job only after every build, index, signature, provenance, SBOM, anonymous pull, and runtime gate succeeds'
+    )
+    expect(normalizedEnglish).toContain(
+      'does not claim cross-channel atomicity'
+    )
+    expect(normalizedChinese).toContain(
+      '`linux/amd64` 固定在 `ubuntu-22.04` 构建，`linux/arm64` 固定在 `ubuntu-22.04-arm` 构建'
+    )
+    expect(normalizedChinese).toContain('容器发布路径不再安装或调用 QEMU')
+    expect(normalizedChinese).toContain(
+      '单一架构不会获得公开版本 tag，因此不能独立成为正式发布版本'
+    )
+    expect(normalizedChinese).toContain(
+      '只有全部构建、index、签名、provenance、SBOM、匿名拉取和 runtime 门禁通过后'
+    )
+    expect(normalizedChinese).toContain('本版本不宣称跨渠道原子性')
+    for (const source of [english, chinese]) {
+      expect(source).toContain('Snap')
+      expect(source).toContain('latest/edge')
+      expect(source).toContain('AppImage')
+      expect(source).toContain('Flatpak')
+      expect(source).toContain(
+        'Motrix-Native-Host-2.0.0-beta.14-linux-<arch>.tar.gz'
+      )
+      expect(source).toContain('SmartScreen')
+      expect(source).toContain(
+        'docker.io/motrixapp/motrix-server:2.0.0-beta.14'
+      )
+      expect(source).toContain('ghcr.io/agalwood/motrix-server:2.0.0-beta.14')
+      expect(source).not.toMatch(restrictedPublicLanguage)
+      expect(source).not.toMatch(secretLikeIdentifier)
+    }
+    expect(normalizedBeta14Metainfo).toContain(
+      'builds amd64 and arm64 independently on native GitHub-hosted runners without QEMU'
+    )
+    expect(normalizedBeta14Metainfo).toContain(
+      'Stable aliases advance only after final native public smoke tests'
+    )
+    expect(beta14Metainfo).not.toMatch(restrictedPublicLanguage)
+    expect(beta14Metainfo).not.toMatch(secretLikeIdentifier)
+  })
+
+  it('records beta.13 desktop/feed success and incomplete container publication', () => {
     const english = read('docs/release-notes/2.0.0-beta.13.md')
     const chinese = read('docs/release-notes/2.0.0-beta.13.zh-CN.md')
-    const normalizedEnglish = english.replace(/\s+/g, ' ')
-    const normalizedChinese = chinese.replace(/\s+/g, ' ')
+    const normalizedEnglish = english
+      .replace(/^>\s?/gm, '')
+      .replace(/\s+/g, ' ')
+    const normalizedChinese = chinese
+      .replace(/^>\s?/gm, '')
+      .replace(/\s+/g, ' ')
     const metainfo = read('flatpak/app.motrix.native.metainfo.xml')
     const beta13Metainfo =
       /<release version="2\.0\.0-beta\.13"[\s\S]*?<\/release>/.exec(
@@ -596,45 +685,59 @@ describe('release version contract', () => {
     const normalizedBeta13Metainfo = beta13Metainfo.replace(/\s+/g, ' ')
 
     expect(normalizedEnglish).toContain(
-      'Retries anonymous signature verification for up to 18 attempts with a 10-second delay'
+      'Motrix 2.0.0-beta.13 was partially distributed'
     )
     expect(normalizedEnglish).toContain(
-      'still failing closed if either registry never exposes a valid signature'
+      'all five desktop builds, all three Finalize jobs, assembly, the GitHub prerelease, and the R2 update feed completed successfully'
     )
     expect(normalizedEnglish).toContain(
-      'Verifies BuildKit provenance against the exact current repository workflow run'
+      'At 57.27 seconds in the ARM `pnpm install` layer, QEMU exited with target signal 4'
+    )
+    expect(normalizedEnglish).toContain('canceled about 33 minutes later')
+    expect(normalizedEnglish).toContain(
+      'neither immutable beta.13 tag was published, no final index was signed'
     )
     expect(normalizedEnglish).toContain(
-      'The builder attempt must be a positive integer no greater than the current run attempt'
+      'this result must not be described as atomic across distribution channels'
     )
     expect(normalizedEnglish).toContain(
-      'without accepting another repository, workflow run, future attempt, or path suffix'
-    )
-    expect(normalizedEnglish).toContain(
-      'Existing beta.12 release assets and container tags are never overwritten or reused; mutable beta update feeds advance only after beta.13 versioned assets publish'
+      'The `v2.0.0-beta.13` tag remains immutable and is not moved or reused'
     )
     expect(normalizedChinese).toContain(
-      '匿名签名验证最多执行 18 次，每次间隔 10 秒'
+      'Motrix 2.0.0-beta.13 完成了部分渠道分发'
     )
     expect(normalizedChinese).toContain(
-      '根据当前仓库的精确 workflow run 验证 BuildKit provenance'
+      '5 个桌面构建、3 个 Finalize job、assemble、GitHub 预发布版以及 R2 更新数据源 均成功完成'
     )
     expect(normalizedChinese).toContain(
-      '拒绝其他 仓库、其他 workflow run、未来 attempt 或附加路径后缀'
+      'ARM `pnpm install` 层运行到 57.27 秒时，QEMU 因目标 signal 4'
+    )
+    expect(normalizedChinese).toContain('约 33 分钟后容器 job 被取消')
+    expect(normalizedChinese).toContain(
+      '不能把该结果描述为跨分发渠道的原子发布'
     )
     for (const source of [english, chinese]) {
-      expect(source).toContain('Snap')
-      expect(source).toContain('latest/edge')
-      expect(source).toContain('AppImage')
-      expect(source).toContain('Flatpak')
-      expect(source).toContain(
+      const normalizedSource = source
+        .replace(/^>\s?/gm, '')
+        .replace(/\s+/g, ' ')
+      expect(normalizedSource).toContain('v2.0.0-beta.14')
+      expect(normalizedSource).toContain('31932206203')
+      expect(normalizedSource).toContain('QEMU')
+      expect(normalizedSource).toContain('Illegal instruction')
+      expect(normalizedSource).toContain('Snap')
+      expect(normalizedSource).toContain('latest/edge')
+      expect(normalizedSource).toContain('AppImage')
+      expect(normalizedSource).toContain('Flatpak')
+      expect(normalizedSource).toContain(
         'Motrix-Native-Host-2.0.0-beta.13-linux-<arch>.tar.gz'
       )
-      expect(source).toContain('SmartScreen')
-      expect(source).toContain(
+      expect(normalizedSource).toContain('SmartScreen')
+      expect(normalizedSource).toContain(
         'docker.io/motrixapp/motrix-server:2.0.0-beta.13'
       )
-      expect(source).toContain('ghcr.io/agalwood/motrix-server:2.0.0-beta.13')
+      expect(normalizedSource).toContain(
+        'ghcr.io/agalwood/motrix-server:2.0.0-beta.13'
+      )
       expect(source).not.toMatch(restrictedPublicLanguage)
       expect(source).not.toMatch(secretLikeIdentifier)
     }
@@ -642,13 +745,13 @@ describe('release version contract', () => {
       '<release version="2.0.0-beta.13" date="2026-08-16">'
     )
     expect(normalizedBeta13Metainfo).toContain(
-      'waits for registry signature visibility with a bounded fail-closed retry'
+      'All desktop builds, Finalize jobs, assembly, the GitHub prerelease, and the R2 update feed completed'
     )
     expect(normalizedBeta13Metainfo).toContain(
-      'the exact repository workflow run and a valid current-or-earlier attempt'
+      'no beta.13 container tag, signature, public artifact verification, or runtime smoke completed'
     )
     expect(normalizedBeta13Metainfo).toContain(
-      'Windows packages remain unsigned'
+      'Windows packages were published unsigned'
     )
     expect(beta13Metainfo).not.toMatch(restrictedPublicLanguage)
     expect(beta13Metainfo).not.toMatch(secretLikeIdentifier)

--- a/tests/scripts/verify-container-publication.test.ts
+++ b/tests/scripts/verify-container-publication.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { describe, expect, it } from 'vitest'
 // @ts-expect-error -- JavaScript release script intentionally has no declarations
 import {
@@ -5,7 +6,10 @@ import {
   CONTAINER_REPOSITORIES,
 } from '../../scripts/container-release-metadata.mjs'
 // @ts-expect-error -- JavaScript release script intentionally has no declarations
-import { verifyContainerPublication } from '../../scripts/verify-container-publication.mjs'
+import {
+  verifyContainerArtifact,
+  verifyContainerPublication,
+} from '../../scripts/verify-container-publication.mjs'
 
 const VERSION = '2.3.4'
 const REVISION = 'a'.repeat(40)
@@ -37,7 +41,11 @@ function inspect() {
   }
 }
 
-function index(options?: { omitArmAttestation?: boolean }) {
+function index(options?: {
+  amd64Digest?: string
+  omitArmAttestation?: boolean
+  unexpectedPlatform?: boolean
+}) {
   const manifest = (architecture: string, digest: string) => ({
     mediaType: 'application/vnd.oci.image.manifest.v1+json',
     digest,
@@ -58,12 +66,18 @@ function index(options?: { omitArmAttestation?: boolean }) {
     schemaVersion: 2,
     mediaType: 'application/vnd.oci.image.index.v1+json',
     manifests: [
-      manifest('amd64', AMD64_DIGEST),
-      attestation(AMD64_DIGEST, `sha256:${'e'.repeat(64)}`),
+      manifest('amd64', options?.amd64Digest ?? AMD64_DIGEST),
+      attestation(
+        options?.amd64Digest ?? AMD64_DIGEST,
+        `sha256:${'e'.repeat(64)}`
+      ),
       manifest('arm64', ARM64_DIGEST),
       ...(options?.omitArmAttestation
         ? []
         : [attestation(ARM64_DIGEST, `sha256:${'f'.repeat(64)}`)]),
+      ...(options?.unexpectedPlatform
+        ? [manifest('s390x', `sha256:${'1'.repeat(64)}`)]
+        : []),
     ],
   }
 }
@@ -157,6 +171,7 @@ function verify(
     dockerHub?: ReturnType<typeof artifact>
     ghcr?: ReturnType<typeof artifact>
     maximumBuilderAttempt?: number
+    platformMetadata?: Record<string, unknown>
   } = {}
 ) {
   return verifyContainerPublication({
@@ -165,6 +180,7 @@ function verify(
     ghcr: overrides.ghcr ?? artifact(),
     maximumBuilderAttempt:
       overrides.maximumBuilderAttempt ?? MAXIMUM_BUILDER_ATTEMPT,
+    platformMetadata: overrides.platformMetadata,
     revision: REVISION,
     version: VERSION,
   })
@@ -196,6 +212,77 @@ describe('container publication verifier', () => {
         ghcr: current,
       }).provenance
     ).toBe('SLSA BuildKit')
+  })
+
+  it('verifies a recovery source before it is copied to the missing registry', () => {
+    const rawIndex = Buffer.from(JSON.stringify(index()))
+    const rawDigest = `sha256:${createHash('sha256').update(rawIndex).digest('hex')}`
+    const source = artifact({
+      indexBytes: rawIndex,
+      inspect: {
+        ...inspect(),
+        manifest: { digest: rawDigest },
+      },
+    })
+    expect(
+      verifyContainerArtifact({
+        artifact: source,
+        builderRunId: BUILDER_RUN_ID,
+        maximumBuilderAttempt: MAXIMUM_BUILDER_ATTEMPT,
+        repository: CONTAINER_REPOSITORIES.dockerHub,
+        revision: REVISION,
+        version: VERSION,
+      }).digest
+    ).toBe(rawDigest)
+  })
+
+  it('rejects recovery when raw index bytes do not match the immutable digest', () => {
+    const rawIndex = Buffer.from(JSON.stringify(index()))
+    const rawDigest = `sha256:${createHash('sha256').update(rawIndex).digest('hex')}`
+    expect(() =>
+      verifyContainerArtifact({
+        artifact: artifact({
+          indexBytes: Buffer.concat([rawIndex, Buffer.from(' ')]),
+          inspect: {
+            ...inspect(),
+            manifest: { digest: rawDigest },
+          },
+        }),
+        builderRunId: BUILDER_RUN_ID,
+        maximumBuilderAttempt: MAXIMUM_BUILDER_ATTEMPT,
+        repository: CONTAINER_REPOSITORIES.ghcr,
+        revision: REVISION,
+        version: VERSION,
+      })
+    ).toThrow(/raw index digest conflicts/)
+  })
+
+  it('binds the final index to both native platform build records', () => {
+    expect(
+      verify({
+        platformMetadata: {
+          schemaVersion: 1,
+          version: VERSION,
+          revision: REVISION,
+          platforms: {
+            'linux/amd64': {
+              digest: `sha256:${'2'.repeat(64)}`,
+              manifests: {
+                image: AMD64_DIGEST,
+                attestation: `sha256:${'e'.repeat(64)}`,
+              },
+            },
+            'linux/arm64': {
+              digest: `sha256:${'3'.repeat(64)}`,
+              manifests: {
+                image: ARM64_DIGEST,
+                attestation: `sha256:${'f'.repeat(64)}`,
+              },
+            },
+          },
+        },
+      }).digest
+    ).toBe(INDEX_DIGEST)
   })
 
   it.each([
@@ -257,6 +344,11 @@ describe('container publication verifier', () => {
       }),
       /incomplete at materials/,
     ],
+    [
+      'unexpected architecture',
+      artifact({ index: index({ unexpectedPlatform: true }) }),
+      /unexpected image platform/,
+    ],
   ])('rejects %s', (_, dockerHub, error) => {
     expect(() => verify({ dockerHub })).toThrow(error)
   })
@@ -267,6 +359,41 @@ describe('container publication verifier', () => {
     expect(() => verify({ ghcr: artifact({ inspect: ghcrInspect }) })).toThrow(
       /Immutable container tags disagree/
     )
+  })
+
+  it('rejects cross-registry platform manifest divergence', () => {
+    const divergent = artifact({
+      index: index({ amd64Digest: `sha256:${'4'.repeat(64)}` }),
+    })
+    expect(() => verify({ ghcr: divergent })).toThrow(/disagree across/)
+  })
+
+  it('rejects a final manifest that differs from native build metadata', () => {
+    expect(() =>
+      verify({
+        platformMetadata: {
+          schemaVersion: 1,
+          version: VERSION,
+          revision: REVISION,
+          platforms: {
+            'linux/amd64': {
+              digest: `sha256:${'2'.repeat(64)}`,
+              manifests: {
+                image: `sha256:${'5'.repeat(64)}`,
+                attestation: `sha256:${'e'.repeat(64)}`,
+              },
+            },
+            'linux/arm64': {
+              digest: `sha256:${'3'.repeat(64)}`,
+              manifests: {
+                image: ARM64_DIGEST,
+                attestation: `sha256:${'f'.repeat(64)}`,
+              },
+            },
+          },
+        },
+      })
+    ).toThrow(/published image digest conflicts/)
   })
 
   it('keeps the expected public registry coordinates in the verified labels', () => {

--- a/tests/scripts/workflow-release-matrix.test.ts
+++ b/tests/scripts/workflow-release-matrix.test.ts
@@ -778,80 +778,260 @@ describe('release workflow publication contract', () => {
     )
   })
 
-  it('publishes resumable signed multi-architecture containers only from release tags', () => {
+  it('fans native container builds into one fail-closed signed index and promotes aliases last', () => {
     const jobs = workflowJobs(releaseWorkflow)
-    const containerJob = asRecord(
+    const plan = asRecord(
+      jobs['plan-container-publication'],
+      'container publication plan job'
+    )
+    const platformBuild = asRecord(
+      jobs['build-container-platform'],
+      'container platform build job'
+    )
+    const finalize = asRecord(
       jobs['publish-container'],
       'publish-container job'
     )
-    expect(jobNeeds(containerJob)).toEqual(
+    const runtime = asRecord(
+      jobs['verify-container-runtime'],
+      'container runtime job'
+    )
+    const promote = asRecord(
+      jobs['promote-container-aliases'],
+      'container alias promotion job'
+    )
+
+    expect(jobNeeds(plan)).toEqual(
       expect.arrayContaining(['preflight', 'publish'])
     )
-    const condition = stringField(containerJob, 'if')
-    expect(condition).toContain("github.event_name == 'push'")
-    expect(condition).toContain("startsWith(github.ref, 'refs/tags/v')")
-    expect(stringField(containerJob, 'environment')).toBe('container-release')
-    expect(asRecord(containerJob.permissions, 'container permissions')).toEqual(
-      {
-        contents: 'read',
-        'id-token': 'write',
-        packages: 'write',
-      }
+    expect(jobNeeds(platformBuild)).toEqual(
+      expect.arrayContaining([
+        'preflight',
+        'publish',
+        'plan-container-publication',
+      ])
+    )
+    expect(jobNeeds(finalize)).toEqual(
+      expect.arrayContaining([
+        'preflight',
+        'publish',
+        'plan-container-publication',
+        'build-container-platform',
+      ])
+    )
+    expect(jobNeeds(runtime)).toEqual(
+      expect.arrayContaining(['preflight', 'publish-container'])
+    )
+    expect(jobNeeds(promote)).toEqual(
+      expect.arrayContaining([
+        'preflight',
+        'publish-container',
+        'verify-container-runtime',
+      ])
     )
 
-    const steps = jobSteps(containerJob)
-    const stepIndex = (name: string) =>
-      steps.findIndex((step) => step.name === name)
-    const build =
-      steps[stepIndex('Build and stage immutable multi-architecture image')]
-    expect(build).toBeDefined()
-    const buildInputs = asRecord(build?.with, 'container build inputs')
-    expect(stringField(buildInputs, 'platforms')).toBe(
-      'linux/amd64,linux/arm64'
+    expect(stringField(platformBuild, 'if')).toContain(
+      "needs.plan-container-publication.outputs.action == 'build'"
     )
-    expect(buildInputs.push).toBe(true)
+    const finalCondition = stringField(finalize, 'if')
+    expect(finalCondition).toContain('always()')
+    expect(finalCondition).toContain(
+      "needs.plan-container-publication.outputs.action == 'build'"
+    )
+    expect(finalCondition).toContain(
+      "needs.build-container-platform.result == 'success'"
+    )
+    expect(finalCondition).toContain(
+      "needs.build-container-platform.result == 'skipped'"
+    )
+    for (const job of [plan, finalize, runtime]) {
+      const condition = stringField(job, 'if', finalCondition)
+      expect(condition).toContain("github.event_name == 'push'")
+      expect(condition).toContain("startsWith(github.ref, 'refs/tags/v')")
+    }
+
+    const matrix = asRecord(
+      asRecord(platformBuild.strategy, 'platform build strategy').matrix,
+      'platform build matrix'
+    )
+    expect(matrix.include).toEqual([
+      {
+        platform: 'linux/amd64',
+        os: 'ubuntu-22.04',
+        runner_arch: 'X64',
+        artifact: 'container-build-linux-amd64',
+        metadata_file: 'linux-amd64.json',
+      },
+      {
+        platform: 'linux/arm64',
+        os: 'ubuntu-22.04-arm',
+        runner_arch: 'ARM64',
+        artifact: 'container-build-linux-arm64',
+        metadata_file: 'linux-arm64.json',
+      },
+    ])
+    expect(stringField(platformBuild, 'runs-on')).toBe(`\${{ matrix.os }}`)
+    expect(stringField(platformBuild, 'environment')).toBe('container-release')
+    expect(
+      asRecord(platformBuild.permissions, 'platform build permissions')
+    ).toEqual({
+      contents: 'read',
+      packages: 'write',
+    })
+    expect(asRecord(finalize.permissions, 'finalize permissions')).toEqual({
+      contents: 'read',
+      'id-token': 'write',
+      packages: 'write',
+    })
+    expect(asRecord(runtime.permissions, 'runtime permissions')).toEqual({
+      contents: 'read',
+    })
+
+    const buildSteps = jobSteps(platformBuild)
+    const buildStepIndex = (name: string) =>
+      buildSteps.findIndex((step) => step.name === name)
+    const build =
+      buildSteps[buildStepIndex('Build and push native platform digest')]
+    const buildInputs = asRecord(build?.with, 'native container build inputs')
+    expect(stringField(buildInputs, 'platforms')).toBe(
+      `\${{ matrix.platform }}`
+    )
+    expect(stringField(buildInputs, 'outputs')).toContain('push-by-digest=true')
+    expect(stringField(buildInputs, 'outputs')).toContain('name-canonical=true')
+    expect(stringField(buildInputs, 'outputs')).toContain('oci-artifact=true')
+    expect(stringField(buildInputs, 'outputs')).toContain('push=true')
+    expect(buildInputs).not.toHaveProperty('tags')
     expect(buildInputs.sbom).toBe(true)
     expect(stringField(buildInputs, 'provenance')).toBe('mode=max')
-    expect(stringField(buildInputs, 'cache-from')).toContain('type=gha')
+    expect(stringField(buildInputs, 'cache-from')).toContain(
+      'matrix.runner_arch'
+    )
     expect(stringField(buildInputs, 'cache-to')).toContain('mode=max')
-
-    const qemu = steps.find((step) => step.name === 'Set up pinned QEMU')
-    expect(stringField(asRecord(qemu?.with, 'QEMU inputs'), 'image')).toMatch(
-      /^tonistiigi\/binfmt@sha256:[0-9a-f]{64}$/
-    )
-    expect(stringField(asRecord(qemu?.with, 'QEMU inputs'), 'platforms')).toBe(
-      'arm64'
-    )
-
-    const inspectCommand = stringField(
-      steps[stepIndex('Inspect existing immutable tags')] as LooseRecord,
-      'run'
-    )
-    expect(inspectCommand).not.toContain('pull access denied')
-    expect(stepIndex('Resolve immutable publication state')).toBeLessThan(
-      stepIndex('Build and stage immutable multi-architecture image')
-    )
-    expect(stepIndex('Verify immutable publication state')).toBeLessThan(
-      stepIndex('Sign immutable digests with GitHub OIDC')
-    )
-    expect(stepIndex('Sign immutable digests with GitHub OIDC')).toBeLessThan(
-      stepIndex('Prepare anonymous registry client')
-    )
-    expect(stepIndex('Verify immutable signatures')).toBeLessThan(
-      stepIndex('Verify anonymous multi-architecture artifacts')
+    expect(
+      buildStepIndex('Require native GitHub-hosted Linux runner')
+    ).toBeLessThan(buildStepIndex('Build and push native platform digest'))
+    expect(buildStepIndex('Inspect staged platform digests')).toBeLessThan(
+      buildStepIndex('Smoke anonymous staged platform digests')
     )
     expect(
-      stepIndex('Verify anonymous multi-architecture artifacts')
-    ).toBeLessThan(stepIndex('Smoke anonymous published architectures'))
-    expect(stepIndex('Smoke anonymous published architectures')).toBeLessThan(
-      stepIndex('Promote stable container aliases')
+      buildStepIndex('Smoke anonymous staged platform digests')
+    ).toBeLessThan(buildStepIndex('Write immutable platform build metadata'))
+    expect(
+      buildStepIndex('Write immutable platform build metadata')
+    ).toBeLessThan(buildStepIndex('Upload immutable platform build metadata'))
+    const runnerCommand = stringField(
+      buildSteps[
+        buildStepIndex('Require native GitHub-hosted Linux runner')
+      ] as LooseRecord,
+      'run'
     )
-    expect(stepIndex('Promote stable container aliases')).toBeLessThan(
-      stepIndex('Update Docker Hub description')
+    expect(runnerCommand).toContain("'github-hosted'")
+    expect(runnerCommand).toContain('EXPECTED_RUNNER_ARCH')
+    const stagedSmoke = stringField(
+      buildSteps[
+        buildStepIndex('Smoke anonymous staged platform digests')
+      ] as LooseRecord,
+      'run'
     )
+    expect(stagedSmoke).toContain('smoke-server-image.mjs')
+    expect(stagedSmoke).toContain('"$DOCKERHUB_REPOSITORY" "$GHCR_REPOSITORY"')
+    expect(stagedSmoke).not.toContain('--mode health')
+    const metadataCommand = stringField(
+      buildSteps[
+        buildStepIndex('Write immutable platform build metadata')
+      ] as LooseRecord,
+      'run'
+    )
+    expect(metadataCommand).toContain('container-platform-metadata.mjs create')
+    expect(metadataCommand).toContain('--runner-arch')
+    expect(metadataCommand).toContain('--docker-hub-index')
+    expect(metadataCommand).toContain('--ghcr-index')
+    const metadataUpload = buildSteps[
+      buildStepIndex('Upload immutable platform build metadata')
+    ] as LooseRecord
+    expect(
+      asRecord(metadataUpload.with, 'metadata upload inputs').overwrite
+    ).toBe(true)
 
-    const signatureVerification = steps[
-      stepIndex('Verify immutable signatures')
+    const finalSteps = jobSteps(finalize)
+    const finalStepIndex = (name: string) =>
+      finalSteps.findIndex((step) => step.name === name)
+    const metadataDownloads = finalSteps
+      .filter((step) =>
+        stringField(step, 'uses', '').startsWith('actions/download-artifact@')
+      )
+      .map((step) =>
+        stringField(asRecord(step.with, 'metadata download inputs'), 'name')
+      )
+    expect(metadataDownloads).toEqual([
+      'container-build-linux-amd64',
+      'container-build-linux-arm64',
+    ])
+    for (const step of finalSteps.filter((step) =>
+      stringField(step, 'uses', '').startsWith('actions/download-artifact@')
+    )) {
+      expect(step.if).toBeUndefined()
+    }
+    expect(finalStepIndex('Verify complete platform build set')).toBeLessThan(
+      finalStepIndex('Revalidate immutable tags before finalization')
+    )
+    expect(finalStepIndex('Resolve finalization state')).toBeLessThan(
+      finalStepIndex('Create immutable multi-platform indexes')
+    )
+    expect(
+      finalStepIndex('Create immutable multi-platform indexes')
+    ).toBeLessThan(finalStepIndex('Verify immutable publication state'))
+    expect(
+      finalStepIndex('Verify partial immutable source before repair')
+    ).toBeLessThan(finalStepIndex('Repair partial immutable publication'))
+    expect(finalStepIndex('Repair partial immutable publication')).toBeLessThan(
+      finalStepIndex('Verify immutable publication state')
+    )
+    expect(finalStepIndex('Verify immutable publication state')).toBeLessThan(
+      finalStepIndex(
+        'Verify anonymous multi-platform index artifacts before signing'
+      )
+    )
+    expect(
+      finalStepIndex(
+        'Verify anonymous multi-platform index artifacts before signing'
+      )
+    ).toBeLessThan(finalStepIndex('Sign immutable digests with GitHub OIDC'))
+    expect(
+      finalStepIndex('Sign immutable digests with GitHub OIDC')
+    ).toBeLessThan(finalStepIndex('Verify immutable signatures'))
+    const setCommand = stringField(
+      finalSteps[
+        finalStepIndex('Verify complete platform build set')
+      ] as LooseRecord,
+      'run'
+    )
+    expect(setCommand).toContain('container-platform-metadata.mjs verify-set')
+    expect(setCommand).toContain('--builder-attempt "$GITHUB_RUN_ATTEMPT"')
+    const createCommand = stringField(
+      finalSteps[
+        finalStepIndex('Create immutable multi-platform indexes')
+      ] as LooseRecord,
+      'run'
+    )
+    expect(createCommand).toContain('AMD64_DIGEST')
+    expect(createCommand).toContain('ARM64_DIGEST')
+    expect(createCommand).toContain('imagetools create')
+    const repairVerification = stringField(
+      finalSteps[
+        finalStepIndex('Verify partial immutable source before repair')
+      ] as LooseRecord,
+      'run'
+    )
+    expect(repairVerification).toContain('--repository "$source_repository"')
+    expect(repairVerification).toContain(
+      '--platform-metadata "$VERIFIED_METADATA"'
+    )
+    expect(repairVerification).toContain("--format '{{json .SBOM}}'")
+    expect(repairVerification).toContain("--format '{{json .Provenance}}'")
+
+    const signatureVerification = finalSteps[
+      finalStepIndex('Verify immutable signatures')
     ] as LooseRecord
     const signatureEnvironment = asRecord(
       signatureVerification.env,
@@ -876,8 +1056,10 @@ describe('release workflow publication contract', () => {
     expect(signatureCommand).toContain('sleep "$retry_delay_seconds"')
     expect(signatureCommand).not.toContain('|| true')
 
-    const publicVerification = steps[
-      stepIndex('Verify anonymous multi-architecture artifacts')
+    const publicVerification = finalSteps[
+      finalStepIndex(
+        'Verify anonymous multi-platform index artifacts before signing'
+      )
     ] as LooseRecord
     const publicEnvironment = asRecord(
       publicVerification.env,
@@ -896,27 +1078,62 @@ describe('release workflow publication contract', () => {
     expect(publicCommand).toContain("--format '{{json .SBOM}}'")
     expect(publicCommand).toContain("--format '{{json .Provenance}}'")
     expect(publicCommand).toContain('verify-container-publication.mjs')
+    expect(publicCommand).toContain('--platform-metadata "$VERIFIED_METADATA"')
     expect(publicCommand).toContain('--builder-run-id "$EXPECTED_BUILDER_RUN"')
-    expect(publicCommand).toContain(
-      '--maximum-builder-attempt "$MAXIMUM_BUILDER_ATTEMPT"'
-    )
     expect(publicCommand).not.toContain('--builder-id-prefix')
-    const smokeCommand = stringField(
-      steps[
-        stepIndex('Smoke anonymous published architectures')
-      ] as LooseRecord,
+
+    const runtimeMatrix = asRecord(
+      asRecord(runtime.strategy, 'runtime strategy').matrix,
+      'runtime matrix'
+    )
+    expect(runtimeMatrix.include).toEqual([
+      { platform: 'linux/amd64', os: 'ubuntu-22.04', runner_arch: 'X64' },
+      { platform: 'linux/arm64', os: 'ubuntu-22.04-arm', runner_arch: 'ARM64' },
+    ])
+    const runtimeSteps = jobSteps(runtime)
+    const publicSmoke = stringField(
+      runtimeSteps.find(
+        (step) =>
+          step.name === 'Smoke immutable public index on native platform'
+      ) as LooseRecord,
       'run'
     )
-    expect(smokeCommand).toContain('--platform linux/amd64')
-    expect(smokeCommand).toContain('--platform linux/arm64')
-    expect(smokeCommand).toContain('--mode health')
-    expect(smokeCommand).toContain('smoke-server-image.mjs')
+    expect(publicSmoke).toContain('smoke-server-image.mjs')
+    expect(publicSmoke).toContain('"$DOCKERHUB_REPOSITORY" "$GHCR_REPOSITORY"')
+    expect(publicSmoke).toContain('--platform "$PLATFORM"')
+    expect(publicSmoke).not.toContain('--mode health')
 
-    const allOtherJobs = Object.entries(jobs).filter(
-      ([name]) => name !== 'publish-container'
+    const promoteSteps = jobSteps(promote)
+    expect(stringField(promote, 'if')).toContain(
+      "needs.preflight.outputs.container_prerelease != 'true'"
     )
-    expect(JSON.stringify(allOtherJobs)).not.toContain('DOCKERHUB_TOKEN')
-    expect(JSON.stringify(allOtherJobs)).not.toContain('packages":"write')
+    expect(promoteSteps.at(-1)?.name).toBe(
+      'Promote and verify stable container aliases last'
+    )
+    const revalidateAliases = stringField(
+      promoteSteps.find(
+        (step) =>
+          step.name === 'Revalidate immutable inputs before alias promotion'
+      ) as LooseRecord,
+      'run'
+    )
+    expect(revalidateAliases).toContain('cosign verify')
+    expect(revalidateAliases).toContain('PUBLISHED_DIGEST')
+    const aliasCommand = stringField(promoteSteps.at(-1) as LooseRecord, 'run')
+    expect(aliasCommand).toContain('imagetools create')
+    expect(aliasCommand).toContain('all_tags')
+    expect(aliasCommand).toContain('PUBLISHED_DIGEST')
+
+    expect(releaseSource).not.toMatch(/qemu|setup-qemu|binfmt/i)
+    const jobsWithDockerHubToken = Object.entries(jobs)
+      .filter(([, job]) => JSON.stringify(job).includes('DOCKERHUB_TOKEN'))
+      .map(([name]) => name)
+      .sort()
+    expect(jobsWithDockerHubToken).toEqual([
+      'build-container-platform',
+      'promote-container-aliases',
+      'publish-container',
+    ])
   })
 
   it('bounds anonymous signature visibility retries and still fails closed', () => {


### PR DESCRIPTION
## Summary

- replace the emulated combined Server image build with native `linux/amd64` (`ubuntu-22.04`) and `linux/arm64` (`ubuntu-22.04-arm`) jobs
- stage each architecture only by digest, run a full native smoke against Docker Hub and GHCR, and emit strict immutable build metadata
- fan both verified architecture records into one finalize job that creates the versioned OCI index only after the complete set succeeds
- validate raw index digests, exact platform and attestation manifests, provenance, SBOM, revision, workflow run, and cross-registry equality before signing
- verify both final indexes and signatures anonymously, then run the public index on native amd64 and arm64 runners
- move stable alias promotion into the final recovery-safe job after every immutable publication and runtime gate
- preserve fail-closed immutable-tag resume/one-sided repair semantics, including verification of the recovery source before copying it
- record the partial beta.13 result accurately and prepare paired beta.14 release notes, AppStream metadata, README references, and version contracts

## Root cause addressed

The beta.13 container job attempted `linux/arm64` dependency installation under QEMU on an x64 runner. QEMU exited with target signal 4 during the `pnpm install` layer, and the Buildx action remained active until the job was canceled. Desktop publication, the GitHub prerelease, and the R2 feed had already succeeded, while the beta.13 container tag, signature, and public container verification did not complete.

The immutable `v2.0.0-beta.13` tag is not moved or reused. This PR prepares the fix for a later beta.14 release and does not claim atomic publication across independent distribution channels.

## Recovery and security review

- platform metadata rejects missing, duplicate, unexpected, cross-wired, wrong-run, future-attempt, wrong-runner, and shared-digest records
- reruns always recover the same run's two architecture artifacts before resuming or repairing a final index
- a one-sided existing index must match the raw digest, native build records, provenance, and SBOM before it can be copied
- both final registries must expose the same index digest, image manifests, and attestation manifests before signing
- stable aliases remain untouched until signature, anonymous artifact verification, and both native public runtime smokes succeed
- beta publication remains immutable-version-only; Snap prerelease remains preflight-only; Windows remains unsigned

## Validation

- related release/container Vitest: 139 passed
- full Vitest: 624 files passed, 4 skipped; 6754 tests passed, 8 skipped
- `actionlint` for release and CI workflows
- Biome full repository and required `src/` check
- TypeScript `tsc --noEmit`
- repository boundary and file-name checks
- Flatpak packaging contract and XML validation
- staged diff check

The optional Obsidian vault check was not runnable because this worktree has no ignored local `obsidian-docs.config.json`; release documentation is covered by the paired version-contract tests.

## Release control

This is intentionally a draft. No `v2.0.0-beta.14` tag has been created. Merge and release should wait for explicit maintainer confirmation after all PR checks reach a terminal passing state.
