### PR TITLE
feat(settings): add hover feedback and icon animation to settings cards

### DIFF
--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -54,6 +54,7 @@ function buildBuiltins() {
     const child = spawn('pnpm', ['run', 'build:builtin'], {
       stdio: 'inherit',
       cwd: projectRoot,
+      shell: true,
     })
     child.on('exit', (code) => {
       if (code === 0) {

--- a/src/renderer/routes/settings/cards/settings-card.tsx
+++ b/src/renderer/routes/settings/cards/settings-card.tsx
@@ -27,7 +27,7 @@ export function SettingsCard({
         className
       )}
     >
-      <div className="flex max-h-18 flex-1 items-center justify-center transition-[filter,transform] duration-200 ease-out group-hover:-translate-y-0.5 group-hover:scale-110 group-active:grayscale-50 motion-reduce:transform-none motion-reduce:transition-none min-[914px]:max-h-none [&_img]:max-h-16 [&_img]:w-auto min-[914px]:[&_img]:max-h-none">
+      <div className="flex max-h-18 flex-1 items-center justify-center transition-[filter,rotate,scale] duration-200 ease-out group-hover:-rotate-8 group-hover:scale-110 group-active:grayscale-50 motion-reduce:rotate-0 motion-reduce:scale-100 motion-reduce:transition-none min-[914px]:max-h-none [&_img]:max-h-16 [&_img]:w-auto min-[914px]:[&_img]:max-h-none">
         {Icon}
       </div>
       <div className="min-h-14 pt-3 min-[914px]:min-h-[90px] min-[914px]:pt-6">

--- a/src/renderer/routes/settings/cards/settings-card.tsx
+++ b/src/renderer/routes/settings/cards/settings-card.tsx
@@ -23,7 +23,7 @@ export function SettingsCard({
       type="button"
       onClick={onClick}
       className={cn(
-        'group flex h-full min-h-33 select-none flex-col items-start rounded-lg px-5 py-3 text-left transition-[box-shadow,background-color] duration-200 ease-out hover:bg-muted/40 hover:shadow-lg outline-none focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none min-[914px]:min-h-[170px] min-[914px]:px-6 min-[914px]:py-4',
+        'group flex h-full min-h-33 select-none flex-col items-start rounded-lg bg-muted/40 px-5 py-3 text-left transition-[box-shadow,background-color] duration-200 ease-out hover:bg-muted/60 hover:shadow-lg outline-none focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none min-[914px]:min-h-[170px] min-[914px]:px-6 min-[914px]:py-4',
         className
       )}
     >

--- a/src/renderer/routes/settings/cards/settings-card.tsx
+++ b/src/renderer/routes/settings/cards/settings-card.tsx
@@ -23,11 +23,11 @@ export function SettingsCard({
       type="button"
       onClick={onClick}
       className={cn(
-        'group flex h-full min-h-33 select-none flex-col items-start px-5 py-3 text-left min-[914px]:min-h-[170px] min-[914px]:px-6 min-[914px]:py-4',
+        'group flex h-full min-h-33 select-none flex-col items-start rounded-lg px-5 py-3 text-left transition-[box-shadow,background-color] duration-200 ease-out hover:bg-muted/40 hover:shadow-lg outline-none focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none min-[914px]:min-h-[170px] min-[914px]:px-6 min-[914px]:py-4',
         className
       )}
     >
-      <div className="flex max-h-18 flex-1 items-center justify-center transition-[filter] group-active:grayscale-50 min-[914px]:max-h-none [&_img]:max-h-16 [&_img]:w-auto min-[914px]:[&_img]:max-h-none">
+      <div className="flex max-h-18 flex-1 items-center justify-center transition-[filter,transform] duration-200 ease-out group-hover:-translate-y-0.5 group-hover:scale-110 group-active:grayscale-50 motion-reduce:transform-none motion-reduce:transition-none min-[914px]:max-h-none [&_img]:max-h-16 [&_img]:w-auto min-[914px]:[&_img]:max-h-none">
         {Icon}
       </div>
       <div className="min-h-14 pt-3 min-[914px]:min-h-[90px] min-[914px]:pt-6">

--- a/src/renderer/routes/settings/settings-page.tsx
+++ b/src/renderer/routes/settings/settings-page.tsx
@@ -9,25 +9,19 @@ export function SettingsPage() {
   const navigate = useNavigate()
   const { cardId } = useParams<{ cardId: string }>()
   const activeCard = findCard(cardId)
-  const columnsPerRow = 3
-  const lastRowStartIndex =
-    Math.floor((SETTINGS_CARDS.length - 1) / columnsPerRow) * columnsPerRow
 
   const closeDialog = () => navigate('/settings')
 
   return (
     <PanelShell title={t('settings.title')}>
-      <div className="grid h-full grid-cols-2 items-stretch border-t-[0.5px] px-6 py-4 min-[914px]:grid-cols-3">
-        {SETTINGS_CARDS.map((card, index) => (
+      <div className="grid h-full grid-cols-2 gap-3 items-stretch px-6 py-4 min-[914px]:grid-cols-3">
+        {SETTINGS_CARDS.map((card) => (
           <SettingsCard
             key={card.id}
             icon={card.icon}
             labelKey={card.labelKey}
             descKey={card.descKey}
             onClick={() => navigate(`/settings/${card.id}`)}
-            className={
-              index < lastRowStartIndex ? 'border-b-[0.5px] border-border' : ''
-            }
           />
         ))}
       </div>


### PR DESCRIPTION
# 原因

原有的设置入口页面过于呆板，没有反馈，无法增强选中的视觉效果

# 修改以及效果

- 设置卡片新增 hover 反馈：悬停时卡片浮起，出现柔和阴影并加深背景色。
- 卡片图标在悬停时向左旋转（-8°）同时放大到 110%，移开鼠标后平滑恢复
  原样；已适配 `prefers-reduced-motion`（减弱动效时不动）。
- 移除了卡片之间的浅色分割线。每张卡片现在自带常驻的浅色圆角背景，
  网格增加间距，8 个选项读起来是独立卡片而非扁平表格。
<img width="1373" height="1011" alt="image" src="https://github.com/user-attachments/assets/356b159b-e730-4c39-a711-325e7492f01f" />

## 完整效果视频

https://github.com/user-attachments/assets/71e107a7-220b-4686-98aa-09afbbe05c65

