### PR TITLE
fix(release): accept Buildx platform output and stabilize seed smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. After its remaining release gates pass,
-download [v2.0.0-beta.15 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.15)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.15.md) before
+download [v2.0.0-beta.16 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.16)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.16.md) before
 installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -149,7 +149,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.15'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.16'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。剩余发布门禁通过后，请从 GitHub Releases
-下载 [v2.0.0-beta.15](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.15)，
-并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.15.zh-CN.md)。
+下载 [v2.0.0-beta.16](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.16)，
+并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.16.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -143,7 +143,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.15'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.16'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.15.md
+++ b/docs/release-notes/2.0.0-beta.15.md
@@ -1,131 +1,74 @@
 # Motrix 2.0.0-beta.15
 
-English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.15/docs/release-notes/2.0.0-beta.15.zh-CN.md)
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.16/docs/release-notes/2.0.0-beta.15.zh-CN.md)
 
-Motrix 2.0.0-beta.15 is the next Motrix Turbo beta intended for public
-distribution after every protected release gate passes. It fixes the native
-container runtime-smoke compatibility failure found during beta.14 without
-moving or reusing the immutable `v2.0.0-beta.14` tag.
+Motrix 2.0.0-beta.15 was partially distributed on 2026-08-16. In
+[Build/Release run 31939678223](https://github.com/agalwood/Motrix/actions/runs/31939678223),
+all five desktop builds, all three Finalize jobs, assembly, the GitHub
+prerelease, and the R2 update feed completed successfully. Windows packages
+were published unsigned as intended.
 
-The [beta.14 historical record](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.15/docs/release-notes/2.0.0-beta.14.md)
-documents the successful GitHub prerelease and R2 update-feed publication, the
-two successful native container builds, and the fail-closed container result.
+The protected prerelease Snap run passed source validation and, as designed,
+skipped both architecture builds and Store publication. It did not change
+public `latest/edge`.
 
-## Native container smoke compatibility recovery
+## Container result
 
-- Builds `linux/amd64` on `ubuntu-22.04` and `linux/arm64` on
-  `ubuntu-22.04-arm`. Each job verifies the GitHub-hosted Linux runner and its
-  native architecture before Buildx starts. The container release path does
-  not install or invoke QEMU.
-- Each native smoke explicitly pulls its staged digest with the required
-  platform, then inspects the selected local image using the Docker CLI syntax
-  supported by both GitHub runner images. It still fails closed unless the
-  inspected image architecture exactly matches the matrix platform, and every
-  runtime container remains platform-pinned.
-- Pushes each successful platform only by its untagged, content-addressed OCI
-  digest to Docker Hub and GHCR. A single architecture never receives the
-  public version tag and cannot become the official release on its own.
-- Anonymously pulls the exact staged digest from both registries and runs the
-  full Server runtime smoke on its native runner. Immutable platform metadata
-  can be uploaded only after both registry smokes succeed.
-- Binds each platform record to the exact version, source commit, workflow run
-  and attempt, native runner identity, raw OCI index hash, image manifest,
-  attestation manifest, provenance, and SPDX SBOM.
-- Allows one finalize job to proceed only after the complete amd64/arm64 build
-  set succeeds. It rejects missing, duplicate, unexpected, cross-wired, shared,
-  or future-attempt digests before creating either versioned index.
-- Rechecks both immutable version tags immediately before finalization. A clean
-  run creates both indexes from the verified platform digests; a rerun resumes
-  an identical complete result or repairs one missing registry from the
-  verified existing index. Any conflicting immutable tag fails closed.
-- Requires Docker Hub and GHCR to expose the same final index digest, platform
-  manifests, and attestation manifests. It validates max-level BuildKit
-  provenance, the exact source revision and builder run, and a non-empty SPDX
-  SBOM for both architectures before signing.
-- Signs each final index digest with the exact protected tag-workflow identity,
-  verifies both signatures anonymously, and then runs the full public runtime
-  smoke on native amd64 and arm64 runners against both registries.
-- Stable floating aliases are handled by the final recovery-safe job only after
-  every build, index, signature, provenance, SBOM, anonymous pull, and runtime
-  gate succeeds. Beta releases publish only their immutable version tag, so
-  beta.15 does not update `latest`, `stable`, or another stable alias.
+The container fan-out built `linux/amd64` on `ubuntu-22.04` and `linux/arm64`
+on `ubuntu-22.04-arm`. Both jobs verified their native GitHub-hosted runner,
+built without QEMU, and pushed only untagged, content-addressed staged digests
+to Docker Hub and GHCR. A staged digest was never a public beta.15 version tag
+or an official single-architecture release.
 
-The GitHub prerelease, R2 update feed, container registries, and Snap Store
-remain independently gated publication channels. Their individual safety and
-recovery rules are strict, but this release does not claim cross-channel
-atomicity.
+The arm64 job anonymously pulled its exact staged digest from both registries
+and passed the complete Server runtime smoke in each case. Metadata generation
+then failed closed because its parser expected a platform-keyed image map while
+Docker Buildx returned the documented flat `.Image` configuration for this
+single-platform source.
 
-## Snap beta policy
+The amd64 job failed closed earlier in its first staged-digest runtime smoke.
+Its deterministic local BitTorrent task did not reach `seeding` or `completed`
+within 180 seconds. This was a smoke-fixture readiness failure after the native
+image had built and pushed, not an emulated build failure.
 
-Snap is not part of the beta.15 distribution. Protected prerelease Snap runs
-stop after source validation, so they do not build Snap artifacts, upload Store
-revisions, or change `latest/edge`. Stable Snap publication retains its
-complete two-architecture verification and protected Store gates.
+Neither platform job uploaded verified immutable metadata, so the fan-in
+finalize job did not run. Neither registry received an immutable
+`2.0.0-beta.15` tag or final multi-platform index. No beta.15 index was signed;
+no final cross-registry provenance, SBOM, or anonymous signature set was
+verified; and no final public native runtime matrix completed. `latest`,
+`stable`, and every other stable container alias remained unchanged.
 
-## Highlights
+The GitHub prerelease, R2 update feed, container registries, and Snap Store are
+independently gated publication channels; this result must not be described as
+atomic across distribution channels. The `v2.0.0-beta.15` tag remains immutable
+and is not moved or reused. The recovery is carried by
+[Motrix 2.0.0-beta.16](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.16/docs/release-notes/2.0.0-beta.16.md).
 
-- A ground-up desktop rebuild with Electron 43, React 19, and TypeScript 7,
-  including a customizable Dashboard, dark mode, a cross-platform application
-  menu, and clearer task-inspector feedback.
-- One host-neutral download core for both the desktop app and the Node/Web
-  Server, with SQLite session recovery, tracker management, UPnP/NAT-PMP, and
-  HTTP, FTP, BitTorrent, and magnet support.
-- MDXP-based integration for the official CLI and browser handoff, including
-  local discovery and device-code pairing for remote Server instances.
-- A QuickJS plugin sandbox with capability consent, bundled builtin plugins,
-  and an in-app plugin marketplace.
-- Persistent multi-platform Server containers for NAS and home-server
-  deployments, published only after the complete native architecture set and
-  every public verification gate pass.
+## Available beta.15 downloads
 
-## Before testing
-
-This is prerelease software. Back up your existing Motrix application data and
-downloads before installing it. Migration from Motrix v1 data has not yet been
-validated, so do not use your only copy of v1 data with this beta.
-
-When practical, test v2 in parallel using a separate OS account, machine, or
-Docker data directory. Do not rely on this beta for your only copy of important
-downloads.
-
-## What to test
-
-- HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
-  session recovery
-- Desktop integrations, browser and CLI handoff through MDXP, and sandboxed
-  plugins
-- Headless Server deployment, persistent storage, remote pairing, and native
-  amd64 and arm64 container images
-
-## Planned downloads after release gates pass
-
-| Distribution | Architectures | Planned output |
-|--------------|---------------|----------------|
+| Distribution | Architectures | Published output |
+|--------------|---------------|------------------|
 | macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
 | Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
 | Linux | `x64`, `arm64` | DEB and RPM |
 | Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.15-linux-<arch>.tar.gz` |
-| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.15` tag in both registries |
+| Docker Hub / GHCR | — | No `2.0.0-beta.15` tag or final index |
 | Snap Store | — | Not published for this beta |
 
-After every container gate passes, the versioned image references will be
-`docker.io/motrixapp/motrix-server:2.0.0-beta.15` and
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.15`. See the
-[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.15/docs/docker-server.md)
-for storage, networking, and upgrade guidance.
+Do not use `docker.io/motrixapp/motrix-server:2.0.0-beta.15` or
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.15`: those immutable version tags
+were not published. Untagged staged digests from the failed workflow are not an
+official release.
 
 ## Known distribution limits
 
-- AppImage is not published for this beta.
-- Flatpak is validated separately and is not published by the release tag;
+- AppImage was not published for this beta.
+- Flatpak was validated separately and was not published by the release tag;
   the GitHub prerelease includes its Native Host companion archives.
-- Windows `arm64` and all 32-bit packages are not available.
+- Windows `arm64` and all 32-bit packages are unavailable.
 - Windows packages are unsigned and may trigger a Windows SmartScreen warning.
-  Download them only from the official GitHub prerelease after it is published.
-- Beta container tags are immutable and do not update `latest`, `stable`, or
-  other stable floating tags.
-- Snap is not published for this beta. Prerelease Snap runs stop after source
-  validation without building or publishing Snap artifacts.
+- Snap was not published. The prerelease Snap run stopped after source
+  validation without building or publishing artifacts.
 
 ## Feedback
 

--- a/docs/release-notes/2.0.0-beta.15.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.15.zh-CN.md
@@ -1,114 +1,69 @@
 # Motrix 2.0.0-beta.15
 
-[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.15/docs/release-notes/2.0.0-beta.15.md) | 简体中文
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.16/docs/release-notes/2.0.0-beta.15.md) | 简体中文
 
