### PR TITLE
chore(engine): bump bundled aria2 to 1.37.0-motrix.4

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -299,7 +299,7 @@ jobs:
                 -path "*/native-messaging-hosts/*" \
               \) -print -quit)"
               output="$("$aria2c" --version)"
-              printf "%s\n" "$output" | grep -qF "aria2 version 1.37.0-motrix.3"
+              printf "%s\n" "$output" | grep -qF "aria2 version 1.37.0-motrix.4"
               printf "%s\n" "$output" | grep -qF "Async DNS"
               printf "%s\n" "$output" | grep -qF "BitTorrent"
               printf "%s\n" "$output" | grep -qF "HTTPS"

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -83,8 +83,8 @@ must obtain permission or replace the font before distributing the build.
 Desktop builds bundle an `aria2c` executable pinned by
 `scripts/engine.lock.json`:
 
-- **Version:** 1.37.0-motrix.3
-- **Source:** <https://github.com/motrixapp/aria2/tree/v1.37.0-motrix.3>
+- **Version:** 1.37.0-motrix.4
+- **Source:** <https://github.com/motrixapp/aria2/tree/v1.37.0-motrix.4>
 - **License:** GNU General Public License v2.0 or later (`GPL-2.0-or-later`)
 - **Full license text:** `THIRD_PARTY_LICENSES/aria2-COPYING`
 - **OpenSSL exception / notice:**

--- a/THIRD_PARTY_NOTICES.zh-CN.md
+++ b/THIRD_PARTY_NOTICES.zh-CN.md
@@ -71,8 +71,8 @@ src/renderer/routes/settings/icons/icon-network@2x.png
 
 桌面版随应用打包 `aria2c` 可执行文件，版本由 `scripts/engine.lock.json` 固定：
 
-- **版本：** 1.37.0-motrix.3
-- **对应源码：** <https://github.com/motrixapp/aria2/tree/v1.37.0-motrix.3>
+- **版本：** 1.37.0-motrix.4
+- **对应源码：** <https://github.com/motrixapp/aria2/tree/v1.37.0-motrix.4>
 - **许可证：** GNU General Public License v2.0 or later（`GPL-2.0-or-later`）
 - **完整许可证文本：** `THIRD_PARTY_LICENSES/aria2-COPYING`
 - **OpenSSL 例外条款 / 声明：**

--- a/flatpak/app.motrix.native.yml
+++ b/flatpak/app.motrix.native.yml
@@ -102,7 +102,7 @@ modules:
         set -e
         output="$(src/aria2c --version)"
         printf '%s\n' "$output"
-        printf '%s\n' "$output" | grep -qF 'aria2 version 1.37.0-motrix.3'
+        printf '%s\n' "$output" | grep -qF 'aria2 version 1.37.0-motrix.4'
         for feature in \
           'Async DNS' \
           'BitTorrent' \
@@ -124,8 +124,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/motrixapp/aria2.git
-        tag: v1.37.0-motrix.3
-        commit: 4368a461cc765758a533b8cd4b30d74601310cd1
+        tag: v1.37.0-motrix.4
+        commit: bfc033ae4d054c78ad7aac3faff4f11c56b4d363
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+-motrix\.\d+)$
@@ -137,9 +137,9 @@ modules:
         commands:
           - |
             sed -i -E \
-              's/AC_INIT\(\[aria2\],\[[^]]+\]/AC_INIT([aria2],[1.37.0-motrix.3]/' \
+              's/AC_INIT\(\[aria2\],\[[^]]+\]/AC_INIT([aria2],[1.37.0-motrix.4]/' \
               configure.ac
-            grep -qF 'AC_INIT([aria2],[1.37.0-motrix.3]' configure.ac
+            grep -qF 'AC_INIT([aria2],[1.37.0-motrix.4]' configure.ac
       - type: script
         dest-filename: autogen.sh
         commands:

