### PR TITLE
fix(tray): preserve macos icon position

### DIFF
--- a/src/main/platform/tray.test.ts
+++ b/src/main/platform/tray.test.ts
@@ -1,0 +1,134 @@
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  appDock,
+  icon,
+  iconProvider,
+  speedometer,
+  trayConstructor,
+  trayInstance,
+} = vi.hoisted(() => {
+  const trayInstance = {
+    destroy: vi.fn(),
+    on: vi.fn(),
+    popUpContextMenu: vi.fn(),
+    removeAllListeners: vi.fn(),
+    setContextMenu: vi.fn(),
+    setIgnoreDoubleClickEvents: vi.fn(),
+    setImage: vi.fn(),
+    setToolTip: vi.fn(),
+  }
+
+  return {
+    appDock: { hide: vi.fn(), show: vi.fn() },
+    icon: { kind: 'tray-icon' },
+    iconProvider: {
+      getIcon: vi.fn(),
+      init: vi.fn(),
+    },
+    speedometer: {
+      destroy: vi.fn(),
+      onSpeedChange: vi.fn(),
+      setEnabled: vi.fn(),
+    },
+    trayConstructor: vi.fn(),
+    trayInstance,
+  }
+})
+
+vi.mock('electron', () => ({
+  app: { dock: appDock },
+  Tray: class {
+    destroy = trayInstance.destroy
+    on = trayInstance.on
+    popUpContextMenu = trayInstance.popUpContextMenu
+    removeAllListeners = trayInstance.removeAllListeners
+    setContextMenu = trayInstance.setContextMenu
+    setIgnoreDoubleClickEvents = trayInstance.setIgnoreDoubleClickEvents
+    setImage = trayInstance.setImage
+    setToolTip = trayInstance.setToolTip
+
+    constructor(...args: unknown[]) {
+      trayConstructor(...args)
+    }
+  },
+}))
+
+vi.mock('@core/logger', () => ({
+  getLogger: () => ({ error: vi.fn(), info: vi.fn() }),
+}))
+
+vi.mock('./tray-icon', () => ({
+  createIconProvider: () => iconProvider,
+}))
+
+vi.mock('./tray-speedometer', () => ({
+  createSpeedometer: () => speedometer,
+}))
+
+import { RunMode } from '@shared/constants'
+import { setupTray, type TrayDeps } from './tray'
+
+const originalPlatform = process.platform
+
+function createDeps(): TrayDeps {
+  return {
+    eventBus: {
+      off: vi.fn(),
+      on: vi.fn(),
+    },
+    settingsManager: {
+      getApp: () => ({
+        runMode: RunMode.Standard,
+        traySpeedometer: false,
+      }),
+    },
+    menuManager: {
+      getTrayMenu: () => null,
+      onTrayRebuilt: vi.fn(),
+    },
+    protocolManager: {
+      handle: vi.fn(),
+      handleTorrentFile: vi.fn(),
+    },
+    extraResourceDir: path.join(process.cwd(), 'extra'),
+  } as unknown as TrayDeps
+}
+
+describe('setupTray', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    iconProvider.getIcon.mockReturnValue(icon)
+    iconProvider.init.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform })
+  })
+
+  it('uses a stable GUID on macOS so the system can restore its position', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+
+    const handle = setupTray(createDeps())
+
+    await vi.waitFor(() => {
+      expect(trayConstructor).toHaveBeenCalledWith(
+        icon,
+        '493f17b6-d4ac-48d3-8723-c3ac490b14cf'
+      )
+    })
+    handle.destroy()
+  })
+
+  it('does not pass the macOS GUID on other platforms', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+
+    const handle = setupTray(createDeps())
+
+    await vi.waitFor(() => {
+      expect(trayConstructor).toHaveBeenCalledWith(icon)
+    })
+    handle.destroy()
+  })
+})

--- a/src/main/platform/tray.ts
+++ b/src/main/platform/tray.ts
@@ -18,6 +18,10 @@ import { createSpeedometer } from './tray-speedometer'
 // Module-scope getLogger() runs before initLogger() and would only
 // write to stdout (invisible in packaged apps).
 
+// Keep this value stable: macOS uses it to restore the tray item's position
+// between launches.
+const MACOS_TRAY_GUID = '493f17b6-d4ac-48d3-8723-c3ac490b14cf'
+
 // Linux requires setContextMenu for the context menu to work.
 function applyMenuToTray(tray: Tray, menu: Menu): void {
   if (process.platform === 'linux') {
@@ -78,7 +82,11 @@ export function setupTray(deps: TrayDeps): TrayHandle {
     iconProvider = createIconProvider(svgPath, trayAssetDir)
     await iconProvider.init()
 
-    tray = new Tray(iconProvider.getIcon(false))
+    const icon = iconProvider.getIcon(false)
+    tray =
+      process.platform === 'darwin'
+        ? new Tray(icon, MACOS_TRAY_GUID)
+        : new Tray(icon)
 
     if (process.platform !== 'darwin') {
       tray.setToolTip('Motrix')


### PR DESCRIPTION
## Summary

- assign a stable UUID to the Electron tray item on macOS
- keep the existing tray construction behavior on Linux and Windows
- add regression coverage for macOS and non-macOS tray construction

## Root cause

Motrix created the macOS tray item with `new Tray(image)` and did not provide the optional Electron GUID. Without a stable GUID, macOS could not reliably associate the recreated status item with its previously saved menu-bar position.

## Impact

After users position the Motrix menu-bar icon once, macOS can restore that position on subsequent application launches.

## Validation

- `node scripts/check-boundaries.mjs`
- `./node_modules/.bin/biome check .`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run src/main/platform/tray.test.ts`
- `git diff --cached --check`

Fixes #1873