### PR TITLE
fix(release): support runner Docker image inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. After its remaining release gates pass,
-download [v2.0.0-beta.14 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.14)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.14.md) before
+download [v2.0.0-beta.15 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.15)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.15.md) before
 installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -149,7 +149,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.14'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.15'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。剩余发布门禁通过后，请从 GitHub Releases
-下载 [v2.0.0-beta.14](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.14)，
-并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.14.zh-CN.md)。
+下载 [v2.0.0-beta.15](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.15)，
+并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.15.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -143,7 +143,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.14'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.15'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.14.md
+++ b/docs/release-notes/2.0.0-beta.14.md
@@ -1,127 +1,69 @@
 # Motrix 2.0.0-beta.14
 
-English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.14/docs/release-notes/2.0.0-beta.14.zh-CN.md)
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.15/docs/release-notes/2.0.0-beta.14.zh-CN.md)
 
-Motrix 2.0.0-beta.14 is the next Motrix Turbo beta intended for public
-distribution after every protected release gate passes. It supersedes the
-incomplete beta.13 container result without moving or reusing the immutable
-`v2.0.0-beta.13` tag.
+Motrix 2.0.0-beta.14 was partially distributed on 2026-08-16. In Build/Release
+run [31937363296](https://github.com/agalwood/Motrix/actions/runs/31937363296),
+all five desktop builds, all three Finalize jobs, assembly, the GitHub
+prerelease, and the R2 update feed completed successfully. Windows packages
+were published unsigned as intended.
 
-The [beta.13 historical record](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.14/docs/release-notes/2.0.0-beta.13.md)
-documents the successful desktop and R2 publication and the container failure.
+The protected prerelease Snap run passed source validation and, as designed,
+skipped both architecture builds and Store publication. It did not change
+public `latest/edge`.
 
-## Native container publication recovery
+## Container result
 
-- Builds `linux/amd64` on `ubuntu-22.04` and `linux/arm64` on
-  `ubuntu-22.04-arm`. Each job verifies the GitHub-hosted Linux runner and its
-  native architecture before Buildx starts. The container release path no
-  longer installs or invokes QEMU.
-- Pushes each successful platform only by its untagged, content-addressed OCI
-  digest to Docker Hub and GHCR. A single architecture never receives the
-  public version tag and cannot become the official release on its own.
-- Inspects the raw per-platform OCI index in both registries, hashes it back to
-  the Buildx digest, validates the exact version, source commit, non-root user,
-  image manifest, and attestation manifest, and records immutable build
-  metadata tied to the exact workflow run and attempt.
-- Anonymously pulls the exact staged digest from both registries and runs the
-  full Server runtime smoke on its native runner before that platform metadata
-  can leave the job.
-- Allows one finalize job to proceed only after the complete amd64/arm64 build
-  set succeeds. It rejects missing, duplicate, unexpected, cross-wired, or
-  future-attempt records before creating the versioned multi-platform index.
-- Rechecks both immutable version tags immediately before finalization. A clean
-  run creates both indexes from the verified platform digests; a rerun resumes
-  an identical complete result or repairs one missing registry from the
-  verified existing index. Any conflicting immutable tag fails closed.
-- Requires Docker Hub and GHCR to expose the same final index digest, platform
-  manifests, and attestation manifests. It also validates max-level BuildKit
-  provenance, the exact source revision and builder run, and a non-empty SPDX
-  SBOM for both architectures.
-- Signs each final index digest with the exact protected tag-workflow identity,
-  then verifies both signatures anonymously with a bounded fail-closed wait.
-- Runs the full anonymous runtime smoke for the final public index on native
-  amd64 and arm64 runners and against both registries. Stable floating aliases
-  are handled by a final recovery-safe job only after every build, index,
-  signature, provenance, SBOM, anonymous pull, and runtime gate succeeds.
-- Beta releases still publish only their immutable version tag; beta.14 does
-  not update `latest`, `stable`, or another stable floating alias.
+The new release path built `linux/amd64` on `ubuntu-22.04` and `linux/arm64` on
+`ubuntu-22.04-arm`. Both jobs verified their native GitHub-hosted runner, built
+without QEMU, and pushed their untagged content-addressed platform digest to
+Docker Hub and GHCR. Neither staged digest was a public beta.14 version tag or
+an official single-architecture release.
 
-The GitHub prerelease, R2 update feed, container registries, and Snap Store
-remain independently gated publication channels. Their individual safety
-checks and recovery rules are strict, but this release does not claim
-cross-channel atomicity.
+Both jobs then failed closed in the anonymous staged-digest runtime smoke. The
+GitHub runner Docker clients rejected `docker image inspect --platform` with
+`unknown flag: --platform` after each platform-pinned pull had succeeded. The
+failure was in the smoke client's Docker CLI compatibility, not in an emulated
+build or a Server-process crash.
 
-## Snap beta policy
+Because neither job could upload its verified immutable platform metadata, the
+fan-in finalize job did not run. Neither registry received an immutable
+`2.0.0-beta.14` tag or final multi-platform index. No beta.14 container index
+was signed, no final provenance or SBOM set was publicly verified, and no final
+public native runtime smoke completed. `latest`, `stable`, and every other
+stable container alias remained unchanged.
 
-Snap is not part of the beta.14 distribution. Protected prerelease Snap runs
-stop after source validation, so they do not build Snap artifacts, upload Store
-revisions, or change `latest/edge`. Stable Snap publication retains its
-complete two-architecture verification and protected Store gates.
+The GitHub prerelease, R2 update feed, container registries, and Snap Store are
+independently gated publication channels; this result must not be described as
+atomic across distribution channels. The `v2.0.0-beta.14` tag remains immutable
+and is not moved or reused. The compatibility fix is carried by
+[Motrix 2.0.0-beta.15](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.15/docs/release-notes/2.0.0-beta.15.md).
 
-## Highlights
+## Available beta.14 downloads
 
-- A ground-up desktop rebuild with Electron 43, React 19, and TypeScript 7,
-  including a customizable Dashboard, dark mode, a cross-platform application
-  menu, and clearer task-inspector feedback.
-- One host-neutral download core for both the desktop app and the Node/Web
-  Server, with SQLite session recovery, tracker management, UPnP/NAT-PMP, and
-  HTTP, FTP, BitTorrent, and magnet support.
-- MDXP-based integration for the official CLI and browser handoff, including
-  local discovery and device-code pairing for remote Server instances.
-- A QuickJS plugin sandbox with capability consent, bundled builtin plugins,
-  and an in-app plugin marketplace.
-- Persistent, verified multi-platform Server containers for NAS and
-  home-server deployments, published to both Docker Hub and GHCR after the
-  complete native architecture set passes.
-
-## Before testing
-
-This is prerelease software. Back up your existing Motrix application data and
-downloads before installing it. Migration from Motrix v1 data has not yet been
-validated, so do not use your only copy of v1 data with this beta.
-
-When practical, test v2 in parallel using a separate OS account, machine, or
-Docker data directory. Do not rely on this beta for your only copy of important
-downloads.
-
-## What to test
-
-- HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
-  session recovery
-- Desktop integrations, browser and CLI handoff through MDXP, and sandboxed
-  plugins
-- Headless Server deployment, persistent storage, remote pairing, and native
-  amd64 and arm64 container images
-
-## Planned downloads after release gates pass
-
-| Distribution | Architectures | Planned output |
-|--------------|---------------|----------------|
+| Distribution | Architectures | Published output |
+|--------------|---------------|------------------|
 | macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
 | Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
 | Linux | `x64`, `arm64` | DEB and RPM |
 | Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.14-linux-<arch>.tar.gz` |
-| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.14` tag in both registries |
+| Docker Hub / GHCR | — | No `2.0.0-beta.14` tag or final index |
 | Snap Store | — | Not published for this beta |
 
-After every container gate passes, the versioned image references will be
-`docker.io/motrixapp/motrix-server:2.0.0-beta.14` and
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.14`. See the
-[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.14/docs/docker-server.md)
-for storage, networking, and upgrade guidance.
+Do not use `docker.io/motrixapp/motrix-server:2.0.0-beta.14` or
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.14`: those immutable version tags
+were not published. Untagged staged digests from the failed workflow are not an
+official release.
 
 ## Known distribution limits
 
-- AppImage is not published for this beta.
-- Flatpak is validated separately and is not published by the release tag;
+- AppImage was not published for this beta.
+- Flatpak was validated separately and was not published by the release tag;
   the GitHub prerelease includes its Native Host companion archives.
-- Windows `arm64` and all 32-bit packages are not available.
+- Windows `arm64` and all 32-bit packages are unavailable.
 - Windows packages are unsigned and may trigger a Windows SmartScreen warning.
-  Download them only from the official GitHub prerelease after it is published.
-- Beta container tags are immutable and do not update `latest`, `stable`, or
-  other stable floating tags.
-- Snap is not published for this beta. Prerelease Snap runs stop after source
-  validation without building or publishing Snap artifacts.
+- Snap was not published. The prerelease Snap run stopped after source
+  validation without building or publishing artifacts.
 
 ## Feedback
 

--- a/docs/release-notes/2.0.0-beta.14.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.14.zh-CN.md
@@ -1,108 +1,63 @@
 # Motrix 2.0.0-beta.14
 
-[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.14/docs/release-notes/2.0.0-beta.14.md) | 简体中文
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.15/docs/release-notes/2.0.0-beta.14.md) | 简体中文
 
