### PR TITLE
fix: sync and align window controls

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1356,10 +1356,6 @@ async function initializeMainProcess(): Promise<void> {
 
   const engineSettings = settingsManager.getEngine()
 
-  // Apply persisted theme to Electron's nativeTheme BEFORE opening windows,
-  // so macOS vibrancy + titlebar paint in the right mode on the first frame.
-  setupNativeThemeSync(eventBus, settingsManager)
-
   const gate = new DisclaimerGate({ settings: settingsManager })
   pendingDisclaimerGate = gate.isAccepted() ? null : gate
   const liquidGlass = new LiquidGlassController({ settingsManager })
@@ -1374,6 +1370,11 @@ async function initializeMainProcess(): Promise<void> {
         ? 'onboarding'
         : requested,
     onSessionEnd: () => quitController.markSessionEnding(),
+  })
+  // Apply the persisted theme before opening windows, then keep Windows
+  // caption symbols synchronized with the resolved app/system theme.
+  setupNativeThemeSync(eventBus, settingsManager, (shouldUseDarkColors) => {
+    windowManager.syncWindowControlsTheme(shouldUseDarkColors)
   })
   // Install forwarding before the onboarding window becomes interactive.
   // SetDisclaimerLanguage persists before its asynchronous locale transaction

--- a/src/main/platform/native-theme-sync.test.ts
+++ b/src/main/platform/native-theme-sync.test.ts
@@ -6,6 +6,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const { nativeThemeMock } = vi.hoisted(() => ({
   nativeThemeMock: {
     themeSource: 'system' as 'system' | 'light' | 'dark',
+    shouldUseDarkColors: false,
+    on: vi.fn(),
+    off: vi.fn(),
   },
 }))
 
