### PR TITLE
fix(release): unblock container runtime verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2118,34 +2118,6 @@ jobs:
             verify_signature "$repository"
           done
 
-      - name: Update Docker Hub description
-        shell: bash
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          dockerhub_login_payload="$(jq -cn \
-            --arg username "$DOCKERHUB_USERNAME" \
-            --arg password "$DOCKERHUB_TOKEN" \
-            '{username: $username, password: $password}')"
-          dockerhub_jwt="$(curl --fail --silent --show-error \
-            --header 'Content-Type: application/json' \
-            --data "$dockerhub_login_payload" \
-            https://hub.docker.com/v2/users/login/ | jq -er '.token')"
-          dockerhub_description="$(jq -cn \
-            --arg description \
-              'Motrix Server for persistent Docker and NAS deployments' \
-            --rawfile full_description docs/docker-server.md \
-            '{description: $description, full_description: $full_description}')"
-          curl --fail --silent --show-error \
-            --request PATCH \
-            --header "Authorization: JWT ${dockerhub_jwt}" \
-            --header 'Content-Type: application/json' \
-            --data "$dockerhub_description" \
-            https://hub.docker.com/v2/repositories/motrixapp/motrix-server/ \
-            > /dev/null
-
   verify-container-runtime:
     name: Verify Server runtime / ${{ matrix.platform }}
     needs: [preflight, publish-container]

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. After its remaining release gates pass,
-download [v2.0.0-beta.16 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.16)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.16.md) before
+download [v2.0.0-beta.17 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.17)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.17.md) before
 installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -149,7 +149,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.16'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.17'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。剩余发布门禁通过后，请从 GitHub Releases
-下载 [v2.0.0-beta.16](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.16)，
-并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.16.zh-CN.md)。
+下载 [v2.0.0-beta.17](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.17)，
+并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.17.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -143,7 +143,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.16'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.17'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.16.md
+++ b/docs/release-notes/2.0.0-beta.16.md
@@ -1,122 +1,74 @@
 # Motrix 2.0.0-beta.16
 
-English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.16/docs/release-notes/2.0.0-beta.16.zh-CN.md)
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.17/docs/release-notes/2.0.0-beta.16.zh-CN.md)
 