-Motrix 2.0.0-beta.14 是下一次计划公开发布的 Motrix Turbo beta，但只有全部受保护
-发布门禁通过后才会进入分发。它会取代 beta.13 未完成的容器结果，但不会移动或
-复用不可变的 `v2.0.0-beta.13` tag。
+Motrix 2.0.0-beta.14 于 2026-08-16 完成了部分渠道分发。在 Build/Release
+run [31937363296](https://github.com/agalwood/Motrix/actions/runs/31937363296) 中，
+5 个桌面构建、3 个 Finalize job、assemble、GitHub 预发布版以及 R2 更新数据源
+均成功完成。Windows 安装包按计划以未签名形式发布。
 
-[beta.13 历史记录](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.14/docs/release-notes/2.0.0-beta.13.zh-CN.md)
-准确记录了成功的桌面/R2 发布和容器失败结果。
+受保护的预发布 Snap run 通过 source validation 后，按设计跳过了两个架构构建
+与 Store 发布，没有修改公开 `latest/edge`。
 
-## 原生容器发布恢复
+## 容器结果
 
-- `linux/amd64` 固定在 `ubuntu-22.04` 构建，`linux/arm64` 固定在
-  `ubuntu-22.04-arm` 构建。每个 job 都会在 Buildx 启动前验证 GitHub-hosted
-  Linux runner 及其原生架构；容器发布路径不再安装或调用 QEMU。
-- 每个平台成功后只按无 tag、内容寻址的 OCI digest 推送到 Docker Hub 和 GHCR。
-  单一架构不会获得公开版本 tag，因此不能独立成为正式发布版本。
-- 在两个 registry 中检查原始的单平台 OCI index，将其哈希回 Buildx digest，
-  校验精确版本、源码 commit、非 root 用户、image manifest 和 attestation
-  manifest，并生成绑定精确 workflow run 与 attempt 的不可变构建元数据。
-- 在该架构的原生 runner 上，从两个 registry 匿名拉取准确的暂存 digest 并运行
-  完整 Server runtime smoke；只有成功后，该平台元数据才能离开 job。
-- 只有 amd64/arm64 完整构建集合成功后，唯一的 finalize job 才能继续。创建带版本
-  multi-platform index 前，它会拒绝缺失、重复、意外、架构串线或未来 attempt
-  元数据。
-- Finalize 前立即重新检查两个不可变版本 tag。全新发布从已验证平台 digest 创建
-  两个 index；续跑可以接受完全一致的已有结果，或把单 registry 已有的验证 index
-  修复到缺失的 registry。任何冲突的不可变 tag 都会 fail-closed。
-- Docker Hub 和 GHCR 必须公开相同的最终 index digest、平台 manifest 与
-  attestation manifest；同时校验两个架构的 max-level BuildKit provenance、精确
-  源码 revision 与 builder run，以及非空 SPDX SBOM。
-- 使用精确的受保护 tag-workflow 身份签名两个最终 index digest，并通过有界、
-  fail-closed 的等待匿名验证两个签名。
-- 最终公开 index 会在原生 amd64 和 arm64 runner 上、针对两个 registry 完成匿名
-  完整 runtime smoke。只有全部构建、index、签名、provenance、SBOM、匿名拉取和
-  runtime 门禁通过后，最后一个可恢复 job 才能推进稳定版浮动 alias。
-- Beta 仍只发布不可变版本 tag；beta.14 不会更新 `latest`、`stable` 或其他稳定版
-  浮动 alias。
+新发布路径在 `ubuntu-22.04` 构建 `linux/amd64`，并在 `ubuntu-22.04-arm`
+构建 `linux/arm64`。两个 job 都验证了各自的原生 GitHub-hosted runner，在不使用
+QEMU 的情况下完成构建，并把无 tag、内容寻址的平台 digest 推送到 Docker Hub
+和 GHCR。这些暂存 digest 均不是公开 beta.14 版本 tag，也不是单架构正式版本。
 
-GitHub 预发布版、R2 更新数据源、容器 registry 与 Snap Store 仍是各自独立门禁的
-发布渠道。每个渠道都有严格的安全检查和恢复规则，但本版本不宣称跨渠道原子性。
+随后，两个 job 都在匿名暂存 digest runtime smoke 中 fail-closed。每个平台固定拉取
+已成功，但 GitHub runner 的 Docker client 不支持
+`docker image inspect --platform`，并返回 `unknown flag: --platform`。该失败来自 smoke
+client 的 Docker CLI 兼容性，不是模拟构建问题或 Server 进程崩溃。
 
-## Snap beta 策略
+由于两个 job 都无法上传已验证的不可变平台元数据，fan-in finalize job 未运行。
+两个 registry 均没有获得不可变 `2.0.0-beta.14` tag 或最终 multi-platform index。
+没有 beta.14 容器 index 完成签名，没有公开验证最终 provenance 或 SBOM 集合，也没有
+完成最终公开原生 runtime smoke。`latest`、`stable` 与其他稳定版容器 alias 均保持不变。
 
-Snap 不属于 beta.14 的分发范围。受保护的预发布 Snap run 会在 source validation
-后停止，因此不会构建 Snap artifact、上传 Store revision 或修改 `latest/edge`。
-稳定版 Snap 发布仍保留完整的双架构验证与受保护 Store 门禁。
+GitHub 预发布版、R2 更新数据源、容器 registry 和 Snap Store 是各自独立门禁的发布渠道，
+不能把该结果描述为跨分发渠道的原子发布。`v2.0.0-beta.14` tag 保持不可变，不会移动
+或复用。兼容性修复由
+[Motrix 2.0.0-beta.15](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.15/docs/release-notes/2.0.0-beta.15.zh-CN.md)
+承载。
 
-## 主要变化
+## 可用的 beta.14 下载
 
-- 使用 Electron 43、React 19 和 TypeScript 7 从头重建桌面应用，提供可自定义
-  Dashboard、深色模式、跨平台应用菜单，以及更清晰的任务检查器反馈。
-- 桌面应用和 Node/Web Server 共用与宿主无关的下载内核，支持 SQLite session
-  恢复、Tracker 管理、UPnP/NAT-PMP，以及 HTTP、FTP、BitTorrent 和磁力链接下载。
-- 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地发现及远程 Server 的
-  device-code 配对。
-- 提供带能力授权的 QuickJS 插件沙箱、内置插件和应用内插件市场。
-- 面向 NAS 和家庭服务器提供持久化、经过验证的多平台 Server 容器；完整原生架构
-  集合通过后，才会同时发布到 Docker Hub 与 GHCR。
-
-## 测试前须知
-
-这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1 数据的
-迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
-
-条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录与现有环境并行
-测试 v2。请勿让本 beta 成为重要下载文件的唯一存储位置。
-
-## 建议测试项
-
-- HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
-- 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
-- Headless Server 部署、数据持久化、远程配对，以及原生 amd64 与 arm64 容器
-  镜像
-
-## 发布门禁通过后的计划下载
-
-| 发布方式 | 架构 | 计划产物 |
-|----------|------|----------|
+| 发布方式 | 架构 | 已发布产物 |
+|----------|------|--------------|
 | macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
 | Windows | `x64` | 未签名的 NSIS 安装包（`.exe`）和 ZIP |
 | Linux | `x64`、`arm64` | DEB 和 RPM |
 | Flatpak Native Host 配套程序 | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.14-linux-<arch>.tar.gz` |
-| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中不可变的 `2.0.0-beta.14` tag |
-| Snap Store | — | 本 beta 不发布 |
+| Docker Hub / GHCR | — | 没有 `2.0.0-beta.14` tag 或最终 index |
+| Snap Store | — | 本 beta 未发布 |
 
-全部容器门禁通过后，带版本镜像引用为
-`docker.io/motrixapp/motrix-server:2.0.0-beta.14` 和
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.14`。数据持久化、网络和升级方法请参阅
-[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.14/docs/docker-server.zh-CN.md)。
+请勿使用 `docker.io/motrixapp/motrix-server:2.0.0-beta.14` 或
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.14`：这些不可变版本 tag 并未发布。
+失败 workflow 中的无 tag 暂存 digest 不是正式版本。
 
 ## 已知发布限制
 
-- 本 beta 不发布 AppImage。
-- Flatpak 会单独验证，不会随该版本 tag 发布；GitHub 预发布版会包含其 Native Host
+- 本 beta 未发布 AppImage。
+- Flatpak 已单独验证，没有随该版本 tag 发布；GitHub 预发布版包含其 Native Host
   配套程序压缩包。
 - 不提供 Windows `arm64` 和任何 32 位安装包。
-- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅在正式发布后
-  从 GitHub 官方预发布版下载。
-- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
-- 本 beta 不发布 Snap。预发布 Snap run 会在 source validation 后停止，不会构建
-  或发布 Snap artifact。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。
+- Snap 未发布。预发布 Snap run 在 source validation 后停止，没有构建或发布 artifact。
 
 ## 反馈
 
-请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现的问题，
-并附上操作系统、架构、安装包类型和复现步骤。
+请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现的问题，并附上
+操作系统、架构、安装包类型和复现步骤。

--- a/docs/release-notes/2.0.0-beta.15.md
+++ b/docs/release-notes/2.0.0-beta.15.md
@@ -1,0 +1,135 @@
+# Motrix 2.0.0-beta.15
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.15/docs/release-notes/2.0.0-beta.15.zh-CN.md)
+
+Motrix 2.0.0-beta.15 is the next Motrix Turbo beta intended for public
+distribution after every protected release gate passes. It fixes the native
+container runtime-smoke compatibility failure found during beta.14 without
+moving or reusing the immutable `v2.0.0-beta.14` tag.
+
+The [beta.14 historical record](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.15/docs/release-notes/2.0.0-beta.14.md)
+documents the successful GitHub prerelease and R2 update-feed publication, the
+two successful native container builds, and the fail-closed container result.
+
+## Native container smoke compatibility recovery
+
+- Builds `linux/amd64` on `ubuntu-22.04` and `linux/arm64` on
+  `ubuntu-22.04-arm`. Each job verifies the GitHub-hosted Linux runner and its
+  native architecture before Buildx starts. The container release path does
+  not install or invoke QEMU.
+- Each native smoke explicitly pulls its staged digest with the required
+  platform, then inspects the selected local image using the Docker CLI syntax
+  supported by both GitHub runner images. It still fails closed unless the
+  inspected image architecture exactly matches the matrix platform, and every
+  runtime container remains platform-pinned.
+- Pushes each successful platform only by its untagged, content-addressed OCI
+  digest to Docker Hub and GHCR. A single architecture never receives the
+  public version tag and cannot become the official release on its own.
+- Anonymously pulls the exact staged digest from both registries and runs the
+  full Server runtime smoke on its native runner. Immutable platform metadata
+  can be uploaded only after both registry smokes succeed.
+- Binds each platform record to the exact version, source commit, workflow run
+  and attempt, native runner identity, raw OCI index hash, image manifest,
+  attestation manifest, provenance, and SPDX SBOM.
+- Allows one finalize job to proceed only after the complete amd64/arm64 build
+  set succeeds. It rejects missing, duplicate, unexpected, cross-wired, shared,
+  or future-attempt digests before creating either versioned index.
+- Rechecks both immutable version tags immediately before finalization. A clean
+  run creates both indexes from the verified platform digests; a rerun resumes
+  an identical complete result or repairs one missing registry from the
+  verified existing index. Any conflicting immutable tag fails closed.
+- Requires Docker Hub and GHCR to expose the same final index digest, platform
+  manifests, and attestation manifests. It validates max-level BuildKit
+  provenance, the exact source revision and builder run, and a non-empty SPDX
+  SBOM for both architectures before signing.
+- Signs each final index digest with the exact protected tag-workflow identity,
+  verifies both signatures anonymously, and then runs the full public runtime
+  smoke on native amd64 and arm64 runners against both registries.
+- Stable floating aliases are handled by the final recovery-safe job only after
+  every build, index, signature, provenance, SBOM, anonymous pull, and runtime
+  gate succeeds. Beta releases publish only their immutable version tag, so
+  beta.15 does not update `latest`, `stable`, or another stable alias.
+
+The GitHub prerelease, R2 update feed, container registries, and Snap Store
+remain independently gated publication channels. Their individual safety and
+recovery rules are strict, but this release does not claim cross-channel
+atomicity.
+
+## Snap beta policy
+
+Snap is not part of the beta.15 distribution. Protected prerelease Snap runs
+stop after source validation, so they do not build Snap artifacts, upload Store
+revisions, or change `latest/edge`. Stable Snap publication retains its
+complete two-architecture verification and protected Store gates.
+
+## Highlights
+
+- A ground-up desktop rebuild with Electron 43, React 19, and TypeScript 7,
+  including a customizable Dashboard, dark mode, a cross-platform application
+  menu, and clearer task-inspector feedback.
+- One host-neutral download core for both the desktop app and the Node/Web
+  Server, with SQLite session recovery, tracker management, UPnP/NAT-PMP, and
+  HTTP, FTP, BitTorrent, and magnet support.
+- MDXP-based integration for the official CLI and browser handoff, including
+  local discovery and device-code pairing for remote Server instances.
+- A QuickJS plugin sandbox with capability consent, bundled builtin plugins,
+  and an in-app plugin marketplace.
+- Persistent multi-platform Server containers for NAS and home-server
+  deployments, published only after the complete native architecture set and
+  every public verification gate pass.
+
+## Before testing
+
+This is prerelease software. Back up your existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Do not rely on this beta for your only copy of important
+downloads.
+
+## What to test
+
+- HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
+  session recovery
+- Desktop integrations, browser and CLI handoff through MDXP, and sandboxed
+  plugins
+- Headless Server deployment, persistent storage, remote pairing, and native
+  amd64 and arm64 container images
+
+## Planned downloads after release gates pass
+
+| Distribution | Architectures | Planned output |
+|--------------|---------------|----------------|
+| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | DEB and RPM |
+| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.15-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.15` tag in both registries |
+| Snap Store | — | Not published for this beta |
+
+After every container gate passes, the versioned image references will be
+`docker.io/motrixapp/motrix-server:2.0.0-beta.15` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.15`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.15/docs/docker-server.md)
+for storage, networking, and upgrade guidance.
+
+## Known distribution limits
+
+- AppImage is not published for this beta.
+- Flatpak is validated separately and is not published by the release tag;
+  the GitHub prerelease includes its Native Host companion archives.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
+  Download them only from the official GitHub prerelease after it is published.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+- Snap is not published for this beta. Prerelease Snap runs stop after source
+  validation without building or publishing Snap artifacts.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.15.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.15.zh-CN.md
@@ -1,0 +1,114 @@
+# Motrix 2.0.0-beta.15
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.15/docs/release-notes/2.0.0-beta.15.md) | 简体中文
+
+Motrix 2.0.0-beta.15 是下一次计划公开发布的 Motrix Turbo beta，但只有
+全部受保护发布门禁通过后才会进入分发。它修复 beta.14 中原生容器
+runtime smoke 的 Docker CLI 兼容性失败，不会移动或复用不可变的
+`v2.0.0-beta.14` tag。
+
+[beta.14 历史记录](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.15/docs/release-notes/2.0.0-beta.14.zh-CN.md)
+准确记录了已成功的 GitHub 预发布版与 R2 更新数据源、两个已成功的原生容器
+构建，以及 fail-closed 的容器结果。
+
+## 原生容器 smoke 兼容性修复
+
+- `linux/amd64` 固定在 `ubuntu-22.04` 构建，`linux/arm64` 固定在
+  `ubuntu-22.04-arm` 构建。每个 job 都会在 Buildx 启动前验证 GitHub-hosted
+  Linux runner 及其原生架构；容器发布路径不安装或调用 QEMU。
+- 每个原生 smoke 先按要求的 platform 显式拉取暂存 digest，再使用两种
+  GitHub runner 都支持的 Docker CLI 语法检查已选中的本地镜像。检查结果中的
+  architecture 必须与矩阵 platform 完全一致，所有 runtime 容器也继续
+  显式固定 platform，否则 fail-closed。
+- 每个平台成功后只按无 tag、内容寻址的 OCI digest 推送到 Docker Hub
+  和 GHCR。单一架构不会获得公开版本 tag，不能独立成为正式发布版本。
+- 在原生 runner 上从两个 registry 匿名拉取精确的暂存 digest，并运行完整
+  Server runtime smoke。只有两个 registry smoke 都成功后，才能上传不可变
+  平台元数据。
+- 每份平台记录绑定精确版本、源码 commit、workflow run 与 attempt、原生 runner
+  身份、原始 OCI index 哈希、image manifest、attestation manifest、provenance
+  和 SPDX SBOM。
+- 只有 amd64/arm64 完整构建集合成功后，唯一的 finalize job 才能继续。创建
+  任一带版本 index 前，它会拒绝缺失、重复、意外、架构串线、共用或未来
+  attempt digest。
+- Finalize 前立即重新检查两个不可变版本 tag。全新发布从已验证平台
+  digest 创建两个 index；续跑可以接受完全一致的已有结果，或从已验证的现有
+  index 修复缺失的 registry。任何冲突的不可变 tag 都会 fail-closed。
+- Docker Hub 和 GHCR 必须公开相同的最终 index digest、平台 manifest 与
+  attestation manifest；签名前还会验证两个架构的 max-level BuildKit
+  provenance、精确源码 revision 与 builder run，以及非空 SPDX SBOM。
+- 使用精确的受保护 tag-workflow 身份签名两个最终 index digest，匿名验证
+  两个签名，然后在原生 amd64 和 arm64 runner 上针对两个 registry 运行完整公开
+  runtime smoke。
+- 稳定版浮动 alias 只由最后一个可恢复 job 处理，且必须等到全部构建、index、
+  签名、provenance、SBOM、匿名拉取和 runtime 门禁通过。Beta 只发布不可变
+  版本 tag，因此 beta.15 不会更新 `latest`、`stable` 或其他稳定版 alias。
+
+GitHub 预发布版、R2 更新数据源、容器 registry 与 Snap Store 仍是各自独立门禁的
+发布渠道。每个渠道都有严格的安全检查和恢复规则，但本版本不宣称跨渠道
+原子性。
+
+## Snap beta 策略
+
+Snap 不属于 beta.15 的分发范围。受保护的预发布 Snap run 会在 source validation
+后停止，因此不会构建 Snap artifact、上传 Store revision 或修改 `latest/edge`。
+稳定版 Snap 发布仍保留完整的双架构验证与受保护 Store 门禁。
+
+## 主要变化
+
+- 使用 Electron 43、React 19 和 TypeScript 7 从头重建桌面应用，提供可自定义
+  Dashboard、深色模式、跨平台应用菜单，以及更清晰的任务检查器反馈。
+- 桌面应用和 Node/Web Server 共用与宿主无关的下载内核，支持 SQLite session
+  恢复、Tracker 管理、UPnP/NAT-PMP，以及 HTTP、FTP、BitTorrent 和磁力链接下载。
+- 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地发现及远程 Server 的
+  device-code 配对。
+- 提供带能力授权的 QuickJS 插件沙箱、内置插件和应用内插件市场。
+- 面向 NAS 和家庭服务器提供持久化多平台 Server 容器；只有完整原生架构集合
+  与所有公开验证门禁通过后才会发布。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1 数据的
+迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
+
+条件允许时，建议通过独立系统账户、设备或 Docker 数据目录与现有环境并行测试 v2。
+请勿让本 beta 成为重要下载文件的唯一存储位置。
+
+## 建议测试项
+
+- HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
+- 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
+- Headless Server 部署、数据持久化、远程配对，以及原生 amd64 与 arm64 容器镜像
+
+## 发布门禁通过后的计划下载
+
+| 发布方式 | 架构 | 计划产物 |
+|----------|------|----------|
+| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
+| Windows | `x64` | 未签名的 NSIS 安装包（`.exe`）和 ZIP |
+| Linux | `x64`、`arm64` | DEB 和 RPM |
+| Flatpak Native Host 配套程序 | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.15-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中不可变的 `2.0.0-beta.15` tag |
+| Snap Store | — | 本 beta 不发布 |
+
+全部容器门禁通过后，带版本镜像引用为
+`docker.io/motrixapp/motrix-server:2.0.0-beta.15` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.15`。数据持久化、网络和升级方法请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.15/docs/docker-server.zh-CN.md)。
+
+## 已知发布限制
+
+- 本 beta 不发布 AppImage。
+- Flatpak 会单独验证，不会随该版本 tag 发布；GitHub 预发布版会包含其 Native Host
+  配套程序压缩包。
+- 不提供 Windows `arm64` 和任何 32 位安装包。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅在正式发布后
+  从 GitHub 官方预发布版下载。
+- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
+- 本 beta 不发布 Snap。预发布 Snap run 会在 source validation 后停止，不会构建
+  或发布 Snap artifact。
+
+## 反馈
+
+请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现的问题，并附上
+操作系统、架构、安装包类型和复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -76,16 +76,31 @@
   <releases>
     <!-- Update this list on every release; Flathub linter requires the most
          recent version listed here to match the manifest's source tag. -->