-Motrix 2.0.0-beta.15 是下一次计划公开发布的 Motrix Turbo beta，但只有
-全部受保护发布门禁通过后才会进入分发。它修复 beta.14 中原生容器
-runtime smoke 的 Docker CLI 兼容性失败，不会移动或复用不可变的
-`v2.0.0-beta.14` tag。
+Motrix 2.0.0-beta.15 于 2026-08-16 完成了部分渠道分发。在
+[Build/Release run 31939678223](https://github.com/agalwood/Motrix/actions/runs/31939678223)
+中，5 个桌面构建、3 个 Finalize job、assemble、GitHub 预发布版以及 R2 更新数据源
+均成功完成。Windows 安装包按计划以未签名状态发布。
 
-[beta.14 历史记录](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.15/docs/release-notes/2.0.0-beta.14.zh-CN.md)
-准确记录了已成功的 GitHub 预发布版与 R2 更新数据源、两个已成功的原生容器
-构建，以及 fail-closed 的容器结果。
+受保护的预发布 Snap run 通过 source validation 后按设计跳过双架构构建和 Store
+发布，没有修改公开 `latest/edge`。
 
-## 原生容器 smoke 兼容性修复
+## 容器结果
 
-- `linux/amd64` 固定在 `ubuntu-22.04` 构建，`linux/arm64` 固定在
-  `ubuntu-22.04-arm` 构建。每个 job 都会在 Buildx 启动前验证 GitHub-hosted
-  Linux runner 及其原生架构；容器发布路径不安装或调用 QEMU。
-- 每个原生 smoke 先按要求的 platform 显式拉取暂存 digest，再使用两种
-  GitHub runner 都支持的 Docker CLI 语法检查已选中的本地镜像。检查结果中的
-  architecture 必须与矩阵 platform 完全一致，所有 runtime 容器也继续
-  显式固定 platform，否则 fail-closed。
-- 每个平台成功后只按无 tag、内容寻址的 OCI digest 推送到 Docker Hub
-  和 GHCR。单一架构不会获得公开版本 tag，不能独立成为正式发布版本。
-- 在原生 runner 上从两个 registry 匿名拉取精确的暂存 digest，并运行完整
-  Server runtime smoke。只有两个 registry smoke 都成功后，才能上传不可变
-  平台元数据。
-- 每份平台记录绑定精确版本、源码 commit、workflow run 与 attempt、原生 runner
-  身份、原始 OCI index 哈希、image manifest、attestation manifest、provenance
-  和 SPDX SBOM。
-- 只有 amd64/arm64 完整构建集合成功后，唯一的 finalize job 才能继续。创建
-  任一带版本 index 前，它会拒绝缺失、重复、意外、架构串线、共用或未来
-  attempt digest。
-- Finalize 前立即重新检查两个不可变版本 tag。全新发布从已验证平台
-  digest 创建两个 index；续跑可以接受完全一致的已有结果，或从已验证的现有
-  index 修复缺失的 registry。任何冲突的不可变 tag 都会 fail-closed。
-- Docker Hub 和 GHCR 必须公开相同的最终 index digest、平台 manifest 与
-  attestation manifest；签名前还会验证两个架构的 max-level BuildKit
-  provenance、精确源码 revision 与 builder run，以及非空 SPDX SBOM。
-- 使用精确的受保护 tag-workflow 身份签名两个最终 index digest，匿名验证
-  两个签名，然后在原生 amd64 和 arm64 runner 上针对两个 registry 运行完整公开
-  runtime smoke。
-- 稳定版浮动 alias 只由最后一个可恢复 job 处理，且必须等到全部构建、index、
-  签名、provenance、SBOM、匿名拉取和 runtime 门禁通过。Beta 只发布不可变
-  版本 tag，因此 beta.15 不会更新 `latest`、`stable` 或其他稳定版 alias。
+容器 fan-out 在 `ubuntu-22.04` 上构建 `linux/amd64`，在
+`ubuntu-22.04-arm` 上构建 `linux/arm64`。两个 job 都验证了原生
+GitHub-hosted runner，在没有 QEMU 的情况下完成构建，并且只向 Docker Hub 和
+GHCR 推送无 tag、内容寻址的暂存 digest。暂存 digest 从未成为公开 beta.15 版本
+tag，也不是可独立发布的单架构正式版本。
 
-GitHub 预发布版、R2 更新数据源、容器 registry 与 Snap Store 仍是各自独立门禁的
-发布渠道。每个渠道都有严格的安全检查和恢复规则，但本版本不宣称跨渠道
-原子性。
+arm64 job 从两个 registry 匿名拉取精确暂存 digest，并分别通过完整 Server
+runtime smoke。随后元数据生成 fail-closed：解析器期待按 platform 分键的 image
+map，而 Docker Buildx 针对该单平台来源返回了官方定义的扁平 `.Image` 配置。
 
-## Snap beta 策略
+amd64 job 在第一个暂存 digest runtime smoke 中更早 fail-closed。本地确定性
+BitTorrent 任务未能在 180 秒内进入 `seeding` 或 `completed`。这是原生镜像已经
+构建并推送后的 smoke fixture 就绪失败，不是模拟构建失败。
 
-Snap 不属于 beta.15 的分发范围。受保护的预发布 Snap run 会在 source validation
-后停止，因此不会构建 Snap artifact、上传 Store revision 或修改 `latest/edge`。
-稳定版 Snap 发布仍保留完整的双架构验证与受保护 Store 门禁。
+两个平台 job 都没有上传经过验证的不可变元数据，因此 fan-in finalize job 没有
+运行。两个 registry 均没有获得不可变 `2.0.0-beta.15` tag 或最终
+multi-platform index。beta.15 index 未签名；最终跨 registry provenance、SBOM 和
+匿名签名集合未完成验证；最终公开原生 runtime 矩阵也未完成。`latest`、`stable`
+及其他稳定版容器 alias 均保持不变。
 
-## 主要变化
+GitHub 预发布版、R2 更新数据源、容器 registry 与 Snap Store 是各自独立门禁的
+发布渠道，不能把该结果描述为跨分发渠道的原子发布。`v2.0.0-beta.15` tag 保持
+不可变，不会移动或复用。修复由
+[Motrix 2.0.0-beta.16](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.16/docs/release-notes/2.0.0-beta.16.zh-CN.md)
+承载。
 
-- 使用 Electron 43、React 19 和 TypeScript 7 从头重建桌面应用，提供可自定义
-  Dashboard、深色模式、跨平台应用菜单，以及更清晰的任务检查器反馈。
-- 桌面应用和 Node/Web Server 共用与宿主无关的下载内核，支持 SQLite session
-  恢复、Tracker 管理、UPnP/NAT-PMP，以及 HTTP、FTP、BitTorrent 和磁力链接下载。
-- 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地发现及远程 Server 的
-  device-code 配对。
-- 提供带能力授权的 QuickJS 插件沙箱、内置插件和应用内插件市场。
-- 面向 NAS 和家庭服务器提供持久化多平台 Server 容器；只有完整原生架构集合
-  与所有公开验证门禁通过后才会发布。
+## 可用的 beta.15 下载
 
-## 测试前须知
-
-这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1 数据的
-迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
-
-条件允许时，建议通过独立系统账户、设备或 Docker 数据目录与现有环境并行测试 v2。
-请勿让本 beta 成为重要下载文件的唯一存储位置。
-
-## 建议测试项
-
-- HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
-- 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
-- Headless Server 部署、数据持久化、远程配对，以及原生 amd64 与 arm64 容器镜像
-
-## 发布门禁通过后的计划下载
-
-| 发布方式 | 架构 | 计划产物 |
-|----------|------|----------|
+| 发布方式 | 架构 | 已发布产物 |
+|----------|------|------------|
 | macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
 | Windows | `x64` | 未签名的 NSIS 安装包（`.exe`）和 ZIP |
 | Linux | `x64`、`arm64` | DEB 和 RPM |
 | Flatpak Native Host 配套程序 | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.15-linux-<arch>.tar.gz` |
-| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中不可变的 `2.0.0-beta.15` tag |
+| Docker Hub / GHCR | — | 没有 `2.0.0-beta.15` tag 或最终 index |
 | Snap Store | — | 本 beta 不发布 |
 
-全部容器门禁通过后，带版本镜像引用为
-`docker.io/motrixapp/motrix-server:2.0.0-beta.15` 和
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.15`。数据持久化、网络和升级方法请参阅
-[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.15/docs/docker-server.zh-CN.md)。
+请勿使用 `docker.io/motrixapp/motrix-server:2.0.0-beta.15` 或
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.15`：这些不可变版本 tag 并未发布。
+失败 workflow 留下的无 tag 暂存 digest 不是正式发布版本。
 
 ## 已知发布限制
 
 - 本 beta 不发布 AppImage。
-- Flatpak 会单独验证，不会随该版本 tag 发布；GitHub 预发布版会包含其 Native Host
+- Flatpak 会单独验证，不会随该版本 tag 发布；GitHub 预发布版包含其 Native Host
   配套程序压缩包。
 - 不提供 Windows `arm64` 和任何 32 位安装包。
-- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅在正式发布后
-  从 GitHub 官方预发布版下载。
-- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
-- 本 beta 不发布 Snap。预发布 Snap run 会在 source validation 后停止，不会构建
-  或发布 Snap artifact。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。
+- 本 beta 不发布 Snap。预发布 Snap run 在 source validation 后停止，没有构建或
+  发布 artifact。
 
 ## 反馈
 
-请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现的问题，并附上
-操作系统、架构、安装包类型和复现步骤。
+请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现的问题，
+并附上操作系统、架构、安装包类型和复现步骤。

--- a/docs/release-notes/2.0.0-beta.16.md
+++ b/docs/release-notes/2.0.0-beta.16.md
@@ -1,0 +1,139 @@
+# Motrix 2.0.0-beta.16
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.16/docs/release-notes/2.0.0-beta.16.zh-CN.md)
+
+Motrix 2.0.0-beta.16 is the next Motrix Turbo beta intended for public
+distribution only after every protected release gate passes. It repairs the
+two independent fail-closed container checks observed during beta.15 without
+moving or reusing the immutable `v2.0.0-beta.15` tag.
+
+The [beta.15 historical record](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.16/docs/release-notes/2.0.0-beta.15.md)
+documents the successful desktop, GitHub prerelease, and R2 distribution, the
+two successful native container builds, and the incomplete container result.
+
+## Container inspection and smoke recovery
+
+- Builds `linux/amd64` on `ubuntu-22.04` and `linux/arm64` on
+  `ubuntu-22.04-arm`. Each job verifies its GitHub-hosted Linux runner and
+  native architecture before Buildx starts. The container release path does
+  not install or invoke QEMU.
+- Validates Docker Buildx's documented flat image configuration for a
+  single-platform source and the platform-keyed form used by multi-platform
+  inspection. Missing, unexpected, multiple, ambiguous, or conflicting
+  platform data fails closed before metadata can be accepted.
+- Makes the local BitTorrent fixture prove through aria2 JSON-RPC that exactly
+  one active torrent has all bytes available, then proves the seeder port is
+  reachable from the Server container before creating the real download task.
+  Tracker mutation is exercised only after the transfer and file hash pass;
+  bounded failures report task, tracker, peer, and byte-progress diagnostics.
+- Pushes each successful platform only by its untagged, content-addressed OCI
+  digest to Docker Hub and GHCR. A single architecture never receives the
+  public version tag and cannot become the official release on its own.
+- Anonymously pulls the exact staged digest from both registries and runs the
+  full Server runtime smoke on its native runner. Immutable platform metadata
+  can be uploaded only after both registry smokes succeed.
+- Binds each platform record to the exact version, source commit, workflow run
+  and attempt, native runner identity, raw OCI index hash, image manifest,
+  attestation manifest, provenance, and SPDX SBOM.
+- Allows one finalize job to proceed only after the complete amd64/arm64 build
+  set succeeds. It rejects missing, duplicate, unexpected, cross-wired, shared,
+  or future-attempt digests before creating either versioned index.
+- Rechecks both immutable version tags immediately before finalization. A clean
+  run creates both indexes from the verified platform digests; a rerun resumes
+  an identical complete result or repairs one missing registry from the
+  verified existing index. Any conflicting immutable tag fails closed.
+- Requires Docker Hub and GHCR to expose the same final index digest, platform
+  manifests, and attestation manifests. It validates max-level BuildKit
+  provenance, the exact source revision and builder run, and a non-empty SPDX
+  SBOM for both architectures before signing.
+- Signs each final index digest with the exact protected tag-workflow identity,
+  verifies both signatures anonymously, and then runs the full public runtime
+  smoke on native amd64 and arm64 runners against both registries.
+- Stable floating aliases are handled by the final recovery-safe job only after
+  every build, index, signature, provenance, SBOM, anonymous pull, and runtime
+  gate succeeds. Beta releases publish only their immutable version tag, so
+  beta.16 does not update `latest`, `stable`, or another stable alias.
+
+The GitHub prerelease, R2 update feed, container registries, and Snap Store
+remain independently gated publication channels. Their individual safety and
+recovery rules are strict, but this release does not claim cross-channel
+atomicity.
+
+## Snap beta policy
+
+Snap is not part of the beta.16 distribution. Protected prerelease Snap runs
+stop after source validation, so they do not build Snap artifacts, upload Store
+revisions, or change `latest/edge`. Stable Snap publication retains its
+complete two-architecture verification and protected Store gates.
+
+## Highlights
+
+- A ground-up desktop rebuild with Electron 43, React 19, and TypeScript 7,
+  including a customizable Dashboard, dark mode, a cross-platform application
+  menu, and clearer task-inspector feedback.
+- One host-neutral download core for both the desktop app and the Node/Web
+  Server, with SQLite session recovery, tracker management, UPnP/NAT-PMP, and
+  HTTP, FTP, BitTorrent, and magnet support.
+- MDXP-based integration for the official CLI and browser handoff, including
+  local discovery and device-code pairing for remote Server instances.
+- A QuickJS plugin sandbox with capability consent, bundled builtin plugins,
+  and an in-app plugin marketplace.
+- Persistent multi-platform Server containers for NAS and home-server
+  deployments, published only after the complete native architecture set and
+  every public verification gate pass.
+
+## Before testing
+
+This is prerelease software. Back up your existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Do not rely on this beta for your only copy of important
+downloads.
+
+## What to test
+
+- HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
+  session recovery
+- Desktop integrations, browser and CLI handoff through MDXP, and sandboxed
+  plugins
+- Headless Server deployment, persistent storage, remote pairing, and native
+  amd64 and arm64 container images
+
+## Planned downloads after release gates pass
+
+| Distribution | Architectures | Planned output |
+|--------------|---------------|----------------|
+| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | DEB and RPM |
+| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.16-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.16` tag in both registries |
+| Snap Store | — | Not published for this beta |
+
+After every container gate passes, the versioned image references will be
+`docker.io/motrixapp/motrix-server:2.0.0-beta.16` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.16`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.16/docs/docker-server.md)
+for storage, networking, and upgrade guidance.
+
+## Known distribution limits
+
+- AppImage is not published for this beta.
+- Flatpak is validated separately and is not published by the release tag;
+  the GitHub prerelease includes its Native Host companion archives.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
+  Download them only from the official GitHub prerelease after it is published.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+- Snap is not published for this beta. Prerelease Snap runs stop after source
+  validation without building or publishing Snap artifacts.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.16.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.16.zh-CN.md
@@ -1,0 +1,114 @@
+# Motrix 2.0.0-beta.16
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.16/docs/release-notes/2.0.0-beta.16.md) | 简体中文
+
+Motrix 2.0.0-beta.16 是下一次计划公开发布的 Motrix Turbo beta，只有全部受保护
+发布门禁通过后才会进入分发。它修复 beta.15 中两项相互独立的 fail-closed 容器
+检查，不会移动或复用不可变的 `v2.0.0-beta.15` tag。
+
+[beta.15 历史记录](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.16/docs/release-notes/2.0.0-beta.15.zh-CN.md)
+准确记录了已成功的桌面、GitHub 预发布版与 R2 分发、两个已成功的原生容器构建，
+以及未完成的容器结果。
+
+## 容器检查与 smoke 恢复
+
+- `linux/amd64` 固定在 `ubuntu-22.04` 构建，`linux/arm64` 固定在
+  `ubuntu-22.04-arm` 构建。每个 job 都会在 Buildx 启动前验证 GitHub-hosted
+  Linux runner 及其原生架构；容器发布路径不安装或调用 QEMU。
+- 验证 Docker Buildx 为单平台来源定义的扁平 image 配置，同时支持多平台检查使用
+  的按 platform 分键形式。缺失、意外、多个、歧义或相互冲突的 platform 数据均会
+  在元数据被接受前 fail-closed。
+- 本地 BitTorrent fixture 先通过 aria2 JSON-RPC 证明恰好一个 active torrent 已
+  备齐全部字节，再从 Server 容器验证 seeder 端口可达，然后才创建真实下载任务。
+  只有传输和文件哈希通过后才测试 Tracker 修改；有界失败会报告任务、Tracker、
+  peer 与字节进度诊断，不用重试掩盖错误。
+- 每个平台成功后只按无 tag、内容寻址的 OCI digest 推送到 Docker Hub 和 GHCR。
+  单一架构不会获得公开版本 tag，不能独立成为正式发布版本。
+- 在原生 runner 上从两个 registry 匿名拉取精确的暂存 digest，并运行完整 Server
+  runtime smoke。只有两个 registry smoke 都成功后，才能上传不可变平台元数据。
+- 每份平台记录绑定精确版本、源码 commit、workflow run 与 attempt、原生 runner
+  身份、原始 OCI index 哈希、image manifest、attestation manifest、provenance
+  和 SPDX SBOM。
+- 只有 amd64/arm64 完整构建集合成功后，唯一的 finalize job 才能继续。创建任一
+  带版本 index 前，它会拒绝缺失、重复、意外、架构串线、共用或未来 attempt
+  digest。
+- Finalize 前立即重新检查两个不可变版本 tag。全新发布从已验证平台 digest 创建
+  两个 index；续跑可以接受完全一致的已有结果，或从已验证的现有 index 修复缺失
+  的 registry。任何冲突的不可变 tag 都会 fail-closed。
+- Docker Hub 和 GHCR 必须公开相同的最终 index digest、platform manifest 与
+  attestation manifest；签名前还会验证两个架构的 max-level BuildKit
+  provenance、精确源码 revision 与 builder run，以及非空 SPDX SBOM。
+- 使用精确的受保护 tag-workflow 身份签名两个最终 index digest，匿名验证两个
+  签名，然后在原生 amd64 和 arm64 runner 上针对两个 registry 运行完整公开
+  runtime smoke。
+- 稳定版浮动 alias 只由最后一个可恢复 job 处理，且必须等到全部构建、index、
+  签名、provenance、SBOM、匿名拉取和 runtime 门禁通过。Beta 只发布不可变版本
+  tag，因此 beta.16 不会更新 `latest`、`stable` 或其他稳定版 alias。
+
+GitHub 预发布版、R2 更新数据源、容器 registry 与 Snap Store 仍是各自独立门禁的
+发布渠道。每个渠道都有严格的安全检查和恢复规则，但本版本不宣称跨渠道原子性。
+
+## Snap beta 策略
+
+Snap 不属于 beta.16 的分发范围。受保护的预发布 Snap run 会在 source validation
+后停止，因此不会构建 Snap artifact、上传 Store revision 或修改 `latest/edge`。
+稳定版 Snap 发布仍保留完整的双架构验证与受保护 Store 门禁。
+
+## 主要变化
+
+- 使用 Electron 43、React 19 和 TypeScript 7 从头重建桌面应用，提供可自定义
+  Dashboard、深色模式、跨平台应用菜单，以及更清晰的任务检查器反馈。
+- 桌面应用和 Node/Web Server 共用与宿主无关的下载内核，支持 SQLite session
+  恢复、Tracker 管理、UPnP/NAT-PMP，以及 HTTP、FTP、BitTorrent 和磁力链接下载。
+- 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地发现及远程 Server 的
+  device-code 配对。
+- 提供带能力授权的 QuickJS 插件沙箱、内置插件和应用内插件市场。
+- 面向 NAS 和家庭服务器提供持久化多平台 Server 容器；只有完整原生架构集合与
+  所有公开验证门禁通过后才会发布。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1 数据的
+迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
+
+条件允许时，建议通过独立系统账户、设备或 Docker 数据目录与现有环境并行测试 v2。
+请勿让本 beta 成为重要下载文件的唯一存储位置。
+
+## 建议测试项
+
+- HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
+- 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
+- Headless Server 部署、数据持久化、远程配对，以及原生 amd64 与 arm64 容器镜像
+
+## 发布门禁通过后的计划下载
+
+| 发布方式 | 架构 | 计划产物 |
+|----------|------|----------|
+| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
+| Windows | `x64` | 未签名的 NSIS 安装包（`.exe`）和 ZIP |
+| Linux | `x64`、`arm64` | DEB 和 RPM |
+| Flatpak Native Host 配套程序 | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.16-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中不可变的 `2.0.0-beta.16` tag |
+| Snap Store | — | 本 beta 不发布 |
+
+全部容器门禁通过后，带版本镜像引用为
+`docker.io/motrixapp/motrix-server:2.0.0-beta.16` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.16`。数据持久化、网络和升级方法请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.16/docs/docker-server.zh-CN.md)。
+
+## 已知发布限制
+
+- 本 beta 不发布 AppImage。
+- Flatpak 会单独验证，不会随该版本 tag 发布；GitHub 预发布版会包含其 Native Host
+  配套程序压缩包。
+- 不提供 Windows `arm64` 和任何 32 位安装包。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅在正式发布后
+  从 GitHub 官方预发布版下载。
+- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
+- 本 beta 不发布 Snap。预发布 Snap run 会在 source validation 后停止，不会构建
+  或发布 Snap artifact。
+
+## 反馈
+
+请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现的问题，
+并附上操作系统、架构、安装包类型和复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -76,17 +76,31 @@
   <releases>
     <!-- Update this list on every release; Flathub linter requires the most
          recent version listed here to match the manifest's source tag. -->
