### PR TITLE
fix(tray): restore window toggle on left click

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2241,6 +2241,7 @@ async function initializeMainProcess(): Promise<void> {
     menuManager: activeMenuManager,
     protocolManager,
     extraResourceDir: platform.extraResourceDir,
+    toggleMainWindow: () => windowManager.toggle('main'),
   })
 
   launcher.flushDeferred()

--- a/src/main/platform/tray.test.ts
+++ b/src/main/platform/tray.test.ts
@@ -71,7 +71,9 @@ import { RunMode } from '@shared/constants'
 import { setupTray, type TrayDeps } from './tray'
 
 const originalPlatform = process.platform
+const trayMenu = { kind: 'tray-menu' }
 const toggleMainWindow = vi.fn()
+
 function createDeps(): TrayDeps {
   return {
     eventBus: {
@@ -85,7 +87,7 @@ function createDeps(): TrayDeps {
       }),
     },
     menuManager: {
-      getTrayMenu: () => null,
+      getTrayMenu: () => trayMenu,
       onTrayRebuilt: vi.fn(),
     },
     protocolManager: {
@@ -95,6 +97,15 @@ function createDeps(): TrayDeps {
     extraResourceDir: path.join(process.cwd(), 'extra'),
     toggleMainWindow,
   } as unknown as TrayDeps
+}
+
+function getTrayHandler(eventName: string): () => void {
+  const handler = trayInstance.on.mock.calls.find(
+    ([event]) => event === eventName
+  )?.[1]
+
+  expect(handler).toBeTypeOf('function')
+  return handler as () => void
 }
 
 describe('setupTray', () => {
@@ -119,6 +130,7 @@ describe('setupTray', () => {
         '493f17b6-d4ac-48d3-8723-c3ac490b14cf'
       )
     })
+
     handle.destroy()
   })
 
@@ -130,28 +142,78 @@ describe('setupTray', () => {
     await vi.waitFor(() => {
       expect(trayConstructor).toHaveBeenCalledWith(icon)
     })
+
     handle.destroy()
   })
-  it('toggles the main window on left click on Windows', async () => {
+
+  it('toggles the main window without opening the menu on Windows left click', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
 
     const handle = setupTray(createDeps())
 
     await vi.waitFor(() => {
-      expect(trayConstructor).toHaveBeenCalled()
+      expect(trayInstance.on).toHaveBeenCalledWith(
+        'click',
+        expect.any(Function)
+      )
     })
 
-    const clickHandler = trayInstance.on.mock.calls.find(
-      ([event]) => event === 'click'
-    )?.[1] as (() => void) | undefined
-
-    expect(clickHandler).toBeDefined()
-
-    clickHandler?.()
+    getTrayHandler('click')()
 
     expect(toggleMainWindow).toHaveBeenCalledOnce()
     expect(trayInstance.popUpContextMenu).not.toHaveBeenCalled()
 
     handle.destroy()
   })
+
+  it('opens the menu without toggling the window on Windows right click', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    const handle = setupTray(createDeps())
+
+    await vi.waitFor(() => {
+      expect(trayInstance.on).toHaveBeenCalledWith(
+        'right-click',
+        expect.any(Function)
+      )
+    })
+
+    getTrayHandler('right-click')()
+
+    expect(trayInstance.popUpContextMenu).toHaveBeenCalledExactlyOnceWith(
+      trayMenu
+    )
+    expect(toggleMainWindow).not.toHaveBeenCalled()
+
+    handle.destroy()
+  })
+
+  it.each(['darwin', 'linux'] as const)(
+    'preserves the tray-menu behavior on %s left click',
+    async (platform) => {
+      Object.defineProperty(process, 'platform', { value: platform })
+
+      const handle = setupTray(createDeps())
+
+      await vi.waitFor(() => {
+        expect(trayInstance.on).toHaveBeenCalledWith(
+          'click',
+          expect.any(Function)
+        )
+      })
+
+      getTrayHandler('click')()
+
+      expect(trayInstance.popUpContextMenu).toHaveBeenCalledExactlyOnceWith(
+        trayMenu
+      )
+      expect(toggleMainWindow).not.toHaveBeenCalled()
+
+      if (platform === 'linux') {
+        expect(trayInstance.setContextMenu).toHaveBeenCalledWith(trayMenu)
+      }
+
+      handle.destroy()
+    }
+  )
 })