--- a/scripts/engine.lock.json
+++ b/scripts/engine.lock.json
@@ -1,50 +1,50 @@
 {
   "engine": "aria2",
   "repo": "motrixapp/aria2",
-  "tag": "v1.37.0-motrix.3",
-  "version": "1.37.0-motrix.3",
+  "tag": "v1.37.0-motrix.4",
+  "version": "1.37.0-motrix.4",
   "assets": {
     "darwin-arm64": {
-      "file": "aria2c-1.37.0-motrix.3-darwin-arm64.tar.gz",
+      "file": "aria2c-1.37.0-motrix.4-darwin-arm64.tar.gz",
       "bin": "aria2c",
-      "archiveSha256": "33112c7d95d021044517f4fac20643e492e28415b9f9c2004e622db682966206",
-      "binarySha256": "79aa26a10613ed6460865891aa16c661c89dbf8dada73d06af5dd1ba5fb54f46"
+      "archiveSha256": "c4f7042f661e0d1dd22b3448727ebb7f47de853dbf9137381ffd9b05ea5b1873",
+      "binarySha256": "a91dcb82bc8ef057c89b539c5d95695d6a5ee4ea40d88738e9d2109b87c5c389"
     },
     "darwin-x64": {
-      "file": "aria2c-1.37.0-motrix.3-darwin-x64.tar.gz",
+      "file": "aria2c-1.37.0-motrix.4-darwin-x64.tar.gz",
       "bin": "aria2c",
-      "archiveSha256": "4b8ba79218bafcd88efee9596dc9cfbfd7b321a3c5d610b5986752f8a0c0edc9",
-      "binarySha256": "b92e74b6c7768e86d6ecb7925f967b9371ff6838f0ba941e75198c7941235e09"
+      "archiveSha256": "02572685bd7472f521f87423c41934515777bdcbf92c4cfd21c295c20797c7da",
+      "binarySha256": "65e7894d5fbad6be7f5401f6f801b169dfe18587d8770d8d780cd72f33f1eb03"
     },
     "win32-x64": {
-      "file": "aria2c-1.37.0-motrix.3-win32-x64.zip",
+      "file": "aria2c-1.37.0-motrix.4-win32-x64.zip",
       "bin": "aria2c.exe",
-      "archiveSha256": "10175c68d760658945dd0d00c96508dff44d144e760cf90c6b3c251e32fa4230",
-      "binarySha256": "25adcdabc43bc2e30204364ef3cb5d55c2a7331b3da30308ce02437033800516"
+      "archiveSha256": "066be85b2279a2bf9a3d501174a5e9d651963e761af96f6eab688b7b1bc9253d",
+      "binarySha256": "3a1b76452c781c0dfc5f2655b93537fe650933562af6e1621e6f35f7fc0ca172"
     },
     "win32-ia32": {
-      "file": "aria2c-1.37.0-motrix.3-win32-ia32.zip",
+      "file": "aria2c-1.37.0-motrix.4-win32-ia32.zip",
       "bin": "aria2c.exe",
-      "archiveSha256": "71842ebb852dcb356ec24436725612a0478b9fa09fd5b14fe8f830eccb048438",
-      "binarySha256": "416bfc2fec612b53617c932c0897705e6bd86352e40f8a1ce16091b1a9b147d1"
+      "archiveSha256": "4f2e520b6471fda93224b9adc2a796a27a9820b57088bd81a4e9d6d284a56b4f",
+      "binarySha256": "e2122fb8ce4cee868040b5bf9320fe6de00dae7bedfcd16f8108f4a41aeb2f59"
     },
     "linux-x64": {
-      "file": "aria2c-1.37.0-motrix.3-linux-x64.tar.gz",
+      "file": "aria2c-1.37.0-motrix.4-linux-x64.tar.gz",
       "bin": "aria2c",
-      "archiveSha256": "18b22d76e8e06916feb23946145f83385d8afa35dd83988cacd9d0004baa256f",
-      "binarySha256": "906748569adceade7695dfde520bf285cad26d5e00a6e48d3dbee56826e6af55"
+      "archiveSha256": "9cf2594534b84aebf4596f9c73a5269711908109909c954dd03077e6ef67b250",
+      "binarySha256": "015e539bc212342818ccac099a8a25b792d30a12a0a1c304de03829fa1b636a8"
     },
     "linux-arm64": {
-      "file": "aria2c-1.37.0-motrix.3-linux-arm64.tar.gz",
+      "file": "aria2c-1.37.0-motrix.4-linux-arm64.tar.gz",
       "bin": "aria2c",
-      "archiveSha256": "bdc02e13f7b5fb2b35f44d8cf6ebafc1af5168fc88dd21a6a9c98f16d2724b9e",
-      "binarySha256": "efdbb039b8c3aadc7b13a18c51f06247b28c6ef36d524342f2d34e1b66dba7d3"
+      "archiveSha256": "a3759868757356f4628bbceee0a90efeb7232bb8f1905d08d8e1ade620b84e10",
+      "binarySha256": "6895d8e89749cc78bd47b4c9cf49763500d0d6fa923964444320fa6f806c32fe"
     },
     "linux-arm": {
-      "file": "aria2c-1.37.0-motrix.3-linux-armv7l.tar.gz",
+      "file": "aria2c-1.37.0-motrix.4-linux-armv7l.tar.gz",
       "bin": "aria2c",
-      "archiveSha256": "ecc507d6e22af9c19b1d40c0c4f93a8a5250ee8109c9eb0c5d16730f2264c268",
-      "binarySha256": "f83498c1ae350af66285277e2da5c61c39f2a0d117cb5df9b266ec78698a27d1"
+      "archiveSha256": "6e60293bc246c7c5dbbbfffdfb700586b075381a68edbdcc5013074714aef325",
+      "binarySha256": "cdd289c75206e2786b1f1214250ed9539125d603564b02644d0c70395512af27"
     }
   }
 }