+    <release version="2.0.0-beta.16" date="2026-08-16">
+      <description>
+        <p>
+          Single-platform metadata validation now accepts Docker Buildx's
+          documented flat image configuration while rejecting missing,
+          ambiguous, or conflicting platform data. The native BitTorrent smoke
+          waits for a complete aria2 seeder through JSON-RPC and verifies local
+          peer reachability before starting a real transfer. Native fan-out,
+          cross-registry index, provenance, SBOM, signature, and public runtime
+          gates remain fail-closed. Windows packages remain unsigned.
+          Prerelease Snap runs stop after source validation.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.15" date="2026-08-16">
       <description>
         <p>
-          Native staged-digest smoke tests now use Docker CLI syntax supported
-          by both GitHub runner architectures after a platform-pinned pull,
-          while retaining an exact architecture assertion and platform-pinned
-          runtime containers. The complete native fan-out, cross-registry
-          index, provenance, SBOM, signature, and public runtime gates remain
-          fail-closed. Windows packages remain unsigned. Prerelease Snap runs
-          stop after source validation without building or publishing
-          artifacts.
+          The desktop packages, GitHub prerelease, and R2 update feed completed.
+          Native amd64 and arm64 Server builds pushed only untagged staged
+          digests. Both arm64 registry smokes passed before metadata validation
+          rejected Docker Buildx's flat single-platform image configuration;
+          the amd64 smoke separately timed out in its local BitTorrent fixture.
+          No beta.15 container tag or final index was published or signed, and
+          stable aliases remained unchanged. Windows packages were unsigned;
+          the prerelease Snap run stopped after source validation.
         </p>
       </description>
     </release>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.15",
