### PR TITLE
fix(dashboard): prevent activity tooltip resize loop

### DIFF
--- a/e2e/activity-tile.spec.ts
+++ b/e2e/activity-tile.spec.ts
@@ -25,6 +25,10 @@ interface PointerProfile {
   repaintCount: number
   pixelsStable: boolean
   tooltipCountAfterSettle: number
+  tooltipMountedFrames: number
+  tooltipPositionChanges: number
+  tooltipTextChanges: number
+  resizeObserverLoopErrors: string[]
 }
 
 interface ResizeFrameProfile {
@@ -531,26 +535,90 @@ async function pointerProfile(page: Page): Promise<PointerProfile> {
     const contextPrototype = CanvasRenderingContext2D.prototype
     const originalClearRect = contextPrototype.clearRect
     let repaintCount = 0
+    const resizeObserverLoopErrors: string[] = []
+    const captureResizeObserverLoopError = (event: ErrorEvent) => {
+      if (event.message.includes('ResizeObserver loop')) {
+        resizeObserverLoopErrors.push(event.message)
+      }
+    }
     contextPrototype.clearRect = function patchedClearRect(...args) {
       if (this.canvas === canvas) repaintCount += 1
       return originalClearRect.apply(this, args)
     }
+    window.addEventListener('error', captureResizeObserverLoopError)
 
     try {
+      const calendarElement = calendar as HTMLElement
+      calendarElement.focus()
+      await new Promise<void>((resolve) =>
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+      )
+      const tooltip = document.querySelector<HTMLElement>('[role="tooltip"]')
+      const anchor = calendar.querySelector<HTMLElement>(
+        '[data-testid="activity-tooltip-anchor"]'
+      )
+      if (!tooltip || !anchor) {
+        throw new Error('Activity tooltip did not open before pointer sweep')
+      }
+      const pointAtAnchor = () => {
+        const anchorRect = anchor.getBoundingClientRect()
+        return {
+          x: anchorRect.left + anchorRect.width / 2,
+          y: anchorRect.top + anchorRect.height / 2,
+        }
+      }
+      const firstPoint = pointAtAnchor()
+      calendar.dispatchEvent(
+        new KeyboardEvent('keydown', { bubbles: true, key: 'ArrowLeft' })
+      )
+      await new Promise<void>((resolve) =>
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+      )
+      const secondPoint = pointAtAnchor()
+      if (firstPoint.x === secondPoint.x && firstPoint.y === secondPoint.y) {
+        throw new Error('Activity keyboard navigation did not move the anchor')
+      }
+
       const before = canvas.toDataURL()
-      const rect = calendar.getBoundingClientRect()
       const startedAt = performance.now()
-      for (let index = 0; index < 1_000; index += 1) {
-        const x = rect.left + 30 + ((index * 17) % Math.max(1, rect.width - 34))
-        const y = rect.top + 18 + ((index * 11) % Math.max(1, rect.height - 22))
-        calendar.dispatchEvent(
-          new PointerEvent('pointermove', {
-            bubbles: true,
-            clientX: x,
-            clientY: y,
-            pointerType: 'mouse',
-          })
+      const points = [firstPoint, secondPoint]
+      let tooltipMountedFrames = 0
+      let tooltipPositionChanges = 0
+      let tooltipTextChanges = 0
+      let previousTooltipText = tooltip.textContent
+      let previousTooltipRect = tooltip.getBoundingClientRect()
+      for (let frame = 0; frame < 120; frame += 1) {
+        for (let step = 0; step < 7; step += 1) {
+          const point = points[(frame + step) % points.length]
+          if (!point) throw new Error('Activity pointer target is unavailable')
+          calendar.dispatchEvent(
+            new PointerEvent('pointermove', {
+              bubbles: true,
+              clientX: point.x,
+              clientY: point.y,
+              pointerType: 'mouse',
+            })
+          )
+        }
+        await new Promise<void>((resolve) =>
+          requestAnimationFrame(() => resolve())
         )
+        const currentTooltip =
+          document.querySelector<HTMLElement>('[role="tooltip"]')
+        if (currentTooltip === tooltip) tooltipMountedFrames += 1
+        const currentTooltipText = tooltip.textContent
+        if (currentTooltipText !== previousTooltipText) {
+          tooltipTextChanges += 1
+        }
+        previousTooltipText = currentTooltipText
+        const currentTooltipRect = tooltip.getBoundingClientRect()
+        if (
+          currentTooltipRect.left !== previousTooltipRect.left ||
+          currentTooltipRect.top !== previousTooltipRect.top
+        ) {
+          tooltipPositionChanges += 1
+        }
+        previousTooltipRect = currentTooltipRect
       }
       calendar.dispatchEvent(
         new PointerEvent('pointerout', {
@@ -570,9 +638,14 @@ async function pointerProfile(page: Page): Promise<PointerProfile> {
         pixelsStable: before === canvas.toDataURL(),
         tooltipCountAfterSettle:
           document.querySelectorAll('[role="tooltip"]').length,
+        tooltipMountedFrames,
+        tooltipPositionChanges,
+        tooltipTextChanges,
+        resizeObserverLoopErrors,
       }
     } finally {
       contextPrototype.clearRect = originalClearRect
+      window.removeEventListener('error', captureResizeObserverLoopError)
     }
   })
 }
@@ -1290,6 +1363,10 @@ test.describe('Activity Tile production renderer', () => {
     expect(pointer.repaintCount).toBe(0)
     expect(pointer.pixelsStable).toBe(true)
     expect(pointer.tooltipCountAfterSettle).toBe(0)
+    expect(pointer.tooltipMountedFrames).toBe(120)
+    expect(pointer.tooltipPositionChanges).toBeGreaterThan(0)
+    expect(pointer.tooltipTextChanges).toBe(120)
+    expect(pointer.resizeObserverLoopErrors).toEqual([])
     expect(
       resizeFrameProfiles.every((profile) => profile.coalescedFrames === 1)
     ).toBe(true)

--- a/src/renderer/components/ui/tooltip.tsx
+++ b/src/renderer/components/ui/tooltip.tsx
@@ -29,18 +29,27 @@ function TooltipContent({
   sideOffset = 4,
   align = 'center',
   alignOffset = 0,
+  anchor,
+  disableAnchorTracking,
   children,
   ...props
 }: TooltipPrimitive.Popup.Props &
   Pick<
     TooltipPrimitive.Positioner.Props,
-    'align' | 'alignOffset' | 'side' | 'sideOffset'
+    | 'align'
+    | 'alignOffset'
+    | 'anchor'
+    | 'disableAnchorTracking'
+    | 'side'
+    | 'sideOffset'
   >) {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Positioner
         align={align}
         alignOffset={alignOffset}
+        anchor={anchor}
+        disableAnchorTracking={disableAnchorTracking}
         side={side}
         sideOffset={sideOffset}
         className="isolate z-50"

--- a/src/renderer/routes/dashboard/activity/activity-calendar.test.tsx
+++ b/src/renderer/routes/dashboard/activity/activity-calendar.test.tsx
@@ -434,6 +434,50 @@ describe('ActivityCalendar', () => {
     expect(screen.queryByRole('tooltip')).toBeNull()
   })
 
+  it('does not add resize observers while retargeting an open Tooltip', async () => {
+    vi.useFakeTimers({
+      toFake: ['setTimeout', 'clearTimeout', 'Date', 'performance'],
+    })
+    const view = render(
+      <ActivityCalendar
+        snapshot={activitySnapshot()}
+        contentLevel="compact"
+        now={new Date(2026, 6, 29, 12)}
+      />,
+      { wrapper }
+    )
+    await flushFrames()
+
+    const observerCountAfterMount = resizeObservers.length
+    expect(observerCountAfterMount).toBeGreaterThan(0)
+    const geometry = selectActivityGeometry({
+      width: calendarSize.width,
+      height: calendarSize.height,
+      contentLevel: 'compact',
+    })
+    if (!geometry) throw new Error('Missing test geometry')
+    const grid = screen.getByRole('grid')
+    const point = (column: number) => ({
+      clientX: geometry.gridLeft + column * geometry.stride + 1,
+      clientY: geometry.gridTop + 1,
+    })
+
+    fireEvent.pointerMove(grid, point(0))
+    await advanceTimersByTime(ACTIVITY_TOOLTIP_OPEN_DELAY_MS)
+    expect(screen.getByRole('tooltip')).not.toBeNull()
+    expect(resizeObservers).toHaveLength(observerCountAfterMount)
+
+    for (let column = 1; column < geometry.weeks; column += 1) {
+      fireEvent.pointerMove(grid, point(column))
+    }
+    expect(resizeObservers).toHaveLength(observerCountAfterMount)
+
+    view.unmount()
+    expect(
+      resizeObservers.every((observer) => observer.targets.size === 0)
+    ).toBe(true)
+  })
+
   it('keeps the rounded focus border inside a grid that touches every edge', async () => {
     calendarSize.width = 103
     calendarSize.height = 55

--- a/src/renderer/routes/dashboard/activity/activity-calendar.tsx
+++ b/src/renderer/routes/dashboard/activity/activity-calendar.tsx
@@ -288,6 +288,7 @@ export function ActivityCalendar({
 
   const containerRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
+  const tooltipAnchorRef = useRef<HTMLSpanElement>(null)
   const scheduleRef = useRef<(() => void) | null>(null)
   const projectionCacheRef = useRef<{
     source: readonly ActivityCalendarCell[]
@@ -966,6 +967,17 @@ export function ActivityCalendar({
     geometry && tooltipIndex !== null
       ? cellPosition(geometry, tooltipIndex)
       : null
+  // Tooltip text changes width while the pointer crosses cells. A fresh
+  // virtual anchor makes each React commit reposition explicitly, so Base UI
+  // does not need an element ResizeObserver on this high-frequency path.
+  const tooltipAnchor =
+    tooltipCell && tooltipPosition
+      ? {
+          contextElement: containerRef.current ?? undefined,
+          getBoundingClientRect: () =>
+            tooltipAnchorRef.current?.getBoundingClientRect() ?? new DOMRect(),
+        }
+      : null
   const monthLabels = useMemo(() => activityMonthLabels(cells), [cells])
   const tooltipDetails = tooltipCell
     ? [
@@ -1129,6 +1141,7 @@ export function ActivityCalendar({
           id={tooltipTriggerId}
           render={
             <span
+              ref={tooltipAnchorRef}
               aria-hidden="true"
               tabIndex={-1}
               data-testid="activity-tooltip-anchor"
@@ -1177,6 +1190,8 @@ export function ActivityCalendar({
 
       {tooltipCell ? (
         <TooltipContent
+          anchor={tooltipAnchor}
+          disableAnchorTracking
           side="top"
           className="max-w-none animate-none px-3 py-2 transition-none data-open:animate-none data-closed:animate-none"
         >


### PR DESCRIPTION
## Summary

- replace Activity Tile tooltip element resize tracking with an explicitly refreshed virtual anchor
- keep Base UI collision positioning while avoiding the ResizeObserver feedback loop during rapid cell retargeting
- add unit and Electron regression coverage for observer lifecycle, tooltip reuse, positioning, and console errors

## Root cause

The Activity calendar keeps one tooltip mounted while the pointer crosses cells. Each retarget changes both the anchor position and tooltip text dimensions. Base UI/Floating UI observed the moving anchor and resized popup, then synchronously recalculated positioning from its ResizeObserver callback. Rapid movement could therefore produce `ResizeObserver loop completed with undelivered notifications`.

The calendar's own observer and tooltip timers were already cleaned up correctly, so this was a layout feedback loop rather than a retained observer leak.

## Impact

Rapid pointer movement across Activity Tile cells no longer emits renderer errors. Tooltip keyboard/pointer behavior, collision handling, resize/DPR handling, localization, and Canvas rendering remain intact.

## Validation

- `pnpm run check:boundaries`
- `pnpm run lint`
- `pnpm exec tsc --noEmit`
- focused Vitest: 32 tests passed
- Activity Tile Electron E2E: 1 passed
  - tooltip retained for 120/120 retarget frames
  - tooltip text and position followed every target change
  - 0 ResizeObserver loop errors
  - 0 Canvas repaints during the pointer sweep
  - 0 tooltip nodes left after settling
- Electron renderer build completed successfully