--- a/scripts/verify-flatpak-packaging.mjs
+++ b/scripts/verify-flatpak-packaging.mjs
@@ -18,7 +18,8 @@ export const FLATPAK_BUILDER_TOOLS_COMMIT =
 // tag resolves to is pinned by hand (and cross-checked against the manifest).
 export const ARIA2_SOURCE = Object.freeze({
   url: 'https://github.com/motrixapp/aria2.git',
-  commit: '4368a461cc765758a533b8cd4b30d74601310cd1',
+  // v1.37.0-motrix.4 — merge of motrixapp/aria2#10 (supply-chain fixes)
+  commit: 'bfc033ae4d054c78ad7aac3faff4f11c56b4d363',
 })
 
 const PNPM_SOURCE = Object.freeze({

--- a/tests/check-third-party-notices.test.ts
+++ b/tests/check-third-party-notices.test.ts
@@ -256,9 +256,9 @@ describe('third-party graph dependency notices', () => {
 
       expect(notice).toContain('SFNS-Regular.ttf')
       expect(notice).toContain('https://developer.apple.com/fonts/')
-      expect(notice).toContain('1.37.0-motrix.3')
+      expect(notice).toContain('1.37.0-motrix.4')
       expect(notice).toContain(
-        'https://github.com/motrixapp/aria2/tree/v1.37.0-motrix.3'
+        'https://github.com/motrixapp/aria2/tree/v1.37.0-motrix.4'
       )
       expect(notice).toContain('GPL-2.0-or-later')
       expect(notice).toContain('THIRD_PARTY_LICENSES/aria2-COPYING')

--- a/tests/generate-third-party-notices.test.ts
+++ b/tests/generate-third-party-notices.test.ts
@@ -164,7 +164,7 @@ describe('third-party notice generator', () => {
 
     expect(bundle.packageCount).toBeGreaterThan(100)
     expect(inventory).toContain('| @xyflow/react | 12.11.3 |')
-    expect(inventory).toContain('| aria2 | 1.37.0-motrix.3 |')
+    expect(inventory).toContain('| aria2 | 1.37.0-motrix.4 |')
     expect(inventory).toContain('| motrix.filename-template | 1.1.1 |')
     expect(inventory).toContain('Apple San Francisco tray font')
     expect(licenses).toContain('GNU GENERAL PUBLIC LICENSE')


### PR DESCRIPTION
## What

Bumps the bundled aria2 engine from `1.37.0-motrix.3` to `1.37.0-motrix.4` (motrixapp/aria2#10 — the supply-chain hardening release):

- c-ares 1.34.6 → **1.34.8** (CVE-2026-33630 High UAF in `ares_getaddrinfo()`, plus two DoS fixes)
- libssh2 1.11.1 **patched for CVE-2026-55200 (CVSS 9.2, client-side RCE, public PoC) and CVE-2026-55199** — no upstream release exists yet
- expat 2.7.5 → 2.8.3, sqlite 3.51.3 → 3.53.4, libgpg-error 1.59 → 1.61
- every engine build lane now sha256-verifies its dependency downloads

Together with the `dnsMode` auto fallback already on main (#1870), this completes the DNS failure remediation: a fresher resolver stack in the engine, and a system-resolver retry above it.

## Changes

- `scripts/engine.lock.json`: re-pinned via `fetch-engine.mjs --write-lock --tag v1.37.0-motrix.4` (7 platform assets)
- `THIRD_PARTY_NOTICES.md` / `.zh-CN.md`: regenerated (`build:legal`) + aria2 section updated
- `flatpak/app.motrix.native.yml`: tag, `AC_INIT` version pin, `--version` smoke string, and git source commit (`bfc033ae…`, verified independently via the GitHub API as the tag's merge commit)
- `scripts/verify-flatpak-packaging.mjs`: `ARIA2_SOURCE.commit` anchor re-pinned (the intentional human confirmation point against tag moves)
- `.github/workflows/flatpak.yml` smoke string; hardcoded version assertions in the two notices tests

Historical references intentionally left at `motrix.3` (`feature-report.ts` comment, `aria2-adapter.test.ts` "on 1.37.0-motrix.3+" — the `+` covers `.4`).

## How verified

- All 7 lockfile archive digests cross-checked against the release `SHA256SUMS` (independently downloaded)
- Host binary installed via `fetch-engine.mjs` and reports `aria2 version 1.37.0-motrix.4`
- `tests/scripts/` full contract suite: 550/550 (including fetch-engine and Flatpak packaging contracts)
- `check:third-party-notices` (21/21), `pnpm run lint` (exit 0), `tsc --noEmit`, `check:boundaries` all green