@@ -29,7 +32,9 @@ function makeSettingsManager(theme: 'system' | 'light' | 'dark') {
 
 describe('setupNativeThemeSync', () => {
   beforeEach(() => {
+    vi.clearAllMocks()
     nativeThemeMock.themeSource = 'system'
+    nativeThemeMock.shouldUseDarkColors = false
   })
 
   it('applies the persisted theme to nativeTheme on setup', () => {
@@ -56,6 +61,37 @@ describe('setupNativeThemeSync', () => {
     expect(nativeThemeMock.themeSource).toBe('light')
   })
 
+  it('reports the initial and updated resolved native theme', () => {
+    const bus = new EventBus()
+    const onResolvedThemeChanged = vi.fn()
+    setupNativeThemeSync(
+      bus,
+      makeSettingsManager('system'),
+      onResolvedThemeChanged
+    )
+
+    expect(onResolvedThemeChanged).toHaveBeenCalledWith(false)
+
+    nativeThemeMock.shouldUseDarkColors = true
+    bus.emit(Events.SettingsChanged, {
+      old: makeSettings('system'),
+      updated: makeSettings('dark'),
+    })
+    expect(onResolvedThemeChanged).toHaveBeenLastCalledWith(true)
+
+    const updatedListener = nativeThemeMock.on.mock.calls.find(
+      ([event]) => event === 'updated'
+    )?.[1] as (() => void) | undefined
+    expect(updatedListener).toBeTypeOf('function')
+
+    nativeThemeMock.shouldUseDarkColors = false
+    updatedListener?.()
+    updatedListener?.()
+
+    expect(onResolvedThemeChanged).toHaveBeenCalledTimes(3)
+    expect(onResolvedThemeChanged).toHaveBeenLastCalledWith(false)
+  })
+
   it('ignores SettingsChanged when theme is unchanged', () => {
     const bus = new EventBus()
     setupNativeThemeSync(bus, makeSettingsManager('dark'))
@@ -71,6 +107,9 @@ describe('setupNativeThemeSync', () => {
   it('destroy() unsubscribes from the EventBus', () => {
     const bus = new EventBus()
     const handle = setupNativeThemeSync(bus, makeSettingsManager('system'))
+    const updatedListener = nativeThemeMock.on.mock.calls.find(
+      ([event]) => event === 'updated'
+    )?.[1]
     handle.destroy()
 
     bus.emit(Events.SettingsChanged, {
@@ -78,5 +117,6 @@ describe('setupNativeThemeSync', () => {
       updated: makeSettings('dark'),
     })
     expect(nativeThemeMock.themeSource).toBe('system')
+    expect(nativeThemeMock.off).toHaveBeenCalledWith('updated', updatedListener)
   })
 })

--- a/src/main/platform/native-theme-sync.ts
+++ b/src/main/platform/native-theme-sync.ts
@@ -21,9 +21,25 @@ export interface NativeThemeSyncHandle {
 // ThemeSync) stays runtime-agnostic and works in both Electron and browser.
 export function setupNativeThemeSync(
   eventBus: EventBus,
-  settingsManager: SettingsManager
+  settingsManager: SettingsManager,
+  onResolvedThemeChanged?: (shouldUseDarkColors: boolean) => void
 ): NativeThemeSyncHandle {
+  let lastShouldUseDarkColors: boolean | undefined
+
+  function notifyResolvedThemeChanged() {
+    const shouldUseDarkColors = nativeTheme.shouldUseDarkColors
+    if (shouldUseDarkColors === lastShouldUseDarkColors) return
+    lastShouldUseDarkColors = shouldUseDarkColors
+    onResolvedThemeChanged?.(shouldUseDarkColors)
+  }
+
+  function onNativeThemeUpdated() {
+    notifyResolvedThemeChanged()
+  }
+
+  nativeTheme.on('updated', onNativeThemeUpdated)
   apply(settingsManager.getApp().theme)
+  notifyResolvedThemeChanged()
 
   function onSettingsChanged(payload: unknown) {
     const { old, updated } = payload as {
@@ -32,6 +48,7 @@ export function setupNativeThemeSync(
     }
     if (old.app.theme !== updated.app.theme) {
       apply(updated.app.theme)
+      notifyResolvedThemeChanged()
     }
   }
 
@@ -40,6 +57,7 @@ export function setupNativeThemeSync(
   return {
     destroy() {
       eventBus.off(Events.SettingsChanged, onSettingsChanged)
+      nativeTheme.off('updated', onNativeThemeUpdated)
     },
   }
 }

--- a/src/main/window/platform-options.test.ts
+++ b/src/main/window/platform-options.test.ts
@@ -10,14 +10,21 @@ describe('buildPlatformOptions', () => {
     expect(opts.trafficLightPosition).toEqual({ x: 20, y: 20 })
   })
 
-  it('uses the system-adaptive title-bar symbol color on Windows', () => {
+  it('uses dark title-bar symbols for the light Windows theme', () => {
     const opts = buildPlatformOptions('win32')
     expect(opts.titleBarStyle).toBe('hidden')
     expect(opts.titleBarOverlay).toEqual({
       color: '#00000000',
-      height: 36,
+      symbolColor: '#1d1d1f',
+      height: 54,
     })
-    expect(opts.titleBarOverlay).not.toHaveProperty('symbolColor')
+  })
+
+  it('uses light title-bar symbols for the dark Windows theme', () => {
+    const opts = buildPlatformOptions('win32', {
+      shouldUseDarkColors: true,
+    })
+    expect(opts.titleBarOverlay).toMatchObject({ symbolColor: '#f5f5f5' })
   })
 
   it('uses a configured Windows title-bar symbol color', () => {

--- a/src/main/window/platform-options.ts
+++ b/src/main/window/platform-options.ts
@@ -3,7 +3,16 @@ import type { BrowserWindowConstructorOptions } from 'electron'
 export interface PlatformOptionsInput {
   vibrancy?: boolean
   liquidGlass?: boolean
+  shouldUseDarkColors?: boolean
   windowControlsSymbolColor?: string
+}
+
+export const WINDOWS_TITLE_BAR_OVERLAY_HEIGHT = 54
+
+export function getWindowsWindowControlsSymbolColor(
+  shouldUseDarkColors: boolean
+): string {
+  return shouldUseDarkColors ? '#f5f5f5' : '#1d1d1f'
 }
 
 export function buildPlatformOptions(
@@ -11,6 +20,7 @@ export function buildPlatformOptions(
   {
     vibrancy = true,
     liquidGlass = false,
+    shouldUseDarkColors = false,
     windowControlsSymbolColor,
   }: PlatformOptionsInput = {}
 ): BrowserWindowConstructorOptions {
@@ -42,10 +52,12 @@ export function buildPlatformOptions(
         titleBarStyle: 'hidden',
         titleBarOverlay: {
           color: '#00000000',
-          ...(windowControlsSymbolColor && {
-            symbolColor: windowControlsSymbolColor,
-          }),
-          height: 36,
+          symbolColor:
+            windowControlsSymbolColor ??
+            getWindowsWindowControlsSymbolColor(shouldUseDarkColors),
+          // The renderer's 28 px header actions are centered at y=27.
+          // Matching that center keeps native caption buttons on their baseline.
+          height: WINDOWS_TITLE_BAR_OVERLAY_HEIGHT,
         },
       }
     default:

--- a/src/main/window/window-manager.test.ts
+++ b/src/main/window/window-manager.test.ts
@@ -60,6 +60,7 @@ vi.mock('electron', () => {
     setMinimumSize = vi.fn()
     setAutoHideMenuBar = vi.fn()
     setMenuBarVisibility = vi.fn()
+    setTitleBarOverlay = vi.fn()
     setWindowButtonVisibility = vi.fn()
     center = vi.fn()
     on = vi.fn().mockReturnThis()
@@ -92,13 +93,14 @@ vi.mock('electron', () => {
 
   return {
     BrowserWindow: MockBrowserWindow,
+    nativeTheme: { shouldUseDarkColors: false },
     screen: mockScreen,
     shell: { openExternal: vi.fn() },
   }
 })
 
 import type { SettingsManager } from '@core/settings/settings-manager'
-import { BrowserWindow } from 'electron'
+import { BrowserWindow, nativeTheme } from 'electron'
 import type { LiquidGlassController } from './liquid-glass'
 import { initializeRendererUrlPolicy } from './renderer-url-policy'
 import { WINDOW_CONFIGS } from './window-configs'
@@ -122,6 +124,9 @@ function createMockSettingsManager(
 describe('WindowManager', () => {
   beforeEach(() => {
     ;(BrowserWindow as unknown as { instances: unknown[] }).instances.length = 0
+    ;(
+      nativeTheme as unknown as { shouldUseDarkColors: boolean }
+    ).shouldUseDarkColors = false
     vi.clearAllMocks()
   })
 
@@ -136,6 +141,59 @@ describe('WindowManager', () => {
     const win = wm.open('main')
     expect(win).toBeDefined()
     expect(wm.get('main')).toBe(win)
+  })
+
+  it('creates aligned Windows caption controls for the light theme', () => {
+    const wm = new WindowManager({
+      settingsManager: createMockSettingsManager(),
+      preloadPath: '/fake/preload.cjs',
+      loadUrl: vi.fn(),
+      platform: 'win32',
+    })
+
+    const win = wm.open('main')
+    const options = (win as unknown as { options: Record<string, unknown> })
+      .options
+    expect(options.titleBarOverlay).toEqual({
+      color: '#00000000',
+      symbolColor: '#1d1d1f',
+      height: 54,
+    })
+  })
+
+  it('creates and refreshes Windows caption controls for the dark theme', () => {
+    ;(
+      nativeTheme as unknown as { shouldUseDarkColors: boolean }
+    ).shouldUseDarkColors = true
+    const wm = new WindowManager({
+      settingsManager: createMockSettingsManager(),
+      preloadPath: '/fake/preload.cjs',
+      loadUrl: vi.fn(),
+      platform: 'win32',
+    })
+
+    const main = wm.open('main')
+    const onboarding = wm.open('onboarding')
+    const mainOptions = (
+      main as unknown as { options: Record<string, unknown> }
+    ).options
+    expect(mainOptions.titleBarOverlay).toMatchObject({
+      symbolColor: '#f5f5f5',
+      height: 54,
+    })
+
+    wm.syncWindowControlsTheme(true)
+
+    expect(main.setTitleBarOverlay).toHaveBeenCalledWith({
+      color: '#00000000',
+      symbolColor: '#f5f5f5',
+      height: 54,
+    })
+    expect(onboarding.setTitleBarOverlay).toHaveBeenCalledWith({
+      color: '#00000000',
+      symbolColor: '#1d1d1f',
+      height: 54,
+    })
   })
 
   it('uses the explicit secure Electron renderer defaults', () => {

--- a/src/main/window/window-manager.ts
+++ b/src/main/window/window-manager.ts
@@ -3,7 +3,7 @@ import type { SettingsManager } from '@core/settings/settings-manager'
 import { Events } from '@shared/protocol/events'
 import type { AddTaskUrlParams } from '@shared/schemas/add-task'
 import type { WindowBounds } from '@shared/types/settings'
-import { BrowserWindow, screen, shell } from 'electron'
+import { BrowserWindow, nativeTheme, screen, shell } from 'electron'
 import type { LiquidGlassController } from './liquid-glass'
 import { buildPlatformOptions } from './platform-options'
 import {
@@ -236,6 +236,22 @@ export class WindowManager {
     }
   }
 
+  syncWindowControlsTheme(shouldUseDarkColors: boolean): void {
+    const platform = this.deps.platform ?? process.platform
+    if (platform !== 'win32') return
+
+    for (const [id, win] of this.windows.entries()) {
+      if (!win || win.isDestroyed()) continue
+      const config = WINDOW_CONFIGS[id]
+      const titleBarOverlay = buildPlatformOptions('win32', {
+        shouldUseDarkColors,
+        windowControlsSymbolColor: config.windowControlsSymbolColor,
+      }).titleBarOverlay
+      if (!titleBarOverlay || typeof titleBarOverlay === 'boolean') continue
+      win.setTitleBarOverlay(titleBarOverlay)
+    }
+  }
+
   setWillQuit(value: boolean): void {
     this.willQuit = value
   }
@@ -315,6 +331,7 @@ export class WindowManager {
     const platformOpts = buildPlatformOptions(platform, {
       vibrancy: config.vibrancy && !liquidGlass,
       liquidGlass,
+      shouldUseDarkColors: nativeTheme.shouldUseDarkColors,
       windowControlsSymbolColor: config.windowControlsSymbolColor,
     })
 

--- a/src/renderer/components/window-chrome/window-chrome.test.tsx
+++ b/src/renderer/components/window-chrome/window-chrome.test.tsx
@@ -126,6 +126,10 @@ describe('WindowChrome', () => {
     )
     const controls = container.querySelector('.window-controls')
     expect(controls).toHaveClass('ml-auto')
+    expect(controls).toHaveStyle({ paddingTop: '14px' })
+    expect((container.firstChild as HTMLElement).style.paddingRight).toBe(
+      '16px'
+    )
     expect(actions?.compareDocumentPosition(controls as Node)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING
     )
@@ -159,11 +163,11 @@ describe('WindowChrome', () => {
     )
   })
 
-  it('always reserves the Windows caption-button area', () => {
+  it('reserves the Windows caption-button area with a visual gap', () => {
     setPlatform('win32')
     const { container } = render(<WindowChrome variant="overlay" />)
     expect((container.firstChild as HTMLElement).style.paddingRight).toBe(
-      '148px'
+      '154px'
     )
   })
 })

--- a/src/renderer/components/window-chrome/window-chrome.tsx
+++ b/src/renderer/components/window-chrome/window-chrome.tsx
@@ -4,6 +4,10 @@ import { Commands } from '@shared/protocol/commands'
 import type React from 'react'
 import { useTranslation } from 'react-i18next'
 
+const WINDOWS_CAPTION_CONTROLS_WIDTH = 138
+const CAPTION_CONTROLS_EDGE_GAP = 16
+const CAPTION_CONTROLS_TOP_PADDING = 14
+
 function LinuxWindowControls({ pushToEnd }: { pushToEnd: boolean }) {
   const { t } = useTranslation()
   const minimize = () => {
@@ -16,7 +20,11 @@ function LinuxWindowControls({ pushToEnd }: { pushToEnd: boolean }) {
   return (
     <div
       className={cn('window-controls app-no-drag', pushToEnd && 'ml-auto')}
-      style={{ display: 'flex', gap: 8 }}
+      style={{
+        display: 'flex',
+        gap: 8,
+        paddingTop: CAPTION_CONTROLS_TOP_PADDING,
+      }}
     >
       <button
         type="button"
@@ -79,7 +87,12 @@ export function WindowChrome({
     display: 'flex',
     alignItems: 'center',
     paddingLeft: showTrafficLight ? 93 : 12,
-    paddingRight: platform === 'win32' ? 148 : 20,
+    paddingRight:
+      platform === 'win32'
+        ? WINDOWS_CAPTION_CONTROLS_WIDTH + CAPTION_CONTROLS_EDGE_GAP
+        : platform === 'linux'
+          ? CAPTION_CONTROLS_EDGE_GAP
+          : 20,
     flexShrink: 0,
     userSelect: 'none',
     ...(isOverlay && {


### PR DESCRIPTION
## Summary

- derive Windows caption symbol colors from Electron's resolved light/dark theme and refresh existing windows when the theme changes
- increase the Windows title-bar overlay height to 54px so the native controls share the Add Task action's visual center at y=27
- align the renderer-owned Linux controls with 14px top spacing and a 16px right edge gap
- preserve a 16px content gap beside the Windows native caption-control area

## Root cause

The Windows overlay previously omitted `symbolColor`, so Electron followed the operating-system theme instead of Motrix's independently selected app theme. A dark Motrix theme on a light system could therefore render near-black caption symbols on the dark title bar.

The Windows controls were also centered in a 36px overlay at y=18, while the 28px header actions are centered at y=27. Linux's renderer-owned controls were centered at y=20, creating the same visible baseline mismatch.

## Impact

Window controls remain legible in both light and dark themes, including live theme changes. Windows and Linux controls now align visually with the left-side Add Task action, while per-window symbol color overrides remain intact.

## Validation

- `pnpm run check:boundaries`
- `pnpm run lint`
- `pnpm exec tsc --noEmit`
- focused window/theme tests: 4 files, 53 tests passed
- full test suite: 634 files passed, 2 skipped; 6879 tests passed, 3 skipped