+  "version": "2.0.0-beta.16",
   "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1",
   "description": "A full-featured download manager",
   "keywords": [],

--- a/scripts/container-platform-metadata.mjs
+++ b/scripts/container-platform-metadata.mjs
@@ -107,6 +107,67 @@ function platformParts(platform) {
   return { architecture, os }
 }
 
+function resolveInspectedImage(images, repository, platform) {
+  const flatFields = ['architecture', 'config', 'os']
+  const isFlatImage = flatFields.some((field) => Object.hasOwn(images, field))
+  const platformKeys = Object.keys(images).filter((key) => key.includes('/'))
+  if (isFlatImage) {
+    if (platformKeys.length > 0) {
+      throw new Error(`${repository} inspection image shape is ambiguous`)
+    }
+    return images
+  }
+
+  const expectedKeys = Object.keys(images).filter(
+    (key) => key !== 'unknown/unknown'
+  )
+  if (expectedKeys.length !== 1 || expectedKeys[0] !== platform) {
+    throw new Error(`${repository} inspection must contain exactly ${platform}`)
+  }
+  return requireRecord(
+    images[platform],
+    `${repository} ${platform} inspected image`
+  )
+}
+
+function requireInspectedPlatform(image, repository, platform) {
+  const expected = platformParts(platform)
+  const observed = []
+  if (Object.hasOwn(image, 'architecture') || Object.hasOwn(image, 'os')) {
+    observed.push({
+      architecture: requireString(
+        image.architecture,
+        `${repository} inspected image architecture`
+      ),
+      os: requireString(image.os, `${repository} inspected image OS`),
+    })
+  }
+  if (image.platform !== undefined) {
+    const nested = requireRecord(
+      image.platform,
+      `${repository} inspected image platform`
+    )
+    observed.push({
+      architecture: requireString(
+        nested.architecture,
+        `${repository} inspected platform architecture`
+      ),
+      os: requireString(nested.os, `${repository} inspected platform OS`),
+    })
+  }
+  if (observed.length === 0) {
+    throw new Error(`${repository} inspected image platform is missing`)
+  }
+  if (
+    observed.some(
+      (value) =>
+        value.architecture !== expected.architecture || value.os !== expected.os
+    )
+  ) {
+    throw new Error(`${repository} inspected platform conflicts`)
+  }
+}
+
 function inspectPlatformIndex(bytes, repository, platform, sourceDigest) {
   const candidates = [bytes]
   if (bytes.at(-1) === 0x0a) candidates.push(bytes.subarray(0, -1))
@@ -192,16 +253,8 @@ function inspectPlatformConfig(
     throw new Error(`${repository} inspected digest conflicts`)
   }
   const images = requireRecord(document.image, `${repository} inspected images`)
-  const expectedKeys = Object.keys(images).filter(
-    (key) => key !== 'unknown/unknown'
-  )
-  if (expectedKeys.length !== 1 || expectedKeys[0] !== platform) {
-    throw new Error(`${repository} inspection must contain exactly ${platform}`)
-  }
-  const image = requireRecord(
-    images[platform],
-    `${repository} ${platform} image`
-  )
+  const image = resolveInspectedImage(images, repository, platform)
+  requireInspectedPlatform(image, repository, platform)
   const config = requireRecord(image.config, `${repository} ${platform} config`)
   if (config.User !== 'node') {
     throw new Error(`${repository} ${platform} default user is not node`)
@@ -213,16 +266,6 @@ function inspectPlatformConfig(
   for (const [key, expected] of Object.entries(labels)) {
     if (actualLabels[key] !== expected) {
       throw new Error(`${repository} ${platform} label ${key} conflicts`)
-    }
-  }
-  const observedPlatform = image.platform
-  if (observedPlatform !== undefined) {
-    const { architecture, os } = platformParts(platform)
-    if (
-      observedPlatform.architecture !== architecture ||
-      observedPlatform.os !== os
-    ) {
-      throw new Error(`${repository} inspected platform conflicts`)
     }
   }
 }

--- a/scripts/smoke-server-image.mjs
+++ b/scripts/smoke-server-image.mjs
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process'
-import { createHash } from 'node:crypto'
+import { createHash, randomBytes } from 'node:crypto'
 import {
   chmod,
   cp,
@@ -28,6 +28,7 @@ const MAX_LOG_BYTES = 256 * 1024
 const PROJECT_ROOT = fileURLToPath(new URL('..', import.meta.url))
 const HTTP_FIXTURE_NAME = 'motrix-http-smoke.bin'
 const PLUGIN_ID = 'test.demo-config'
+const SEEDER_RPC_PORT = 16_801
 const PLUGIN_FIXTURE = path.join(
   PROJECT_ROOT,
   'tests/fixtures/moext/test.demo-config-1.0.0.moext'
@@ -44,6 +45,24 @@ const TORRENT_DATA_FILE = path.join(TORRENT_DATA_ROOT, 'test.bin')
 const HTTP_FIXTURE = Buffer.from(
   'Motrix Docker Server persistent HTTP fixture\n'.repeat(16_384)
 )
+const SEEDER_STATUS_PROBE = [
+  "const response = await fetch('http://127.0.0.1:' + process.env.MOTRIX_SEEDER_RPC_PORT + '/jsonrpc', {",
+  "method: 'POST',",
+  "headers: {'content-type': 'application/json'},",
+  "body: JSON.stringify({jsonrpc: '2.0', id: 'seed-status', method: 'aria2.tellActive', params: ['token:' + process.env.MOTRIX_SEEDER_RPC_SECRET, ['gid', 'status', 'totalLength', 'completedLength', 'bittorrent']]})",
+  '})',
+  "if (!response.ok) throw new Error('Seeder RPC returned ' + response.status)",
+  'console.log(await response.text())',
+].join('\n')
+const TCP_PROBE = [
+  "import { connect } from 'node:net'",
+  'await new Promise((resolve, reject) => {',
+  'const socket = connect({host: process.env.MOTRIX_SEEDER_HOST, port: Number(process.env.MOTRIX_SEEDER_PORT)})',
+  "const timer = setTimeout(() => socket.destroy(new Error('Seeder TCP probe timed out')), 5000)",
+  "socket.once('connect', () => { clearTimeout(timer); socket.end(); resolve() })",
+  "socket.once('error', (error) => { clearTimeout(timer); reject(error) })",
+  '})',
+].join(';')
 
 function platformArgs(platform) {
   return platform ? ['--platform', platform] : []
@@ -152,6 +171,84 @@ async function waitForExit(name, timeoutMs) {
     await delay(100)
   }
   throw new Error(`Container ${name} did not exit within ${timeoutMs}ms`)
+}
+
+async function querySeederDownloads(name, rpcSecret) {
+  const output = await docker([
+    'exec',
+    '--env',
+    `MOTRIX_SEEDER_RPC_PORT=${SEEDER_RPC_PORT}`,
+    '--env',
+    `MOTRIX_SEEDER_RPC_SECRET=${rpcSecret}`,
+    name,
+    'node',
+    '--input-type=module',
+    '--eval',
+    SEEDER_STATUS_PROBE,
+  ])
+  const response = JSON.parse(output)
+  if (response.error) {
+    throw new Error(`Seeder RPC failed: ${JSON.stringify(response.error)}`)
+  }
+  if (!Array.isArray(response.result)) {
+    throw new Error(`Seeder RPC returned invalid result: ${output}`)
+  }
+  return response.result
+}
+
+async function waitForSeeder(name, rpcSecret, timeoutMs) {
+  const deadline = Date.now() + Math.min(timeoutMs, 30_000)
+  let lastStatus = 'RPC unavailable'
+  while (Date.now() < deadline) {
+    const exited = await containerExited(name)
+    if (exited) {
+      throw new Error(`Seeder exited before readiness: code=${exited.ExitCode}`)
+    }
+    try {
+      const downloads = await querySeederDownloads(name, rpcSecret)
+      if (downloads.length !== 1) {
+        lastStatus = `active downloads=${downloads.length}`
+      } else {
+        const [download] = downloads
+        lastStatus = JSON.stringify({
+          completedLength: download.completedLength,
+          gid: download.gid,
+          status: download.status,
+          totalLength: download.totalLength,
+        })
+        if (
+          download.status === 'active' &&
+          download.bittorrent &&
+          /^[1-9][0-9]*$/.test(download.totalLength) &&
+          download.completedLength === download.totalLength
+        ) {
+          return download
+        }
+      }
+    } catch (error) {
+      lastStatus = error instanceof Error ? error.message : String(error)
+    }
+    await delay(200)
+  }
+  throw new Error(`Seeder did not become ready: ${lastStatus}`)
+}
+
+async function assertSeederReachable(name, seedIp, timeoutMs) {
+  await docker(
+    [
+      'exec',
+      '--env',
+      `MOTRIX_SEEDER_HOST=${seedIp}`,
+      '--env',
+      'MOTRIX_SEEDER_PORT=6881',
+      name,
+      'node',
+      '--input-type=module',
+      '--eval',
+      TCP_PROBE,
+    ],
+    { timeout: Math.min(timeoutMs, 10_000) }
+  )
 }
 
 async function requestJson(url, options = {}, expectedStatus) {
@@ -519,9 +616,11 @@ async function assertRuntimeContract(name, url, token, identity, timeoutMs) {
 
 async function waitForTask(url, token, taskId, accepted, timeoutMs) {
   const deadline = Date.now() + timeoutMs
+  let lastTask
   while (Date.now() < deadline) {
     const tasks = await rpc(url, token, 'query', 'query:listTasks')
     const task = tasks.find((candidate) => candidate.id === taskId)
+    lastTask = task
     if (task?.status === 'error') {
       throw new Error(
         `task ${taskId} failed: ${task.errorMessage ?? task.errorCode ?? 'unknown'}`
@@ -530,7 +629,20 @@ async function waitForTask(url, token, taskId, accepted, timeoutMs) {
     if (task && accepted.has(task.status)) return task
     await delay(250)
   }
-  throw new Error(`task ${taskId} did not reach ${[...accepted].join('/')}`)
+  const progress = lastTask
+    ? {
+        downloadedBytes: lastTask.downloadedBytes,
+        downloadSpeed: lastTask.downloadSpeed,
+        engineTaskId: lastTask.engineTaskId,
+        progress: lastTask.progress,
+        status: lastTask.status,
+        totalBytes: lastTask.totalBytes,
+        uploadSpeed: lastTask.uploadSpeed,
+      }
+    : { status: 'missing' }
+  throw new Error(
+    `task ${taskId} did not reach ${[...accepted].join('/')}; last=${JSON.stringify(progress)}`
+  )
 }
 
 async function assertHostFile(target, expected) {
@@ -752,6 +864,7 @@ export async function smokeServerImage(options) {
       trackerUrl
     )
     const seedRoot = path.join(tempRoot, 'seed')
+    const seederRpcSecret = randomBytes(24).toString('hex')
     await mkdir(seedRoot)
     await cp(TORRENT_DATA_ROOT, path.join(seedRoot, 'sample-data'), {
       recursive: true,
@@ -779,6 +892,10 @@ export async function smokeServerImage(options) {
       '--enable-dht6=false',
       '--bt-enable-lpd=false',
       '--enable-peer-exchange=false',
+      '--enable-rpc=true',
+      '--rpc-listen-all=false',
+      `--rpc-listen-port=${SEEDER_RPC_PORT}`,
+      `--rpc-secret=${seederRpcSecret}`,
       '--allow-overwrite=true',
       '--check-integrity=true',
       '--file-allocation=none',
@@ -790,6 +907,7 @@ export async function smokeServerImage(options) {
       '/seed/sample.torrent',
     ])
     seedCreated = true
+    await waitForSeeder(seedName, seederRpcSecret, timeoutMs)
     const seedIp = await docker([
       'inspect',
       '--format',
@@ -816,6 +934,7 @@ export async function smokeServerImage(options) {
       identity,
       timeoutMs
     )
+    await assertSeederReachable(appName, seedIp, timeoutMs)
 
     if (mode === 'health') {
       await stopServer(appName, timeoutMs)
@@ -888,11 +1007,7 @@ export async function smokeServerImage(options) {
         displayName: 'sample-data',
       }
     )
-    await rpc(url, operatorToken, 'command', 'command:setTaskBtTracker', {
-      engineGid: btTask.gid,
-      trackers: [trackerUrl],
-    })
-    await waitForTask(
+    const finalBtTask = await waitForTask(
       url,
       operatorToken,
       btTask.taskId,
@@ -903,6 +1018,10 @@ export async function smokeServerImage(options) {
       path.join(volumes.downloadsDir, 'sample-data', 'sample-data', 'test.bin'),
       await readFile(TORRENT_DATA_FILE)
     )
+    await rpc(url, operatorToken, 'command', 'command:setTaskBtTracker', {
+      engineGid: finalBtTask.engineTaskId,
+      trackers: [trackerUrl],
+    })
     if (
       fixtureServer.trackerAnnounces() < 2 ||
       fixtureServer.trackerPeerIds().size < 2
@@ -1068,6 +1187,8 @@ export async function smokeServerImage(options) {
       : ''
     const message = error instanceof Error ? error.message : String(error)
     const logs = [
+      seedCreated &&
+        `Fixture tracker: announces=${fixtureServer.trackerAnnounces()} peerIds=${fixtureServer.trackerPeerIds().size}`,
       appLogs && `Server logs:\n${appLogs}`,
       seedLogs && `Seeder logs:\n${seedLogs}`,
     ]

--- a/tests/scripts/container-platform-metadata.test.ts
+++ b/tests/scripts/container-platform-metadata.test.ts
@@ -81,7 +81,10 @@ function verify(directory: string, maximumBuilderAttempt = 3) {
   })
 }
 
-function platformPublication(platform: 'linux/amd64' | 'linux/arm64') {
+function platformPublication(
+  platform: 'linux/amd64' | 'linux/arm64',
+  imageShape: 'flat' | 'platform-map' = 'flat'
+) {
   const architecture = platform.split('/')[1]
   const imageDigest = IMAGE_DIGESTS[platform]
   const attestationDigest = ATTESTATION_DIGESTS[platform]
@@ -110,21 +113,29 @@ function platformPublication(platform: 'linux/amd64' | 'linux/arm64') {
     })
   )
   const digest = `sha256:${createHash('sha256').update(index).digest('hex')}`
-  const inspect = {
-    manifest: { digest },
-    image: {
-      [platform]: {
-        config: {
-          User: 'node',
-          Labels: {
-            ...CONTAINER_LABELS,
-            'org.opencontainers.image.revision': REVISION,
-            'org.opencontainers.image.version': VERSION,
-          },
-        },
-        platform: { architecture, os: 'linux' },
+  const image = {
+    architecture,
+    os: 'linux',
+    config: {
+      User: 'node',
+      Labels: {
+        ...CONTAINER_LABELS,
+        'org.opencontainers.image.revision': REVISION,
+        'org.opencontainers.image.version': VERSION,
       },
     },
+  }
+  const inspect = {
+    manifest: { digest },
+    image:
+      imageShape === 'flat'
+        ? image
+        : {
+            [platform]: {
+              config: image.config,
+              platform: { architecture, os: 'linux' },
+            },
+          },
   }
   return { attestationDigest, digest, imageDigest, index, inspect }
 }
@@ -200,12 +211,30 @@ describe('container platform metadata', () => {
     })
   })
 
+  it('accepts the documented platform-keyed Image shape from a multi-platform inspection', () => {
+    const artifact = platformPublication('linux/amd64', 'platform-map')
+    expect(
+      inspectContainerPlatformPublication({
+        digest: artifact.digest,
+        dockerHubIndex: artifact.index,
+        dockerHubInspect: artifact.inspect,
+        ghcrIndex: artifact.index,
+        ghcrInspect: artifact.inspect,
+        platform: 'linux/amd64',
+        revision: REVISION,
+        version: VERSION,
+      })
+    ).toEqual({
+      imageDigest: artifact.imageDigest,
+      attestationDigest: artifact.attestationDigest,
+    })
+  })
+
   it('rejects a platform inspection with a conflicting source revision', () => {
     const artifact = platformPublication('linux/amd64')
     const conflicting = structuredClone(artifact.inspect)
-    conflicting.image['linux/amd64'].config.Labels[
-      'org.opencontainers.image.revision'
-    ] = '1'.repeat(40)
+    conflicting.image.config.Labels['org.opencontainers.image.revision'] =
+      '1'.repeat(40)
     expect(() =>
       inspectContainerPlatformPublication({
         digest: artifact.digest,
@@ -218,6 +247,47 @@ describe('container platform metadata', () => {
         version: VERSION,
       })
     ).toThrow(/label .* conflicts/)
+  })
+
+  it.each([
+    [
+      'wrong flat architecture',
+      (inspect: { image: Record<string, unknown> }) => {
+        inspect.image.architecture = 'arm64'
+      },
+      /platform conflicts/,
+    ],
+    [
+      'missing flat platform',
+      (inspect: { image: Record<string, unknown> }) => {
+        delete inspect.image.architecture
+        delete inspect.image.os
+      },
+      /platform is missing/,
+    ],
+    [
+      'ambiguous flat and mapped shape',
+      (inspect: { image: Record<string, unknown> }) => {
+        inspect.image['linux/amd64'] = structuredClone(inspect.image)
+      },
+      /shape is ambiguous/,
+    ],
+  ])('rejects a %s inspection', (_, mutate, error) => {
+    const artifact = platformPublication('linux/amd64')
+    const conflicting = structuredClone(artifact.inspect)
+    mutate(conflicting)
+    expect(() =>
+      inspectContainerPlatformPublication({
+        digest: artifact.digest,
+        dockerHubIndex: artifact.index,
+        dockerHubInspect: conflicting,
+        ghcrIndex: artifact.index,
+        ghcrInspect: artifact.inspect,
+        platform: 'linux/amd64',
+        revision: REVISION,
+        version: VERSION,
+      })
+    ).toThrow(error)
   })
 
   it.each([

--- a/tests/scripts/docker-server-runtime.test.ts
+++ b/tests/scripts/docker-server-runtime.test.ts
@@ -147,6 +147,31 @@ describe('Docker Server runtime staging contract', () => {
     expect(imageSmoke).toContain(
       "metadata.Architecture !== platform.split('/')[1]"
     )
+    expect(imageSmoke).toContain("method: 'aria2.tellActive'")
+    expect(imageSmoke).toContain("download.status === 'active'")
+    expect(imageSmoke).toContain(
+      'download.completedLength === download.totalLength'
+    )
+    expect(imageSmoke).toContain("'--enable-rpc=true'")
+    expect(imageSmoke).toContain(
+      'await waitForSeeder(seedName, seederRpcSecret, timeoutMs)'
+    )
+    expect(imageSmoke).toContain(
+      'await assertSeederReachable(appName, seedIp, timeoutMs)'
+    )
+    expect(
+      imageSmoke.indexOf(
+        'await waitForSeeder(seedName, seederRpcSecret, timeoutMs)'
+      )
+    ).toBeLessThan(imageSmoke.indexOf('fixtureServer.setTrackerPeer'))
+    expect(imageSmoke.indexOf("'command:setTaskBtTracker'")).toBeGreaterThan(
+      imageSmoke.indexOf("new Set(['seeding', 'completed'])")
+    )
+    expect(imageSmoke).toContain('engineGid: finalBtTask.engineTaskId')
+    expect(imageSmoke).toContain("randomBytes(24).toString('hex')")
+    expect(imageSmoke).toContain('downloadedBytes: lastTask.downloadedBytes')
+    expect(imageSmoke).toContain('totalBytes: lastTask.totalBytes')
+    expect(imageSmoke).toContain('Fixture tracker: announces=')
     expect(imageSmoke).toContain('identity.user')
     expect(imageSmoke).toContain("'command:createTask'")
     expect(imageSmoke).toContain("'command:setTaskBtTracker'")

--- a/tests/scripts/release-version-contract.test.ts
+++ b/tests/scripts/release-version-contract.test.ts
@@ -591,9 +591,9 @@ describe('release version contract', () => {
     expect(beta12Metainfo).not.toMatch(secretLikeIdentifier)
   })
 
-  it('ships beta.15 Docker smoke compatibility recovery without weakening native gates', () => {
-    const english = read('docs/release-notes/2.0.0-beta.15.md')
-    const chinese = read('docs/release-notes/2.0.0-beta.15.zh-CN.md')
+  it('ships beta.16 inspection and BitTorrent recovery without weakening native gates', () => {
+    const english = read('docs/release-notes/2.0.0-beta.16.md')
+    const chinese = read('docs/release-notes/2.0.0-beta.16.zh-CN.md')
     const normalizedEnglish = english
       .replace(/^>\s?/gm, '')
       .replace(/\s+/g, ' ')
@@ -601,11 +601,11 @@ describe('release version contract', () => {
       .replace(/^>\s?/gm, '')
       .replace(/\s+/g, ' ')
     const metainfo = read('flatpak/app.motrix.native.metainfo.xml')
-    const beta15Metainfo =
-      /<release version="2\.0\.0-beta\.15"[\s\S]*?<\/release>/.exec(
+    const beta16Metainfo =
+      /<release version="2\.0\.0-beta\.16"[\s\S]*?<\/release>/.exec(
         metainfo
       )?.[0] ?? ''
-    const normalizedBeta15Metainfo = beta15Metainfo.replace(/\s+/g, ' ')
+    const normalizedBeta16Metainfo = beta16Metainfo.replace(/\s+/g, ' ')
 
     expect(normalizedEnglish).toContain(
       'Builds `linux/amd64` on `ubuntu-22.04` and `linux/arm64` on `ubuntu-22.04-arm`'
@@ -614,10 +614,19 @@ describe('release version contract', () => {
       'The container release path does not install or invoke QEMU'
     )
     expect(normalizedEnglish).toContain(
-      'explicitly pulls its staged digest with the required platform, then inspects the selected local image using the Docker CLI syntax supported by both GitHub runner images'
+      "Validates Docker Buildx's documented flat image configuration for a single-platform source and the platform-keyed form used by multi-platform inspection"
     )
     expect(normalizedEnglish).toContain(
-      'fails closed unless the inspected image architecture exactly matches the matrix platform'
+      'Missing, unexpected, multiple, ambiguous, or conflicting platform data fails closed'
+    )
+    expect(normalizedEnglish).toContain(
+      'exactly one active torrent has all bytes available'
+    )
+    expect(normalizedEnglish).toContain(
+      'proves the seeder port is reachable from the Server container before creating the real download task'
+    )
+    expect(normalizedEnglish).toContain(
+      'Tracker mutation is exercised only after the transfer and file hash pass'
     )
     expect(normalizedEnglish).toContain(
       'A single architecture never receives the public version tag and cannot become the official release on its own'
@@ -642,13 +651,99 @@ describe('release version contract', () => {
     )
     expect(normalizedChinese).toContain('容器发布路径不安装或调用 QEMU')
     expect(normalizedChinese).toContain(
-      'architecture 必须与矩阵 platform 完全一致'
+      '缺失、意外、多个、歧义或相互冲突的 platform 数据均会 在元数据被接受前 fail-closed'
+    )
+    expect(normalizedChinese).toContain(
+      '恰好一个 active torrent 已 备齐全部字节'
+    )
+    expect(normalizedChinese).toContain(
+      '有界失败会报告任务、Tracker、 peer 与字节进度诊断，不用重试掩盖错误'
     )
     expect(normalizedChinese).toMatch(
       /全部构建、index、\s*签名、provenance、SBOM、匿名拉取和 runtime 门禁通过/u
     )
     expect(normalizedChinese).toMatch(/本版本不宣称跨渠道\s*原子性/u)
     for (const source of [english, chinese]) {
+      expect(source).toContain('Snap')
+      expect(source).toContain('latest/edge')
+      expect(source).toContain('AppImage')
+      expect(source).toContain('Flatpak')
+      expect(source).toContain(
+        'Motrix-Native-Host-2.0.0-beta.16-linux-<arch>.tar.gz'
+      )
+      expect(source).toContain('SmartScreen')
+      expect(source).toContain(
+        'docker.io/motrixapp/motrix-server:2.0.0-beta.16'
+      )
+      expect(source).toContain('ghcr.io/agalwood/motrix-server:2.0.0-beta.16')
+      expect(source).not.toMatch(restrictedPublicLanguage)
+      expect(source).not.toMatch(secretLikeIdentifier)
+    }
+    expect(normalizedBeta16Metainfo).toContain(
+      "accepts Docker Buildx's documented flat image configuration while rejecting missing, ambiguous, or conflicting platform data"
+    )
+    expect(normalizedBeta16Metainfo).toContain(
+      'waits for a complete aria2 seeder through JSON-RPC and verifies local peer reachability before starting a real transfer'
+    )
+    expect(beta16Metainfo).not.toMatch(restrictedPublicLanguage)
+    expect(beta16Metainfo).not.toMatch(secretLikeIdentifier)
+  })
+
+  it('records beta.15 desktop/feed success and two fail-closed native container checks', () => {
+    const english = read('docs/release-notes/2.0.0-beta.15.md')
+    const chinese = read('docs/release-notes/2.0.0-beta.15.zh-CN.md')
+    const normalizedEnglish = english
+      .replace(/^>\s?/gm, '')
+      .replace(/\s+/g, ' ')
+    const normalizedChinese = chinese
+      .replace(/^>\s?/gm, '')
+      .replace(/\s+/g, ' ')
+    const metainfo = read('flatpak/app.motrix.native.metainfo.xml')
+    const beta15Metainfo =
+      /<release version="2\.0\.0-beta\.15"[\s\S]*?<\/release>/.exec(
+        metainfo
+      )?.[0] ?? ''
+    const normalizedBeta15Metainfo = beta15Metainfo.replace(/\s+/g, ' ')
+
+    expect(normalizedEnglish).toContain(
+      'Motrix 2.0.0-beta.15 was partially distributed'
+    )
+    expect(normalizedEnglish).toContain(
+      'all five desktop builds, all three Finalize jobs, assembly, the GitHub prerelease, and the R2 update feed completed successfully'
+    )
+    expect(normalizedEnglish).toContain(
+      'The arm64 job anonymously pulled its exact staged digest from both registries and passed the complete Server runtime smoke in each case'
+    )
+    expect(normalizedEnglish).toContain(
+      'Docker Buildx returned the documented flat `.Image` configuration for this single-platform source'
+    )
+    expect(normalizedEnglish).toContain(
+      'Its deterministic local BitTorrent task did not reach `seeding` or `completed` within 180 seconds'
+    )
+    expect(normalizedEnglish).toContain(
+      'Neither registry received an immutable `2.0.0-beta.15` tag or final multi-platform index'
+    )
+    expect(normalizedEnglish).toContain(
+      'No beta.15 index was signed; no final cross-registry provenance, SBOM, or anonymous signature set was verified; and no final public native runtime matrix completed'
+    )
+    expect(normalizedEnglish).toContain(
+      'this result must not be described as atomic across distribution channels'
+    )
+    expect(normalizedChinese).toContain(
+      'Motrix 2.0.0-beta.15 于 2026-08-16 完成了部分渠道分发'
+    )
+    expect(normalizedChinese).toContain(
+      'arm64 job 从两个 registry 匿名拉取精确暂存 digest，并分别通过完整 Server runtime smoke'
+    )
+    expect(normalizedChinese).toContain(
+      '本地确定性 BitTorrent 任务未能在 180 秒内进入 `seeding` 或 `completed`'
+    )
+    expect(normalizedChinese).toContain(
+      '两个 registry 均没有获得不可变 `2.0.0-beta.15` tag 或最终 multi-platform index'
+    )
+    for (const source of [english, chinese]) {
+      expect(source).toContain('31939678223')
+      expect(source).toContain('v2.0.0-beta.16')
       expect(source).toContain('Snap')
       expect(source).toContain('latest/edge')
       expect(source).toContain('AppImage')
@@ -665,10 +760,10 @@ describe('release version contract', () => {
       expect(source).not.toMatch(secretLikeIdentifier)
     }
     expect(normalizedBeta15Metainfo).toContain(
-      'use Docker CLI syntax supported by both GitHub runner architectures after a platform-pinned pull'
+      'Both arm64 registry smokes passed before metadata validation rejected Docker Buildx'
     )
     expect(normalizedBeta15Metainfo).toContain(
-      'retaining an exact architecture assertion and platform-pinned runtime containers'
+      'No beta.15 container tag or final index was published or signed, and stable aliases remained unchanged'
     )
     expect(beta15Metainfo).not.toMatch(restrictedPublicLanguage)
     expect(beta15Metainfo).not.toMatch(secretLikeIdentifier)


### PR DESCRIPTION
## Summary

- accept Docker Buildx's documented flat single-platform `.Image` configuration while retaining fail-closed validation for platform-keyed output, missing or ambiguous platform data, and OS/architecture conflicts
- make the native BitTorrent runtime fixture wait for a complete aria2 seeder through loopback-only JSON-RPC, verify peer reachability, use a per-run random RPC value, mutate trackers through the task's current engine GID only after transfer/hash verification, and report real byte-progress diagnostics
- record the actual partial beta.15 distribution and prepare beta.16 English/Chinese release notes, AppStream metadata, README references, and version contracts

## Root cause

Build/Release run 31939678223 exposed two independent checks:

1. Docker Buildx returned the documented flat image configuration for a single-platform staged digest, but the platform metadata parser required a platform-keyed map.
2. The local BitTorrent smoke could start the Server before aria2 had proved the seed data ready, then changed trackers during the initial peer handshake.

Both failures occurred after native platform images had built and pushed only untagged staged digests. The fan-in finalizer remained skipped, so no beta.15 container version tag, final index, signature, or stable alias was published.

## Release safety and recovery

- native amd64/arm64 fan-out, no-QEMU workflow contracts, dual-registry staged smokes, complete-set fan-in, immutable-tag conflict protection, provenance/SBOM checks, keyless signatures, anonymous verification, final native runtime matrix, and alias-last ordering are unchanged
- the parser rejects missing, duplicate, unexpected, ambiguous, or conflicting platform representations
- beta.15 remains immutable and is not moved or reused; this change prepares beta.16 and does not create a tag
- Snap beta remains preflight-only and Windows packages remain unsigned
- release channels remain independently gated; the notes do not claim cross-channel atomicity

## Validation

- `pnpm test`: 626 test files passed, 2 skipped; 6765 tests passed, 3 skipped
- focused release/runtime contracts: 47 passed
- `pnpm run lint`
- `pnpm exec tsc --noEmit`
- `actionlint .github/workflows/*.yml`
- `xmllint --noout flatpak/app.motrix.native.metainfo.xml`
- `git diff --check`
- boundaries, file names, i18n, schema parity, third-party notices, Flatpak, and registry-runtime checks
- anonymous end-to-end metadata creation and complete-set fan-in against the real beta.15 amd64 and arm64 staged digests in both Docker Hub and GHCR

The full local container runtime smoke was not run because the local Docker/OrbStack daemon is not active. The PR's native amd64 and arm64 CI jobs exercise that path.