--- a/src/main/platform/tray.test.ts
+++ b/src/main/platform/tray.test.ts
@@ -71,7 +71,7 @@ import { RunMode } from '@shared/constants'
 import { setupTray, type TrayDeps } from './tray'
 
 const originalPlatform = process.platform
-
+const toggleMainWindow = vi.fn()
 function createDeps(): TrayDeps {
   return {
     eventBus: {
@@ -93,6 +93,7 @@ function createDeps(): TrayDeps {
       handleTorrentFile: vi.fn(),
     },
     extraResourceDir: path.join(process.cwd(), 'extra'),
+    toggleMainWindow,
   } as unknown as TrayDeps
 }
 
@@ -129,6 +130,28 @@ describe('setupTray', () => {
     await vi.waitFor(() => {
       expect(trayConstructor).toHaveBeenCalledWith(icon)
     })
+    handle.destroy()
+  })
+  it('toggles the main window on left click on Windows', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    const handle = setupTray(createDeps())
+
+    await vi.waitFor(() => {
+      expect(trayConstructor).toHaveBeenCalled()
+    })
+
+    const clickHandler = trayInstance.on.mock.calls.find(
+      ([event]) => event === 'click'
+    )?.[1] as (() => void) | undefined
+
+    expect(clickHandler).toBeDefined()
+
+    clickHandler?.()
+
+    expect(toggleMainWindow).toHaveBeenCalledOnce()
+    expect(trayInstance.popUpContextMenu).not.toHaveBeenCalled()
+
     handle.destroy()
   })
 })

--- a/src/main/platform/tray.ts
+++ b/src/main/platform/tray.ts
@@ -35,6 +35,7 @@ export interface TrayDeps {
   menuManager: MenuManager
   protocolManager: ReturnType<typeof createProtocolManager>
   extraResourceDir: string
+  toggleMainWindow: () => void
 }
 
 export interface TrayHandle {
@@ -49,7 +50,8 @@ export function setupTray(deps: TrayDeps): TrayHandle {
     menuManager,
     protocolManager,
     extraResourceDir,
-  } = deps
+    toggleMainWindow,
+} = deps
 
   // Resolve asset paths — all tray assets live in extra/tray/
   const trayAssetDir = path.join(extraResourceDir, 'tray')
@@ -109,9 +111,14 @@ export function setupTray(deps: TrayDeps): TrayHandle {
 
     // Events
     tray.on('click', () => {
+      if (process.platform === 'win32') {
+        toggleMainWindow()
+        return
+      }
+
       if (currentMenu) tray?.popUpContextMenu(currentMenu)
     })
-
+  
     tray.on('right-click', () => {
       if (currentMenu) tray?.popUpContextMenu(currentMenu)
     })

--- a/src/main/platform/tray.ts
+++ b/src/main/platform/tray.ts
@@ -51,7 +51,7 @@ export function setupTray(deps: TrayDeps): TrayHandle {
     protocolManager,
     extraResourceDir,
     toggleMainWindow,
-} = deps
+  } = deps
 
   // Resolve asset paths — all tray assets live in extra/tray/
   const trayAssetDir = path.join(extraResourceDir, 'tray')
@@ -118,7 +118,7 @@ export function setupTray(deps: TrayDeps): TrayHandle {
 
       if (currentMenu) tray?.popUpContextMenu(currentMenu)
     })
-  
+
     tray.on('right-click', () => {
       if (currentMenu) tray?.popUpContextMenu(currentMenu)
     })


### PR DESCRIPTION
## Summary

- restore Windows tray left-click behavior to toggle the main window
- preserve existing context-menu behavior on other platforms and on right-click
- add a regression test for the Windows tray click behavior

Fixes #1880

## Testing

- `pnpm exec vitest run src/main/platform/tray.test.ts` — passed (6 tests)
- `pnpm run check:boundaries` — passed
- `pnpm run lint` — passed
- `pnpm exec tsc --noEmit` — passed

All checks were run on the PR branch in GitHub Codespaces.