### PR TITLE
chore(release): prepare 2.0.0-beta.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. After its remaining release gates pass,
-download [v2.0.0-beta.17 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.17)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.17.md) before
+download [v2.0.0-beta.18 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.18)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.18.md) before
 installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -158,7 +158,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.17'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.18'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。剩余发布门禁通过后，请从 GitHub Releases
-下载 [v2.0.0-beta.17](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.17)，
-并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.17.zh-CN.md)。
+下载 [v2.0.0-beta.18](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.18)，
+并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.18.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -152,7 +152,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.17'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.18'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.18.md
+++ b/docs/release-notes/2.0.0-beta.18.md
@@ -1,0 +1,72 @@
+# Motrix 2.0.0-beta.18
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.18/docs/release-notes/2.0.0-beta.18.zh-CN.md)
+
+Motrix 2.0.0-beta.18 updates the bundled aria2 engine and improves DNS
+resolution reliability. It is intended for public distribution only after
+every protected release gate passes.
+
+## Highlights
+
+- Updates the bundled desktop aria2 engine to `1.37.0-motrix.4`, with pinned
+  archives and binary checksums for every supported target.
+- Adds **Auto**, **System DNS**, and **Built-in DNS** choices under Network
+  settings on both the desktop app and Server web UI.
+- In Auto mode, Motrix starts with aria2's built-in asynchronous resolver. If
+  aria2 cannot contact any DNS server, Motrix switches the active engine
+  session to the system resolver and retries the affected task once.
+- Limits automatic fallback to recognized DNS transport failures. Deterministic
+  DNS answers and unrelated network failures are not retried, and each task is
+  retried at most once per session.
+- Adds a localized notification when an automatic DNS fallback retry occurs.
+- Adds Traditional Chinese (`zh-TW`) throughout the application.
+- Expands the Plugin SDK development guide with clearer setup, capability,
+  sandbox, packaging, and distribution guidance.
+
+## Before testing
+
+This is prerelease software. Back up existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Do not rely on this beta for your only copy of important
+downloads.
+
+## Planned downloads after release gates pass
+
+| Distribution | Architectures | Planned output |
+|--------------|---------------|----------------|
+| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | DEB and RPM |
+| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.18-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.18` tag in both registries |
+| Snap Store | — | Not published for this beta |
+
+After every container gate passes, the versioned image references will be
+`docker.io/motrixapp/motrix-server:2.0.0-beta.18` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.18`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.18/docs/docker-server.md)
+for storage, networking, and upgrade guidance.
+
+## Distribution notes
+
+- AppImage is not published for this beta.
+- Flatpak is validated separately and is not published by the release tag; the
+  GitHub prerelease includes its Native Host companion archives.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
+  Download them only from the official GitHub prerelease after it is published.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+- Snap is not published for this beta. Prerelease Snap runs stop after source
+  validation, so they do not build Snap artifacts, upload Store revisions, or
+  change `latest/edge`.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.18.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.18.zh-CN.md
@@ -1,0 +1,61 @@
+# Motrix 2.0.0-beta.18
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.18/docs/release-notes/2.0.0-beta.18.md) | 简体中文
+
+Motrix 2.0.0-beta.18 更新了内置 aria2 引擎，并提高了 DNS 解析可靠性。只有全部
+受保护发布门禁通过后，本版本才会进入公开分发。
+
+## 主要变化
+
+- 将桌面版内置 aria2 引擎升级到 `1.37.0-motrix.4`，并为全部受支持目标固定
+  archive 与二进制校验值。
+- 桌面应用与 Server Web UI 的网络设置新增**自动**、**系统解析器**和
+  **内置解析器**三种 DNS 解析方式。
+- 自动模式会先使用 aria2 的内置异步解析器。如果 aria2 无法联系任何 DNS
+  服务器，Motrix 会在当前引擎会话中切换到系统解析器，并将受影响任务重试一次。
+- 自动回退仅响应可识别的 DNS 传输失败。确定性的 DNS 返回结果与其他网络错误
+  不会触发重试；同一任务在每次会话中最多自动重试一次。
+- 自动切换 DNS 并重试任务时会显示本地化通知。
+- 新增繁体中文（`zh-TW`）界面语言。
+- 扩充 Plugin SDK 开发指南，补充环境准备、能力授权、沙箱、打包和分发说明。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据与下载文件。Motrix v1 数据的
+迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
+
+条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录并行测试 v2。
+请勿仅依赖本 beta 保存重要下载文件。
+
+## 发布门禁通过后的计划下载项
+
+| 分发方式 | 架构 | 计划产物 |
+|----------|------|----------|
+| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 与 ZIP |
+| Windows | `x64` | 未签名 NSIS 安装包（`.exe`）与 ZIP |
+| Linux | `x64`、`arm64` | DEB 与 RPM |
+| Flatpak Native Host companion | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.18-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中不可变的 `2.0.0-beta.18` tag |
+| Snap Store | — | 本 beta 不发布 |
+
+全部容器门禁通过后，带版本的镜像引用将是
+`docker.io/motrixapp/motrix-server:2.0.0-beta.18` 与
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.18`。存储、网络与升级说明请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.18/docs/docker-server.zh-CN.md)。
+
+## 分发说明
+
+- 本 beta 不发布 AppImage。
+- Flatpak 会单独验证，不会随版本 tag 发布；GitHub 预发布版包含对应的 Native
+  Host companion archive。
+- 不提供 Windows `arm64` 与任何 32 位安装包。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅在官方
+  GitHub 预发布版发布后下载。
+- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定浮动 tag。
+- 本 beta 不发布 Snap。预发布 Snap run 会在 source validation 后停止，不会
+  构建 Snap artifact、上传 Store revision，也不会更改 `latest/edge`。
+
+## 问题反馈
+
+请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现问题，
+并提供操作系统、架构、安装包类型与复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -76,6 +76,19 @@
   <releases>
     <!-- Update this list on every release; Flathub linter requires the most
          recent version listed here to match the manifest's source tag. -->
+    <release version="2.0.0-beta.18" date="2026-08-17">
+      <description>
+        <p>
+          The bundled aria2 engine is updated to 1.37.0-motrix.4. Network
+          settings now offer automatic, system, and built-in DNS resolution;
+          automatic mode falls back to the system resolver for the session and
+          retries an affected task once when the engine cannot contact a DNS
+          server. Traditional Chinese is now available. Windows packages
+          remain unsigned, and prerelease Snap runs stop after source
+          validation.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.17" date="2026-08-16">
       <description>
         <p>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.17",
+  "version": "2.0.0-beta.18",
   "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1",
   "description": "A full-featured download manager",
   "keywords": [],


### PR DESCRIPTION
## What changed

- bump the application release version to `2.0.0-beta.18`
- add paired English and Simplified Chinese release notes
- update README release and container references
- add the beta.18 Flatpak metainfo entry

## Why

This beta publishes the bundled aria2 `1.37.0-motrix.4` update and the new DNS
resolution modes with automatic session fallback and a guarded one-time task
retry. It also includes Traditional Chinese support and the expanded Plugin SDK
guide merged since beta.17.

## User impact

Users can choose Auto, System DNS, or Built-in DNS. Auto mode falls back to the
system resolver for the active session when aria2 cannot contact a DNS server,
then retries the affected task once.

## Verification

- `pnpm run check:file-names`
- `pnpm run check:boundaries`
- `pnpm run lint`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run tests/scripts/release-version-contract.test.ts` (22 tests)
- `pnpm run check:flatpak`
- `git diff --cached --check`