-Motrix 2.0.0-beta.16 is the next Motrix Turbo beta intended for public
-distribution only after every protected release gate passes. It repairs the
-two independent fail-closed container checks observed during beta.15 without
-moving or reusing the immutable `v2.0.0-beta.15` tag.
+Motrix 2.0.0-beta.16 was partially distributed on 2026-08-16. In
+[Build/Release run 31942836854](https://github.com/agalwood/Motrix/actions/runs/31942836854),
+all five desktop builds, all three Finalize jobs, assembly, the GitHub
+prerelease, and the R2 update feed completed successfully. The Windows
+packages were published unsigned.
 
-The [beta.15 historical record](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.16/docs/release-notes/2.0.0-beta.15.md)
-documents the successful desktop, GitHub prerelease, and R2 distribution, the
-two successful native container builds, and the incomplete container result.
+The protected container path then completed both native platform builds:
+`linux/amd64` ran on `ubuntu-22.04` and `linux/arm64` ran on
+`ubuntu-22.04-arm`, without QEMU. Each job anonymously pulled its exact staged
+digest from Docker Hub and GHCR, passed the complete Server runtime smoke in
+both registries, and emitted version-, commit-, platform-, run-, and
+attempt-bound metadata only after those checks succeeded.
 
-## Container inspection and smoke recovery
+The single finalize job accepted the complete amd64/arm64 set, created the two
+immutable multi-platform indexes, and proved that both registries exposed the
+same digest, platform manifests, attestation manifests, max-level provenance,
+and non-empty SPDX SBOMs. It then signed both final index references with the
+protected tag-workflow identity and anonymously verified both signatures.
 
-- Builds `linux/amd64` on `ubuntu-22.04` and `linux/arm64` on
-  `ubuntu-22.04-arm`. Each job verifies its GitHub-hosted Linux runner and
-  native architecture before Buildx starts. The container release path does
-  not install or invoke QEMU.
-- Validates Docker Buildx's documented flat image configuration for a
-  single-platform source and the platform-keyed form used by multi-platform
-  inspection. Missing, unexpected, multiple, ambiguous, or conflicting
-  platform data fails closed before metadata can be accepted.
-- Makes the local BitTorrent fixture prove through aria2 JSON-RPC that exactly
-  one active torrent has all bytes available, then proves the seeder port is
-  reachable from the Server container before creating the real download task.
-  Tracker mutation is exercised only after the transfer and file hash pass;
-  bounded failures report task, tracker, peer, and byte-progress diagnostics.
-- Pushes each successful platform only by its untagged, content-addressed OCI
-  digest to Docker Hub and GHCR. A single architecture never receives the
-  public version tag and cannot become the official release on its own.
-- Anonymously pulls the exact staged digest from both registries and runs the
-  full Server runtime smoke on its native runner. Immutable platform metadata
-  can be uploaded only after both registry smokes succeed.
-- Binds each platform record to the exact version, source commit, workflow run
-  and attempt, native runner identity, raw OCI index hash, image manifest,
-  attestation manifest, provenance, and SPDX SBOM.
-- Allows one finalize job to proceed only after the complete amd64/arm64 build
-  set succeeds. It rejects missing, duplicate, unexpected, cross-wired, shared,
-  or future-attempt digests before creating either versioned index.
-- Rechecks both immutable version tags immediately before finalization. A clean
-  run creates both indexes from the verified platform digests; a rerun resumes
-  an identical complete result or repairs one missing registry from the
-  verified existing index. Any conflicting immutable tag fails closed.
-- Requires Docker Hub and GHCR to expose the same final index digest, platform
-  manifests, and attestation manifests. It validates max-level BuildKit
-  provenance, the exact source revision and builder run, and a non-empty SPDX
-  SBOM for both architectures before signing.
-- Signs each final index digest with the exact protected tag-workflow identity,
-  verifies both signatures anonymously, and then runs the full public runtime
-  smoke on native amd64 and arm64 runners against both registries.
-- Stable floating aliases are handled by the final recovery-safe job only after
-  every build, index, signature, provenance, SBOM, anonymous pull, and runtime
-  gate succeeds. Beta releases publish only their immutable version tag, so
-  beta.16 does not update `latest`, `stable`, or another stable alias.
+Both public version tags resolve to the same final digest:
 
-The GitHub prerelease, R2 update feed, container registries, and Snap Store
-remain independently gated publication channels. Their individual safety and
-recovery rules are strict, but this release does not claim cross-channel
-atomicity.
+```text
+sha256:0430288a5b97f33bacf59a9ffc1634d98835c71e7af4aaced179409aaf5d395a
+```
+
+After those artifact and signature gates passed, a non-artifact request to
+update the Docker Hub repository description returned HTTP 403. Because that
+request was still part of the finalize job, the job failed and the final
+native public runtime matrix did not run. The `linux/amd64` and `linux/arm64`
+jobs that would each have pulled the final digest from both registries were
+therefore skipped. Stable floating aliases remained unchanged; beta releases
+would not advance them in any case.
+
+The beta.16 container index is public and signed, but the release did not
+complete every final container gate and must not be described as fully
+verified. The immutable `v2.0.0-beta.16` tag is not moved or reused. The
+repository-description mutation is removed from the release authority in
+[Motrix 2.0.0-beta.17](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.17/docs/release-notes/2.0.0-beta.17.md),
+so artifact publication can hand off directly to the fail-closed public
+runtime matrix.
+
+The GitHub prerelease, R2 update feed, container registries, and Snap Store are
+independently gated publication channels. This partial result must not be
+described as atomic across distribution channels.
 
 ## Snap beta policy
 
-Snap is not part of the beta.16 distribution. Protected prerelease Snap runs
-stop after source validation, so they do not build Snap artifacts, upload Store
-revisions, or change `latest/edge`. Stable Snap publication retains its
-complete two-architecture verification and protected Store gates.
+Snap was not part of the beta.16 distribution. Its protected prerelease run
+completed source validation only; it did not build Snap artifacts, upload
+Store revisions, or change `latest/edge`.
 
-## Highlights
+## Available beta.16 downloads
 
-- A ground-up desktop rebuild with Electron 43, React 19, and TypeScript 7,
-  including a customizable Dashboard, dark mode, a cross-platform application
-  menu, and clearer task-inspector feedback.
-- One host-neutral download core for both the desktop app and the Node/Web
-  Server, with SQLite session recovery, tracker management, UPnP/NAT-PMP, and
-  HTTP, FTP, BitTorrent, and magnet support.
-- MDXP-based integration for the official CLI and browser handoff, including
-  local discovery and device-code pairing for remote Server instances.
-- A QuickJS plugin sandbox with capability consent, bundled builtin plugins,
-  and an in-app plugin marketplace.
-- Persistent multi-platform Server containers for NAS and home-server
-  deployments, published only after the complete native architecture set and
-  every public verification gate pass.
-
-## Before testing
-
-This is prerelease software. Back up your existing Motrix application data and
-downloads before installing it. Migration from Motrix v1 data has not yet been
-validated, so do not use your only copy of v1 data with this beta.
-
-When practical, test v2 in parallel using a separate OS account, machine, or
-Docker data directory. Do not rely on this beta for your only copy of important
-downloads.
-
-## What to test
-
-- HTTP, FTP, BitTorrent, and magnet downloads, including pause/resume and
-  session recovery
-- Desktop integrations, browser and CLI handoff through MDXP, and sandboxed
-  plugins
-- Headless Server deployment, persistent storage, remote pairing, and native
-  amd64 and arm64 container images
-
-## Planned downloads after release gates pass
-
-| Distribution | Architectures | Planned output |
-|--------------|---------------|----------------|
-| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Distribution | Architectures | Result |
+|--------------|---------------|--------|
+| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | Signed and notarized DMG and ZIP |
 | Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
 | Linux | `x64`, `arm64` | DEB and RPM |
 | Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.16-linux-<arch>.tar.gz` |
-| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.16` tag in both registries |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Public signed `2.0.0-beta.16` index; final public runtime matrix incomplete |
 | Snap Store | — | Not published for this beta |
 
-After every container gate passes, the versioned image references will be
+The published container references are
 `docker.io/motrixapp/motrix-server:2.0.0-beta.16` and
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.16`. See the
-[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.16/docs/docker-server.md)
-for storage, networking, and upgrade guidance.
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.16`. Users who require a release
+that completed the entire current container gate should use beta.17 after its
+release workflow succeeds.
 
 ## Known distribution limits
 
@@ -125,15 +77,5 @@ for storage, networking, and upgrade guidance.
   the GitHub prerelease includes its Native Host companion archives.
 - Windows `arm64` and all 32-bit packages are not available.
 - Windows packages are unsigned and may trigger a Windows SmartScreen warning.
-  Download them only from the official GitHub prerelease after it is published.
 - Beta container tags are immutable and do not update `latest`, `stable`, or
   other stable floating tags.
-- Snap is not published for this beta. Prerelease Snap runs stop after source
-  validation without building or publishing Snap artifacts.
-
-## Feedback
-
-Please report reproducible problems through
-[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
-operating system, architecture, package type, and the steps needed to reproduce
-the issue.

--- a/docs/release-notes/2.0.0-beta.16.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.16.zh-CN.md
@@ -1,114 +1,69 @@
 # Motrix 2.0.0-beta.16
 
-[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.16/docs/release-notes/2.0.0-beta.16.md) | 简体中文
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.17/docs/release-notes/2.0.0-beta.16.md) | 简体中文
 
-Motrix 2.0.0-beta.16 是下一次计划公开发布的 Motrix Turbo beta，只有全部受保护
-发布门禁通过后才会进入分发。它修复 beta.15 中两项相互独立的 fail-closed 容器
-检查，不会移动或复用不可变的 `v2.0.0-beta.15` tag。
+Motrix 2.0.0-beta.16 于 2026-08-16 完成了部分渠道分发。在
+[Build/Release run 31942836854](https://github.com/agalwood/Motrix/actions/runs/31942836854)
+中，5 个桌面构建、3 个 Finalize job、assemble、GitHub 预发布版和 R2 更新数据源
+均成功完成。Windows 安装包以未签名形式发布。
 
-[beta.15 历史记录](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.16/docs/release-notes/2.0.0-beta.15.zh-CN.md)
-准确记录了已成功的桌面、GitHub 预发布版与 R2 分发、两个已成功的原生容器构建，
-以及未完成的容器结果。
+受保护容器路径随后完成了两个原生平台构建：`linux/amd64` 运行于
+`ubuntu-22.04`，`linux/arm64` 运行于 `ubuntu-22.04-arm`，全程不使用 QEMU。
+每个 job 都从 Docker Hub 和 GHCR 匿名拉取自己的精确暂存 digest，在两个
+registry 中分别通过完整 Server runtime smoke，并且只在这些检查成功后才生成绑定
+版本、commit、platform、run 和 attempt 的元数据。
 
-## 容器检查与 smoke 恢复
+唯一 finalize job 接受了完整 amd64/arm64 集合，创建两个不可变 multi-platform
+index，并证明两个 registry 公开相同的 digest、platform manifest、attestation
+manifest、max-level provenance 和非空 SPDX SBOM。随后它使用受保护 tag-workflow
+身份签名两个最终 index 引用，并匿名验证两个签名。
 
-- `linux/amd64` 固定在 `ubuntu-22.04` 构建，`linux/arm64` 固定在
-  `ubuntu-22.04-arm` 构建。每个 job 都会在 Buildx 启动前验证 GitHub-hosted
-  Linux runner 及其原生架构；容器发布路径不安装或调用 QEMU。
-- 验证 Docker Buildx 为单平台来源定义的扁平 image 配置，同时支持多平台检查使用
-  的按 platform 分键形式。缺失、意外、多个、歧义或相互冲突的 platform 数据均会
-  在元数据被接受前 fail-closed。
-- 本地 BitTorrent fixture 先通过 aria2 JSON-RPC 证明恰好一个 active torrent 已
-  备齐全部字节，再从 Server 容器验证 seeder 端口可达，然后才创建真实下载任务。
-  只有传输和文件哈希通过后才测试 Tracker 修改；有界失败会报告任务、Tracker、
-  peer 与字节进度诊断，不用重试掩盖错误。
-- 每个平台成功后只按无 tag、内容寻址的 OCI digest 推送到 Docker Hub 和 GHCR。
-  单一架构不会获得公开版本 tag，不能独立成为正式发布版本。
-- 在原生 runner 上从两个 registry 匿名拉取精确的暂存 digest，并运行完整 Server
-  runtime smoke。只有两个 registry smoke 都成功后，才能上传不可变平台元数据。
-- 每份平台记录绑定精确版本、源码 commit、workflow run 与 attempt、原生 runner
-  身份、原始 OCI index 哈希、image manifest、attestation manifest、provenance
-  和 SPDX SBOM。
-- 只有 amd64/arm64 完整构建集合成功后，唯一的 finalize job 才能继续。创建任一
-  带版本 index 前，它会拒绝缺失、重复、意外、架构串线、共用或未来 attempt
-  digest。
-- Finalize 前立即重新检查两个不可变版本 tag。全新发布从已验证平台 digest 创建
-  两个 index；续跑可以接受完全一致的已有结果，或从已验证的现有 index 修复缺失
-  的 registry。任何冲突的不可变 tag 都会 fail-closed。
-- Docker Hub 和 GHCR 必须公开相同的最终 index digest、platform manifest 与
-  attestation manifest；签名前还会验证两个架构的 max-level BuildKit
-  provenance、精确源码 revision 与 builder run，以及非空 SPDX SBOM。
-- 使用精确的受保护 tag-workflow 身份签名两个最终 index digest，匿名验证两个
-  签名，然后在原生 amd64 和 arm64 runner 上针对两个 registry 运行完整公开
-  runtime smoke。
-- 稳定版浮动 alias 只由最后一个可恢复 job 处理，且必须等到全部构建、index、
-  签名、provenance、SBOM、匿名拉取和 runtime 门禁通过。Beta 只发布不可变版本
-  tag，因此 beta.16 不会更新 `latest`、`stable` 或其他稳定版 alias。
+两个公开版本 tag 指向同一最终 digest：
 
-GitHub 预发布版、R2 更新数据源、容器 registry 与 Snap Store 仍是各自独立门禁的
-发布渠道。每个渠道都有严格的安全检查和恢复规则，但本版本不宣称跨渠道原子性。
+```text
+sha256:0430288a5b97f33bacf59a9ffc1634d98835c71e7af4aaced179409aaf5d395a
+```
+
+上述 artifact 与签名门禁通过后，一个不属于 artifact 的 Docker Hub 仓库描述更新
+请求返回 HTTP 403。由于该请求当时仍位于 finalize job 内，该 job 失败，最终原生
+公开 runtime matrix 未运行。因此，原本应分别从两个 registry 拉取最终 digest 的
+`linux/amd64` 和 `linux/arm64` job 均被跳过。稳定版浮动 alias 保持不变；beta
+发布本来也不会推进这些 alias。
+
+beta.16 容器 index 已公开并签名，但该版本没有完成全部最终容器门禁，不能描述为
+完整验证通过。不可变 `v2.0.0-beta.16` tag 不会移动或复用。
+[Motrix 2.0.0-beta.17](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.17/docs/release-notes/2.0.0-beta.17.zh-CN.md)
+会从发布权威中移除仓库描述修改，使 artifact 发布在完成后直接进入 fail-closed 的
+公开 runtime matrix。
+
+GitHub 预发布版、R2 更新数据源、容器 registry 和 Snap Store 是分别设门禁的独立
+发布渠道。不能把这个部分完成的结果描述为跨分发渠道的原子发布。
 
 ## Snap beta 策略
 
-Snap 不属于 beta.16 的分发范围。受保护的预发布 Snap run 会在 source validation
-后停止，因此不会构建 Snap artifact、上传 Store revision 或修改 `latest/edge`。
-稳定版 Snap 发布仍保留完整的双架构验证与受保护 Store 门禁。
+Snap 不属于 beta.16 的分发范围。受保护的预发布 run 只完成 source validation；
+没有构建 Snap artifact、上传 Store revision 或修改 `latest/edge`。
 
-## 主要变化
+## 可用的 beta.16 下载
 
-- 使用 Electron 43、React 19 和 TypeScript 7 从头重建桌面应用，提供可自定义
-  Dashboard、深色模式、跨平台应用菜单，以及更清晰的任务检查器反馈。
-- 桌面应用和 Node/Web Server 共用与宿主无关的下载内核，支持 SQLite session
-  恢复、Tracker 管理、UPnP/NAT-PMP，以及 HTTP、FTP、BitTorrent 和磁力链接下载。
-- 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地发现及远程 Server 的
-  device-code 配对。
-- 提供带能力授权的 QuickJS 插件沙箱、内置插件和应用内插件市场。
-- 面向 NAS 和家庭服务器提供持久化多平台 Server 容器；只有完整原生架构集合与
-  所有公开验证门禁通过后才会发布。
-
-## 测试前须知
-
-这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1 数据的
-迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
-
-条件允许时，建议通过独立系统账户、设备或 Docker 数据目录与现有环境并行测试 v2。
-请勿让本 beta 成为重要下载文件的唯一存储位置。
-
-## 建议测试项
-
-- HTTP、FTP、BitTorrent 和磁力链接下载，包括暂停/继续与 session 恢复
-- 桌面集成、通过 MDXP 进行的浏览器和 CLI 任务交接，以及沙箱化插件
-- Headless Server 部署、数据持久化、远程配对，以及原生 amd64 与 arm64 容器镜像
-
-## 发布门禁通过后的计划下载
-
-| 发布方式 | 架构 | 计划产物 |
-|----------|------|----------|
-| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
+| 发布方式 | 架构 | 结果 |
+|----------|------|------|
+| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | 已签名并完成公证的 DMG 和 ZIP |
 | Windows | `x64` | 未签名的 NSIS 安装包（`.exe`）和 ZIP |
 | Linux | `x64`、`arm64` | DEB 和 RPM |
 | Flatpak Native Host 配套程序 | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.16-linux-<arch>.tar.gz` |
-| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中不可变的 `2.0.0-beta.16` tag |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 已公开并签名的 `2.0.0-beta.16` index；最终公开 runtime matrix 未完成 |
 | Snap Store | — | 本 beta 不发布 |
 
-全部容器门禁通过后，带版本镜像引用为
-`docker.io/motrixapp/motrix-server:2.0.0-beta.16` 和
-`ghcr.io/agalwood/motrix-server:2.0.0-beta.16`。数据持久化、网络和升级方法请参阅
-[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.16/docs/docker-server.zh-CN.md)。
+已发布容器引用为 `docker.io/motrixapp/motrix-server:2.0.0-beta.16` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.16`。需要完整通过当前容器门禁的用户，
+应在 beta.17 发布 workflow 成功后改用 beta.17。
 
 ## 已知发布限制
 
 - 本 beta 不发布 AppImage。
-- Flatpak 会单独验证，不会随该版本 tag 发布；GitHub 预发布版会包含其 Native Host
+- Flatpak 会单独验证，不会随版本 tag 发布；GitHub 预发布版包含 Native Host
   配套程序压缩包。
 - 不提供 Windows `arm64` 和任何 32 位安装包。
-- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅在正式发布后
-  从 GitHub 官方预发布版下载。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。
 - Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
-- 本 beta 不发布 Snap。预发布 Snap run 会在 source validation 后停止，不会构建
-  或发布 Snap artifact。
-
-## 反馈
-
-请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现的问题，
-并附上操作系统、架构、安装包类型和复现步骤。

--- a/docs/release-notes/2.0.0-beta.17.md
+++ b/docs/release-notes/2.0.0-beta.17.md
@@ -1,0 +1,138 @@
+# Motrix 2.0.0-beta.17
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.17/docs/release-notes/2.0.0-beta.17.zh-CN.md)
+
+Motrix 2.0.0-beta.17 is the next Motrix Turbo beta intended for public
+distribution only after every protected release gate passes. It fixes the
+non-artifact failure observed after beta.16 had already published and signed
+its two-registry container index, without moving or reusing the immutable
+`v2.0.0-beta.16` tag.
+
+The [beta.16 historical record](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.17/docs/release-notes/2.0.0-beta.16.md)
+documents the successful desktop, GitHub prerelease, R2, native platform,
+cross-registry index, provenance, SBOM, and signature stages, followed by the
+HTTP 403 that prevented the final public runtime matrix from starting.
+
+## Release-gate recovery
+
+- Removes Docker Hub repository-description mutation from the release
+  workflow. Repository description and overview are publisher metadata, not
+  versioned OCI artifacts, and their administrative access boundary is
+  separate from image publication.
+- Makes anonymous signature verification the final step of the single
+  container finalize job. A successful finalize result and its verified digest
+  can therefore hand off directly to the native public runtime matrix.
+- Adds a workflow contract that rejects the removed Docker Hub login route,
+  repository-description payload, or description step if they return to the
+  security-critical release path.
+- Keeps failures visible and fail-closed. The change does not use
+  `continue-on-error`, does not weaken an artifact, signature, provenance,
+  SBOM, platform, anonymous-pull, or runtime check, and does not broaden
+  release access.
+
+## Native container publication
+
+- Builds `linux/amd64` on `ubuntu-22.04` and `linux/arm64` on
+  `ubuntu-22.04-arm`. Each job proves its GitHub-hosted Linux runner and native
+  architecture before Buildx starts. The container release path does not
+  install or invoke QEMU.
+- Pushes each successful platform only by its untagged, content-addressed OCI
+  digest to Docker Hub and GHCR. A single architecture never receives the
+  public version tag and cannot become the official release by itself.
+- Anonymously pulls the exact staged digest from both registries and runs the
+  complete Server runtime smoke on its native runner. Platform metadata is
+  emitted only after both registry smokes succeed.
+- Binds each platform record to the exact version, source commit, workflow run
+  and attempt, native runner identity, raw OCI index hash, image manifest,
+  attestation manifest, max-level provenance, and non-empty SPDX SBOM.
+- Allows the single finalize job to proceed only after the complete
+  amd64/arm64 set succeeds. Missing, duplicate, unexpected, cross-wired,
+  shared, ambiguous, conflicting, or future-attempt data fails closed before
+  either version tag can be created.
+- Rechecks both immutable version tags immediately before finalization. A clean
+  run creates both indexes; a rerun resumes an identical complete result or
+  repairs one missing registry from the verified existing index. A conflicting
+  immutable tag fails closed.
+- Requires Docker Hub and GHCR to expose the same final index digest, platform
+  manifests, attestation manifests, provenance, and SBOM set before signing.
+  Both signatures are then verified anonymously.
+- Runs the complete final public Server runtime smoke on native amd64 and arm64
+  runners against the exact signed digest in both registries.
+- Advances stable floating aliases only in the last recovery-safe job after
+  every build, index, signature, provenance, SBOM, anonymous pull, and runtime
+  gate passes. Beta releases publish only their immutable version tag, so
+  beta.17 does not update `latest`, `stable`, or another stable alias.
+
+The GitHub prerelease, R2 update feed, container registries, and Snap Store
+remain independently gated publication channels. Their individual safety and
+recovery rules are strict, but this release does not claim cross-channel
+atomicity.
+
+## Snap beta policy
+
+Snap is not part of the beta.17 distribution. Protected prerelease Snap runs
+stop after source validation, so they do not build Snap artifacts, upload
+Store revisions, or change `latest/edge`.
+
+## Highlights
+
+- A ground-up desktop rebuild with Electron 43, React 19, and TypeScript 7,
+  including a customizable Dashboard, dark mode, a cross-platform application
+  menu, and clearer task-inspector feedback.
+- One host-neutral download core for both the desktop app and the Node/Web
+  Server, with SQLite session recovery, tracker management, UPnP/NAT-PMP, and
+  HTTP, FTP, BitTorrent, and magnet support.
+- MDXP-based integration for the official CLI and browser handoff, including
+  local discovery and device-code pairing for remote Server instances.
+- A QuickJS plugin sandbox with capability consent, bundled builtin plugins,
+  and an in-app plugin marketplace.
+- Persistent multi-platform Server containers for NAS and home-server
+  deployments, published only after the complete native architecture set and
+  every public verification gate pass.
+
+## Before testing
+
+This is prerelease software. Back up existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Do not rely on this beta for your only copy of important
+downloads.
+
+## Planned downloads after release gates pass
+
+| Distribution | Architectures | Planned output |
+|--------------|---------------|----------------|
+| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | DEB and RPM |
+| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.17-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.17` tag in both registries |
+| Snap Store | — | Not published for this beta |
+
+After every container gate passes, the versioned image references will be
+`docker.io/motrixapp/motrix-server:2.0.0-beta.17` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.17`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.17/docs/docker-server.md)
+for storage, networking, and upgrade guidance.
+
+## Known distribution limits
+
+- AppImage is not published for this beta.
+- Flatpak is validated separately and is not published by the release tag;
+  the GitHub prerelease includes its Native Host companion archives.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
+  Download them only from the official GitHub prerelease after it is published.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+- Snap is not published for this beta. Prerelease Snap runs stop after source
+  validation without building or publishing Snap artifacts.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.17.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.17.zh-CN.md
@@ -1,0 +1,112 @@
+# Motrix 2.0.0-beta.17
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.17/docs/release-notes/2.0.0-beta.17.md) | 简体中文
+
+Motrix 2.0.0-beta.17 是下一次计划公开发布的 Motrix Turbo beta，只有全部受保护
+发布门禁通过后才会进入分发。它修复 beta.16 已经在两个 registry 发布并签名容器
+index 后出现的非 artifact 失败，不会移动或复用不可变的
+`v2.0.0-beta.16` tag。
+
+[beta.16 历史记录](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.17/docs/release-notes/2.0.0-beta.16.zh-CN.md)
+准确记录了已成功的桌面、GitHub 预发布版、R2、原生平台、跨 registry index、
+provenance、SBOM 和签名阶段，以及随后阻止最终公开 runtime matrix 启动的 HTTP
+403。
+
+## 发布门禁恢复
+
+- 从发布 workflow 中移除 Docker Hub 仓库描述修改。仓库 description 与 overview
+  属于发布者资料，不是带版本 OCI artifact，其管理边界与镜像发布相互独立。
+- 把匿名签名验证作为唯一容器 finalize job 的最后一步。Finalize 成功后，其已验证
+  digest 可以直接交给原生公开 runtime matrix。
+- 新增 workflow contract：如果已移除的 Docker Hub login 路径、仓库描述 payload
+  或描述步骤再次进入安全关键发布路径，检查会直接拒绝。
+- 保持失败可见并 fail-closed。本次修改不使用 `continue-on-error`，不削弱 artifact、
+  签名、provenance、SBOM、platform、匿名拉取或 runtime 检查，也不扩大发布访问
+  范围。
+
+## 原生容器发布
+
+- `linux/amd64` 固定在 `ubuntu-22.04` 构建，`linux/arm64` 固定在
+  `ubuntu-22.04-arm` 构建。每个 job 都会在 Buildx 启动前证明 GitHub-hosted
+  Linux runner 及其原生架构；容器发布路径不安装或调用 QEMU。
+- 每个平台成功后只按无 tag、内容寻址的 OCI digest 推送到 Docker Hub 和 GHCR。
+  单一架构不会获得公开版本 tag，不能独立成为正式发布版本。
+- 在原生 runner 上从两个 registry 匿名拉取精确暂存 digest，并运行完整 Server
+  runtime smoke。只有两个 registry smoke 都成功后才生成平台元数据。
+- 每份平台记录绑定精确版本、源码 commit、workflow run 与 attempt、原生 runner
+  身份、原始 OCI index 哈希、image manifest、attestation manifest、max-level
+  provenance 和非空 SPDX SBOM。
+- 只有完整 amd64/arm64 集合成功后，唯一 finalize job 才能继续。缺失、重复、
+  意外、架构串线、共用、歧义、冲突或未来 attempt 数据会在创建任一版本 tag 前
+  fail-closed。
+- Finalize 前立即重新检查两个不可变版本 tag。全新发布会创建两个 index；续跑可以
+  接受完全一致的已有结果，或从已验证的现有 index 修复缺失 registry。冲突的
+  不可变 tag 会 fail-closed。
+- 签名前要求 Docker Hub 和 GHCR 公开相同的最终 index digest、platform manifest、
+  attestation manifest、provenance 与 SBOM 集合，随后匿名验证两个签名。
+- 在原生 amd64 与 arm64 runner 上，针对两个 registry 中的精确已签名 digest
+  运行完整最终公开 Server runtime smoke。
+- 稳定版浮动 alias 只由最后一个可恢复 job 推进，且必须等全部构建、index、签名、
+  provenance、SBOM、匿名拉取和 runtime 门禁通过。Beta 只发布不可变版本 tag，
+  因此 beta.17 不会更新 `latest`、`stable` 或其他稳定版 alias。
+
+GitHub 预发布版、R2 更新数据源、容器 registry 与 Snap Store 仍是各自独立门禁的
+发布渠道。每个渠道都有严格的安全检查和恢复规则，但本版本不宣称跨渠道原子性。
+
+## Snap beta 策略
+
+Snap 不属于 beta.17 的分发范围。受保护的预发布 Snap run 会在 source validation
+后停止，因此不会构建 Snap artifact、上传 Store revision 或修改 `latest/edge`。
+
+## 主要变化
+
+- 使用 Electron 43、React 19 和 TypeScript 7 从头重建桌面应用，提供可自定义
+  Dashboard、深色模式、跨平台应用菜单，以及更清晰的任务检查器反馈。
+- 桌面应用和 Node/Web Server 共用与宿主无关的下载内核，支持 SQLite session
+  恢复、Tracker 管理、UPnP/NAT-PMP，以及 HTTP、FTP、BitTorrent 和磁力链接下载。
+- 官方 CLI 和浏览器任务交接统一使用 MDXP，并支持本地发现及远程 Server 的
+  device-code 配对。
+- 提供带能力授权的 QuickJS 插件沙箱、内置插件和应用内插件市场。
+- 面向 NAS 和家庭服务器提供持久化多平台 Server 容器；只有完整原生架构集合与
+  所有公开验证门禁通过后才会发布。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1 数据的
+迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
+
+条件允许时，建议通过独立系统账户、设备或 Docker 数据目录与现有环境并行测试 v2。
+请勿让本 beta 成为重要下载文件的唯一存储位置。
+
+## 发布门禁通过后的计划下载
+
+| 发布方式 | 架构 | 计划产物 |
+|----------|------|----------|
+| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
+| Windows | `x64` | 未签名的 NSIS 安装包（`.exe`）和 ZIP |
+| Linux | `x64`、`arm64` | DEB 和 RPM |
+| Flatpak Native Host 配套程序 | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.17-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中不可变的 `2.0.0-beta.17` tag |
+| Snap Store | — | 本 beta 不发布 |
+
+全部容器门禁通过后，带版本镜像引用为
+`docker.io/motrixapp/motrix-server:2.0.0-beta.17` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.17`。数据持久化、网络和升级方法请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.17/docs/docker-server.zh-CN.md)。
+
+## 已知发布限制
+
+- 本 beta 不发布 AppImage。
+- Flatpak 会单独验证，不会随版本 tag 发布；GitHub 预发布版包含其 Native Host
+  配套程序压缩包。
+- 不提供 Windows `arm64` 和任何 32 位安装包。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅在正式发布后
+  从 GitHub 官方预发布版下载。
+- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
+- 本 beta 不发布 Snap。预发布 Snap run 会在 source validation 后停止，不会构建
+  或发布 Snap artifact。
+
+## 反馈
+
+请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现的问题，
+并附上操作系统、架构、安装包类型和复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -76,17 +76,29 @@
   <releases>
     <!-- Update this list on every release; Flathub linter requires the most
          recent version listed here to match the manifest's source tag. -->
+    <release version="2.0.0-beta.17" date="2026-08-16">
+      <description>
+        <p>
+          Docker Hub repository-description mutation is no longer part of the
+          artifact release authority. Anonymous signature verification now
+          hands the verified digest directly to the native public runtime
+          matrix. Native fan-out, cross-registry index, provenance, SBOM,
+          signature, runtime, recovery, and alias-last gates remain
+          fail-closed. Windows packages remain unsigned. Prerelease Snap runs
+          stop after source validation.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.16" date="2026-08-16">
       <description>
         <p>
-          Single-platform metadata validation now accepts Docker Buildx's
-          documented flat image configuration while rejecting missing,
-          ambiguous, or conflicting platform data. The native BitTorrent smoke
-          waits for a complete aria2 seeder through JSON-RPC and verifies local
-          peer reachability before starting a real transfer. Native fan-out,
-          cross-registry index, provenance, SBOM, signature, and public runtime
-          gates remain fail-closed. Windows packages remain unsigned.
-          Prerelease Snap runs stop after source validation.
+          The desktop packages, GitHub prerelease, R2 update feed, native
+          platform builds, matching Docker Hub/GHCR index, provenance, SBOM,
+          and anonymous signature checks completed. A subsequent Docker Hub
+          repository-description request returned HTTP 403, so the final
+          native public runtime matrix was skipped. Stable aliases remained
+          unchanged. Windows packages were unsigned; the prerelease Snap run
+          stopped after source validation.
         </p>
       </description>
     </release>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.16",
+  "version": "2.0.0-beta.17",
   "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1",
   "description": "A full-featured download manager",
   "keywords": [],

--- a/tests/scripts/release-version-contract.test.ts
+++ b/tests/scripts/release-version-contract.test.ts
@@ -591,7 +591,94 @@ describe('release version contract', () => {
     expect(beta12Metainfo).not.toMatch(secretLikeIdentifier)
   })
 
-  it('ships beta.16 inspection and BitTorrent recovery without weakening native gates', () => {
+  it('ships beta.17 Docker Hub metadata recovery without weakening native gates', () => {
+    const english = read('docs/release-notes/2.0.0-beta.17.md')
+    const chinese = read('docs/release-notes/2.0.0-beta.17.zh-CN.md')
+    const normalizedEnglish = english
+      .replace(/^>\s?/gm, '')
+      .replace(/\s+/g, ' ')
+    const normalizedChinese = chinese
+      .replace(/^>\s?/gm, '')
+      .replace(/\s+/g, ' ')
+    const metainfo = read('flatpak/app.motrix.native.metainfo.xml')
+    const beta17Metainfo =
+      /<release version="2\.0\.0-beta\.17"[\s\S]*?<\/release>/.exec(
+        metainfo
+      )?.[0] ?? ''
+    const normalizedBeta17Metainfo = beta17Metainfo.replace(/\s+/g, ' ')
+
+    expect(normalizedEnglish).toContain(
+      'Removes Docker Hub repository-description mutation from the release workflow'
+    )
+    expect(normalizedEnglish).toContain(
+      'anonymous signature verification the final step of the single container finalize job'
+    )
+    expect(normalizedEnglish).toContain(
+      'rejects the removed Docker Hub login route, repository-description payload, or description step'
+    )
+    expect(normalizedEnglish).toContain(
+      'does not use `continue-on-error`, does not weaken an artifact, signature, provenance, SBOM, platform, anonymous-pull, or runtime check'
+    )
+    expect(normalizedEnglish).toContain(
+      'Builds `linux/amd64` on `ubuntu-22.04` and `linux/arm64` on `ubuntu-22.04-arm`'
+    )
+    expect(normalizedEnglish).toContain(
+      'The container release path does not install or invoke QEMU'
+    )
+    expect(normalizedEnglish).toContain(
+      'A single architecture never receives the public version tag and cannot become the official release by itself'
+    )
+    expect(normalizedEnglish).toContain(
+      'a rerun resumes an identical complete result or repairs one missing registry'
+    )
+    expect(normalizedEnglish).toContain(
+      'Advances stable floating aliases only in the last recovery-safe job after every build, index, signature, provenance, SBOM, anonymous pull, and runtime gate passes'
+    )
+    expect(normalizedEnglish).toContain(
+      'this release does not claim cross-channel atomicity'
+    )
+    expect(normalizedChinese).toContain(
+      '从发布 workflow 中移除 Docker Hub 仓库描述修改'
+    )
+    expect(normalizedChinese).toContain(
+      '把匿名签名验证作为唯一容器 finalize job 的最后一步'
+    )
+    expect(normalizedChinese).toContain(
+      '本次修改不使用 `continue-on-error`，不削弱 artifact、 签名、provenance、SBOM、platform、匿名拉取或 runtime 检查'
+    )
+    expect(normalizedChinese).toContain('容器发布路径不安装或调用 QEMU')
+    expect(normalizedChinese).toMatch(
+      /全部构建、index、签名、\s*provenance、SBOM、匿名拉取和 runtime 门禁通过/u
+    )
+    expect(normalizedChinese).toMatch(/本版本不宣称跨渠道原子性/u)
+    for (const source of [english, chinese]) {
+      expect(source).toContain('v2.0.0-beta.16')
+      expect(source).toContain('Snap')
+      expect(source).toContain('latest/edge')
+      expect(source).toContain('AppImage')
+      expect(source).toContain('Flatpak')
+      expect(source).toContain(
+        'Motrix-Native-Host-2.0.0-beta.17-linux-<arch>.tar.gz'
+      )
+      expect(source).toContain('SmartScreen')
+      expect(source).toContain(
+        'docker.io/motrixapp/motrix-server:2.0.0-beta.17'
+      )
+      expect(source).toContain('ghcr.io/agalwood/motrix-server:2.0.0-beta.17')
+      expect(source).not.toMatch(restrictedPublicLanguage)
+      expect(source).not.toMatch(secretLikeIdentifier)
+    }
+    expect(normalizedBeta17Metainfo).toContain(
+      'Docker Hub repository-description mutation is no longer part of the artifact release authority'
+    )
+    expect(normalizedBeta17Metainfo).toContain(
+      'hands the verified digest directly to the native public runtime matrix'
+    )
+    expect(beta17Metainfo).not.toMatch(restrictedPublicLanguage)
+    expect(beta17Metainfo).not.toMatch(secretLikeIdentifier)
+  })
+
+  it('records beta.16 signed indexes and incomplete final runtime matrix', () => {
     const english = read('docs/release-notes/2.0.0-beta.16.md')
     const chinese = read('docs/release-notes/2.0.0-beta.16.zh-CN.md')
     const normalizedEnglish = english
@@ -608,62 +695,48 @@ describe('release version contract', () => {
     const normalizedBeta16Metainfo = beta16Metainfo.replace(/\s+/g, ' ')
 
     expect(normalizedEnglish).toContain(
-      'Builds `linux/amd64` on `ubuntu-22.04` and `linux/arm64` on `ubuntu-22.04-arm`'
+      'Motrix 2.0.0-beta.16 was partially distributed'
     )
     expect(normalizedEnglish).toContain(
-      'The container release path does not install or invoke QEMU'
+      'all five desktop builds, all three Finalize jobs, assembly, the GitHub prerelease, and the R2 update feed completed successfully'
     )
     expect(normalizedEnglish).toContain(
-      "Validates Docker Buildx's documented flat image configuration for a single-platform source and the platform-keyed form used by multi-platform inspection"
+      'Each job anonymously pulled its exact staged digest from Docker Hub and GHCR, passed the complete Server runtime smoke in both registries'
     )
     expect(normalizedEnglish).toContain(
-      'Missing, unexpected, multiple, ambiguous, or conflicting platform data fails closed'
+      'created the two immutable multi-platform indexes'
+    )
+    expect(normalizedEnglish).toContain('anonymously verified both signatures')
+    expect(normalizedEnglish).toContain(
+      'sha256:0430288a5b97f33bacf59a9ffc1634d98835c71e7af4aaced179409aaf5d395a'
     )
     expect(normalizedEnglish).toContain(
-      'exactly one active torrent has all bytes available'
+      'update the Docker Hub repository description returned HTTP 403'
     )
     expect(normalizedEnglish).toContain(
-      'proves the seeder port is reachable from the Server container before creating the real download task'
+      'the final native public runtime matrix did not run'
     )
     expect(normalizedEnglish).toContain(
-      'Tracker mutation is exercised only after the transfer and file hash pass'
+      'The beta.16 container index is public and signed, but the release did not complete every final container gate'
     )
     expect(normalizedEnglish).toContain(
-      'A single architecture never receives the public version tag and cannot become the official release on its own'
-    )
-    expect(normalizedEnglish).toContain(
-      'Immutable platform metadata can be uploaded only after both registry smokes succeed'
-    )
-    expect(normalizedEnglish).toContain(
-      'rejects missing, duplicate, unexpected, cross-wired, shared, or future-attempt digests'
-    )
-    expect(normalizedEnglish).toContain(
-      'a rerun resumes an identical complete result or repairs one missing registry'
-    )
-    expect(normalizedEnglish).toContain(
-      'Stable floating aliases are handled by the final recovery-safe job only after every build, index, signature, provenance, SBOM, anonymous pull, and runtime gate succeeds'
-    )
-    expect(normalizedEnglish).toContain(
-      'this release does not claim cross-channel atomicity'
+      'must not be described as atomic across distribution channels'
     )
     expect(normalizedChinese).toContain(
-      '`linux/amd64` 固定在 `ubuntu-22.04` 构建，`linux/arm64` 固定在 `ubuntu-22.04-arm` 构建'
+      'Motrix 2.0.0-beta.16 于 2026-08-16 完成了部分渠道分发'
     )
-    expect(normalizedChinese).toContain('容器发布路径不安装或调用 QEMU')
+    expect(normalizedChinese).toContain('创建两个不可变 multi-platform index')
+    expect(normalizedChinese).toContain('仓库描述更新 请求返回 HTTP 403')
+    expect(normalizedChinese).toContain('最终原生 公开 runtime matrix 未运行')
     expect(normalizedChinese).toContain(
-      '缺失、意外、多个、歧义或相互冲突的 platform 数据均会 在元数据被接受前 fail-closed'
+      'beta.16 容器 index 已公开并签名，但该版本没有完成全部最终容器门禁'
     )
     expect(normalizedChinese).toContain(
-      '恰好一个 active torrent 已 备齐全部字节'
+      '不能把这个部分完成的结果描述为跨分发渠道的原子发布'
     )
-    expect(normalizedChinese).toContain(
-      '有界失败会报告任务、Tracker、 peer 与字节进度诊断，不用重试掩盖错误'
-    )
-    expect(normalizedChinese).toMatch(
-      /全部构建、index、\s*签名、provenance、SBOM、匿名拉取和 runtime 门禁通过/u
-    )
-    expect(normalizedChinese).toMatch(/本版本不宣称跨渠道\s*原子性/u)
     for (const source of [english, chinese]) {
+      expect(source).toContain('31942836854')
+      expect(source).toContain('v2.0.0-beta.17')
       expect(source).toContain('Snap')
       expect(source).toContain('latest/edge')
       expect(source).toContain('AppImage')
@@ -680,10 +753,10 @@ describe('release version contract', () => {
       expect(source).not.toMatch(secretLikeIdentifier)
     }
     expect(normalizedBeta16Metainfo).toContain(
-      "accepts Docker Buildx's documented flat image configuration while rejecting missing, ambiguous, or conflicting platform data"
+      'matching Docker Hub/GHCR index, provenance, SBOM, and anonymous signature checks completed'
     )
     expect(normalizedBeta16Metainfo).toContain(
-      'waits for a complete aria2 seeder through JSON-RPC and verifies local peer reachability before starting a real transfer'
+      'repository-description request returned HTTP 403, so the final native public runtime matrix was skipped'
     )
     expect(beta16Metainfo).not.toMatch(restrictedPublicLanguage)
     expect(beta16Metainfo).not.toMatch(secretLikeIdentifier)

--- a/tests/scripts/workflow-release-matrix.test.ts
+++ b/tests/scripts/workflow-release-matrix.test.ts
@@ -1055,6 +1055,10 @@ describe('release workflow publication contract', () => {
     expect(signatureCommand).toContain('return 1')
     expect(signatureCommand).toContain('sleep "$retry_delay_seconds"')
     expect(signatureCommand).not.toContain('|| true')
+    expect(finalSteps.at(-1)?.name).toBe('Verify immutable signatures')
+    expect(finalStepIndex('Update Docker Hub description')).toBe(-1)
+    expect(releaseSource).not.toContain('hub.docker.com/v2/users/login')
+    expect(releaseSource).not.toContain('full_description')
 
     const publicVerification = finalSteps[
       finalStepIndex(


### PR DESCRIPTION
## What changed

- remove Docker Hub repository-description mutation from the security-critical container finalize job
- require anonymous Cosign verification to remain the final finalize step, then hand the verified digest directly to the native public runtime matrix
- add workflow contracts that reject the removed Docker Hub login route, description payload, or description step
- record the actual partial beta.16 outcome and prepare paired beta.17 release notes, AppStream metadata, README references, and package version

## Root cause

Build/Release run [31942836854](https://github.com/agalwood/Motrix/actions/runs/31942836854) successfully built both native Server platforms, published matching Docker Hub/GHCR indexes, verified provenance and SBOMs, signed both final digests, and anonymously verified both signatures. A subsequent repository-description PATCH returned HTTP 403, which failed the finalize job and skipped the final public native runtime matrix.

Docker's current Hub API documentation separates repository information administration from image publication, and its GitHub Actions guide treats description synchronization as a separate concern. Repository profile metadata is not a versioned OCI artifact and must not block artifact safety gates.

## Safety and recovery

- beta.16 remains immutable; this PR does not move or reuse its tag
- beta.17 is not tagged by this PR
- native amd64/arm64 fan-out, no-QEMU enforcement, staging smokes, complete-set validation, cross-registry consistency, provenance, SBOM, keyless signing, anonymous verification, recovery semantics, and alias-last ordering are unchanged
- no `continue-on-error` or widened release access is introduced
- Windows remains unsigned and beta Snap remains preflight-only
- release notes do not claim cross-channel atomicity

## Verification

- full Vitest: 626 files passed, 2 skipped; 6766 tests passed, 3 skipped
- all `tests/scripts`: 41 files and 550 tests passed
- focused release contracts: 71 tests passed
- boundaries, full-repository Biome, TypeScript, actionlint, XML, diff check
- file names, i18n, schema parity, third-party notices, Flatpak, and Electron registry-runtime checks