+    <release version="2.0.0-beta.15" date="2026-08-16">
+      <description>
+        <p>
+          Native staged-digest smoke tests now use Docker CLI syntax supported
+          by both GitHub runner architectures after a platform-pinned pull,
+          while retaining an exact architecture assertion and platform-pinned
+          runtime containers. The complete native fan-out, cross-registry
+          index, provenance, SBOM, signature, and public runtime gates remain
+          fail-closed. Windows packages remain unsigned. Prerelease Snap runs
+          stop after source validation without building or publishing
+          artifacts.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.14" date="2026-08-16">
       <description>
         <p>
-          Container publication now builds amd64 and arm64 independently on
-          native GitHub-hosted runners without QEMU. Untagged platform digests
-          must pass cross-registry metadata and native runtime checks before a
-          single job creates, signs, and anonymously verifies the final index.
-          Stable aliases advance only after final native public smoke tests.
-          Windows packages remain unsigned. Prerelease Snap runs stop after
-          source validation without building or publishing artifacts.
+          The GitHub prerelease and R2 update feed completed. Native amd64 and
+          arm64 Server builds without QEMU pushed only untagged staged digests,
+          then failed closed because the runner Docker clients did not support
+          the image-inspect platform flag. No beta.14 container tag, final
+          index, signature, public provenance or SBOM verification, or final
+          runtime smoke completed; stable aliases remained unchanged. Windows
+          packages were published unsigned. The prerelease Snap run stopped
+          after source validation.
         </p>
       </description>
     </release>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.14",
+  "version": "2.0.0-beta.15",
   "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1",
   "description": "A full-featured download manager",
   "keywords": [],

--- a/scripts/smoke-server-image.mjs
+++ b/scripts/smoke-server-image.mjs
@@ -724,7 +724,11 @@ export async function smokeServerImage(options) {
   try {
     if (platform) await docker(['pull', '--platform', platform, image])
     const metadata = JSON.parse(
-      await docker(['image', 'inspect', ...platformArgs(platform), image])
+      // `docker image inspect --platform` requires a newer Docker CLI than the
+      // GitHub-hosted Ubuntu runners consistently provide. The preceding
+      // platform-pinned pull selects the local image; the architecture check
+      // below remains the fail-closed platform assertion.
+      await docker(['image', 'inspect', image])
     )[0]
     if (metadata.Config.User !== 'node') {
       throw new Error(

--- a/tests/scripts/docker-server-runtime.test.ts
+++ b/tests/scripts/docker-server-runtime.test.ts
@@ -137,6 +137,16 @@ describe('Docker Server runtime staging contract', () => {
     )
 
     expect(imageSmoke).toContain("'--read-only'")
+    expect(imageSmoke).toContain(
+      "if (platform) await docker(['pull', '--platform', platform, image])"
+    )
+    expect(imageSmoke).toContain("await docker(['image', 'inspect', image])")
+    expect(imageSmoke).not.toContain(
+      "docker(['image', 'inspect', ...platformArgs(platform), image])"
+    )
+    expect(imageSmoke).toContain(
+      "metadata.Architecture !== platform.split('/')[1]"
+    )
     expect(imageSmoke).toContain('identity.user')
     expect(imageSmoke).toContain("'command:createTask'")
     expect(imageSmoke).toContain("'command:setTaskBtTracker'")

--- a/tests/scripts/release-version-contract.test.ts
+++ b/tests/scripts/release-version-contract.test.ts
@@ -591,7 +591,90 @@ describe('release version contract', () => {
     expect(beta12Metainfo).not.toMatch(secretLikeIdentifier)
   })
 
-  it('ships beta.14 native container recovery without cross-channel atomicity claims', () => {
+  it('ships beta.15 Docker smoke compatibility recovery without weakening native gates', () => {
+    const english = read('docs/release-notes/2.0.0-beta.15.md')
+    const chinese = read('docs/release-notes/2.0.0-beta.15.zh-CN.md')
+    const normalizedEnglish = english
+      .replace(/^>\s?/gm, '')
+      .replace(/\s+/g, ' ')
+    const normalizedChinese = chinese
+      .replace(/^>\s?/gm, '')
+      .replace(/\s+/g, ' ')
+    const metainfo = read('flatpak/app.motrix.native.metainfo.xml')
+    const beta15Metainfo =
+      /<release version="2\.0\.0-beta\.15"[\s\S]*?<\/release>/.exec(
+        metainfo
+      )?.[0] ?? ''
+    const normalizedBeta15Metainfo = beta15Metainfo.replace(/\s+/g, ' ')
+
+    expect(normalizedEnglish).toContain(
+      'Builds `linux/amd64` on `ubuntu-22.04` and `linux/arm64` on `ubuntu-22.04-arm`'
+    )
+    expect(normalizedEnglish).toContain(
+      'The container release path does not install or invoke QEMU'
+    )
+    expect(normalizedEnglish).toContain(
+      'explicitly pulls its staged digest with the required platform, then inspects the selected local image using the Docker CLI syntax supported by both GitHub runner images'
+    )
+    expect(normalizedEnglish).toContain(
+      'fails closed unless the inspected image architecture exactly matches the matrix platform'
+    )
+    expect(normalizedEnglish).toContain(
+      'A single architecture never receives the public version tag and cannot become the official release on its own'
+    )
+    expect(normalizedEnglish).toContain(
+      'Immutable platform metadata can be uploaded only after both registry smokes succeed'
+    )
+    expect(normalizedEnglish).toContain(
+      'rejects missing, duplicate, unexpected, cross-wired, shared, or future-attempt digests'
+    )
+    expect(normalizedEnglish).toContain(
+      'a rerun resumes an identical complete result or repairs one missing registry'
+    )
+    expect(normalizedEnglish).toContain(
+      'Stable floating aliases are handled by the final recovery-safe job only after every build, index, signature, provenance, SBOM, anonymous pull, and runtime gate succeeds'
+    )
+    expect(normalizedEnglish).toContain(
+      'this release does not claim cross-channel atomicity'
+    )
+    expect(normalizedChinese).toContain(
+      '`linux/amd64` 固定在 `ubuntu-22.04` 构建，`linux/arm64` 固定在 `ubuntu-22.04-arm` 构建'
+    )
+    expect(normalizedChinese).toContain('容器发布路径不安装或调用 QEMU')
+    expect(normalizedChinese).toContain(
+      'architecture 必须与矩阵 platform 完全一致'
+    )
+    expect(normalizedChinese).toMatch(
+      /全部构建、index、\s*签名、provenance、SBOM、匿名拉取和 runtime 门禁通过/u
+    )
+    expect(normalizedChinese).toMatch(/本版本不宣称跨渠道\s*原子性/u)
+    for (const source of [english, chinese]) {
+      expect(source).toContain('Snap')
+      expect(source).toContain('latest/edge')
+      expect(source).toContain('AppImage')
+      expect(source).toContain('Flatpak')
+      expect(source).toContain(
+        'Motrix-Native-Host-2.0.0-beta.15-linux-<arch>.tar.gz'
+      )
+      expect(source).toContain('SmartScreen')
+      expect(source).toContain(
+        'docker.io/motrixapp/motrix-server:2.0.0-beta.15'
+      )
+      expect(source).toContain('ghcr.io/agalwood/motrix-server:2.0.0-beta.15')
+      expect(source).not.toMatch(restrictedPublicLanguage)
+      expect(source).not.toMatch(secretLikeIdentifier)
+    }
+    expect(normalizedBeta15Metainfo).toContain(
+      'use Docker CLI syntax supported by both GitHub runner architectures after a platform-pinned pull'
+    )
+    expect(normalizedBeta15Metainfo).toContain(
+      'retaining an exact architecture assertion and platform-pinned runtime containers'
+    )
+    expect(beta15Metainfo).not.toMatch(restrictedPublicLanguage)
+    expect(beta15Metainfo).not.toMatch(secretLikeIdentifier)
+  })
+
+  it('records beta.14 desktop/feed success and fail-closed native container smoke', () => {
     const english = read('docs/release-notes/2.0.0-beta.14.md')
     const chinese = read('docs/release-notes/2.0.0-beta.14.zh-CN.md')
     const normalizedEnglish = english
@@ -607,42 +690,41 @@ describe('release version contract', () => {
       )?.[0] ?? ''
     const normalizedBeta14Metainfo = beta14Metainfo.replace(/\s+/g, ' ')
 
+    expect(normalizedEnglish).toContain('was partially distributed')
     expect(normalizedEnglish).toContain(
-      'Builds `linux/amd64` on `ubuntu-22.04` and `linux/arm64` on `ubuntu-22.04-arm`'
+      'all five desktop builds, all three Finalize jobs, assembly, the GitHub prerelease, and the R2 update feed completed successfully'
     )
     expect(normalizedEnglish).toContain(
-      'The container release path no longer installs or invokes QEMU'
+      'Both jobs verified their native GitHub-hosted runner, built without QEMU, and pushed their untagged content-addressed platform digest to Docker Hub and GHCR'
     )
     expect(normalizedEnglish).toContain(
-      'A single architecture never receives the public version tag and cannot become the official release on its own'
+      'The GitHub runner Docker clients rejected `docker image inspect --platform` with `unknown flag: --platform`'
     )
     expect(normalizedEnglish).toContain(
-      'Anonymously pulls the exact staged digest from both registries and runs the full Server runtime smoke on its native runner'
+      "The failure was in the smoke client's Docker CLI compatibility, not in an emulated build or a Server-process crash"
     )
     expect(normalizedEnglish).toContain(
-      'rejects missing, duplicate, unexpected, cross-wired, or future-attempt records'
+      'Neither registry received an immutable `2.0.0-beta.14` tag or final multi-platform index'
     )
     expect(normalizedEnglish).toContain(
-      'a rerun resumes an identical complete result or repairs one missing registry'
+      'No beta.14 container index was signed, no final provenance or SBOM set was publicly verified, and no final public native runtime smoke completed'
     )
     expect(normalizedEnglish).toContain(
-      'Stable floating aliases are handled by a final recovery-safe job only after every build, index, signature, provenance, SBOM, anonymous pull, and runtime gate succeeds'
-    )
-    expect(normalizedEnglish).toContain(
-      'does not claim cross-channel atomicity'
+      'this result must not be described as atomic across distribution channels'
     )
     expect(normalizedChinese).toContain(
-      '`linux/amd64` 固定在 `ubuntu-22.04` 构建，`linux/arm64` 固定在 `ubuntu-22.04-arm` 构建'
-    )
-    expect(normalizedChinese).toContain('容器发布路径不再安装或调用 QEMU')
-    expect(normalizedChinese).toContain(
-      '单一架构不会获得公开版本 tag，因此不能独立成为正式发布版本'
+      '5 个桌面构建、3 个 Finalize job、assemble、GitHub 预发布版以及 R2 更新数据源 均成功完成'
     )
     expect(normalizedChinese).toContain(
-      '只有全部构建、index、签名、provenance、SBOM、匿名拉取和 runtime 门禁通过后'
+      '两个 job 都在匿名暂存 digest runtime smoke 中 fail-closed'
     )
-    expect(normalizedChinese).toContain('本版本不宣称跨渠道原子性')
+    expect(normalizedChinese).toContain(
+      '两个 registry 均没有获得不可变 `2.0.0-beta.14` tag 或最终 multi-platform index'
+    )
     for (const source of [english, chinese]) {
+      expect(source).toContain('31937363296')
+      expect(source).toContain('unknown flag: --platform')
+      expect(source).toContain('v2.0.0-beta.15')
       expect(source).toContain('Snap')
       expect(source).toContain('latest/edge')
       expect(source).toContain('AppImage')
@@ -659,10 +741,10 @@ describe('release version contract', () => {
       expect(source).not.toMatch(secretLikeIdentifier)
     }
     expect(normalizedBeta14Metainfo).toContain(
-      'builds amd64 and arm64 independently on native GitHub-hosted runners without QEMU'
+      'The GitHub prerelease and R2 update feed completed'
     )
     expect(normalizedBeta14Metainfo).toContain(
-      'Stable aliases advance only after final native public smoke tests'
+      'No beta.14 container tag, final index, signature, public provenance or SBOM verification, or final runtime smoke completed'
     )
     expect(beta14Metainfo).not.toMatch(restrictedPublicLanguage)
     expect(beta14Metainfo).not.toMatch(secretLikeIdentifier)


### PR DESCRIPTION
## Summary

- make native staged-digest smoke compatible with the Docker CLI installed on both GitHub runner architectures
- retain platform-pinned pulls, exact architecture validation, and platform-pinned runtime containers
- record the partial beta.14 release accurately and prepare the paired beta.15 release notes, AppStream entry, and version contract

## beta.14 failure and boundary

Build/Release run 31937363296 completed all desktop builds, GitHub prerelease publication, and the R2 update feed. Both native Server builds also pushed untagged platform digests to Docker Hub and GHCR without QEMU. The staged smoke then failed closed because the runner clients rejected docker image inspect --platform with unknown flag: --platform.

No beta.14 container version tag, final multi-platform index, signature, final provenance or SBOM verification, or public runtime smoke completed. Stable aliases remained unchanged. The immutable beta.14 tag is not moved or reused.

## Verification

- full Vitest suite: 626 files passed, 2 skipped; 6760 tests passed, 3 skipped
- focused release, container runtime, and Snap workflow contracts: 44 passed
- actionlint
- Biome, TypeScript, boundary and file-name checks
- AppStream XML and Flatpak validation
- git diff check

## Release control

This PR remains draft. Do not create the beta.15 tag until the PR is reviewed, merged, and release confirmation is explicit.