### PR TITLE
chore(release): prepare 2.0.0-beta.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. After its remaining release gates pass,
-download [v2.0.0-beta.18 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.18)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.18.md) before
+download [v2.0.0-beta.19 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.19)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.19.md) before
 installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -158,7 +158,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.18'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.19'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。剩余发布门禁通过后，请从 GitHub Releases
-下载 [v2.0.0-beta.18](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.18)，
-并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.18.zh-CN.md)。
+下载 [v2.0.0-beta.19](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.19)，
+并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.19.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -152,7 +152,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.18'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.19'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.19.md
+++ b/docs/release-notes/2.0.0-beta.19.md
@@ -1,0 +1,90 @@
+# Motrix 2.0.0-beta.19
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.19/docs/release-notes/2.0.0-beta.19.zh-CN.md)
+
+Motrix 2.0.0-beta.19 makes the in-app updater hand off to the installer
+reliably, restores clipboard link autofill in New Task, tightens plugin and
+task-removal safety, and fixes tray and window-control behavior across
+platforms. It is intended for public distribution only after every protected
+release gate passes.
+
+## Highlights
+
+- **Restart and install** now completes the update handoff reliably: the
+  updater prepares the quit policy before installing, so hide-to-tray windows
+  close instead of leaving the old version running. The About dialog's update
+  action and channel selector are consolidated into one compact control.
+- Opening New Task on the Links tab with an empty URL field reads the
+  clipboard once and autofills it when every non-empty line is a downloadable
+  link (`http`/`https`/`ftp`/`magnet`). This restores the v1 behavior, is
+  gated by a new General setting (default on), and never watches the
+  clipboard in the background.
+- Each line pasted on the Links tab now creates its own independent task
+  instead of being submitted as mirrors of one file. Partial failures are
+  reported with created/failed counts.
+- Removing tasks never pre-checks **Delete downloaded files** based on task
+  status. Deleting data is always an explicit opt-in; only the Shift shortcut
+  pre-checks the box.
+- Plugins' HTTP access is now limited to the `hostPermissions` declared in
+  their manifest, enforced on the initial URL and on every redirect hop.
+- The Pieces tab now covers HTTP downloads as well as BitTorrent tasks, piece
+  length survives restore, and duplicate aria2 rows are reconciled by GID
+  during session restore so stale history cannot overwrite a paused task.
+- Downloads handed over from the browser extension are deduplicated by
+  idempotency key, so bridge retries cannot create duplicate tasks.
+- Tray behavior is fixed: left-clicking the tray icon toggles the window
+  again, and macOS preserves the tray icon position.
+- Window controls follow Motrix's own theme: Windows caption symbols use the
+  app's resolved light/dark theme and refresh on theme change, Linux caption
+  controls use the theme foreground color, and title-bar alignment is refined
+  on both platforms.
+- The dashboard activity tooltip no longer triggers a resize loop when moving
+  quickly across cells.
+
+## Before testing
+
+This is prerelease software. Back up existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Do not rely on this beta for your only copy of important
+downloads.
+
+## Planned downloads after release gates pass
+
+| Distribution | Architectures | Planned output |
+|--------------|---------------|----------------|
+| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | DEB and RPM |
+| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.19-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.19` tag in both registries |
+| Snap Store | — | Not published for this beta |
+
+After every container gate passes, the versioned image references will be
+`docker.io/motrixapp/motrix-server:2.0.0-beta.19` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.19`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.19/docs/docker-server.md)
+for storage, networking, and upgrade guidance.
+
+## Distribution notes
+
+- AppImage is not published for this beta.
+- Flatpak is validated separately and is not published by the release tag; the
+  GitHub prerelease includes its Native Host companion archives.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
+  Download them only from the official GitHub prerelease after it is published.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+- Snap is not published for this beta. Prerelease Snap runs stop after source
+  validation, so they do not build Snap artifacts, upload Store revisions, or
+  change `latest/edge`.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.19.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.19.zh-CN.md
@@ -1,0 +1,74 @@
+# Motrix 2.0.0-beta.19
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.19/docs/release-notes/2.0.0-beta.19.md) | 简体中文
+
+Motrix 2.0.0-beta.19 让应用内更新流程可靠完成安装交接，恢复了新建任务的剪贴板
+链接自动填充，收紧了插件与任务删除的安全默认值，并修复了各平台的托盘与窗口
+控件行为。只有全部受保护发布门禁通过后，本版本才会进入公开分发。
+
+## 主要变化
+
+- **重启并安装**现在能可靠完成更新交接：更新器会在安装前调整退出策略，
+  隐藏到托盘的窗口会真正关闭，而不是让旧版本继续运行。关于对话框中的更新
+  操作与更新通道选择合并为一个紧凑控件。
+- 在 Links 标签页打开新建任务且 URL 输入框为空时，会读取一次剪贴板；当每个
+  非空行都是可下载链接（`http`/`https`/`ftp`/`magnet`）时自动填充。该行为
+  与 v1 一致，由新增的通用设置项控制（默认开启），并且绝不在后台监视
+  剪贴板。
+- Links 标签页粘贴的每一行现在都会创建独立任务，而不再作为同一文件的镜像
+  地址提交。部分失败时会按创建/失败数量给出提示。
+- 删除任务时，**同时删除已下载文件**不再根据任务状态自动勾选。删除数据
+  始终需要显式选择；只有 Shift 快捷键会预先勾选该选项。
+- 插件的 HTTP 访问现在严格受 manifest 中声明的 `hostPermissions` 限制，
+  初始 URL 与每一跳重定向都会校验。
+- Pieces 标签页现在同时支持 HTTP 下载与 BitTorrent 任务，分片长度会跨恢复
+  持久保存；会话恢复时按 GID 合并重复的 aria2 记录，过期历史不会再覆盖
+  当前已暂停的任务。
+- 浏览器扩展移交的下载按幂等键去重，bridge 重试不会再产生重复任务。
+- 修复托盘行为：左键单击托盘图标可再次切换窗口显示，macOS 保持托盘图标
+  位置不变。
+- 窗口控件跟随 Motrix 自身主题：Windows 标题栏符号使用应用解析后的
+  明暗主题并在主题切换时刷新，Linux 标题栏控件使用主题前景色，两个平台的
+  标题栏对齐也已优化。
+- 仪表盘活动提示不再在快速移动单元格时触发 resize 循环。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据与下载文件。Motrix v1 数据的
+迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
+
+条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录并行测试 v2。
+请勿仅依赖本 beta 保存重要下载文件。
+
+## 发布门禁通过后的计划下载项
+
+| 分发方式 | 架构 | 计划产物 |
+|----------|------|----------|
+| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 与 ZIP |
+| Windows | `x64` | 未签名 NSIS 安装包（`.exe`）与 ZIP |
+| Linux | `x64`、`arm64` | DEB 与 RPM |
+| Flatpak Native Host companion | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.19-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中不可变的 `2.0.0-beta.19` tag |
+| Snap Store | — | 本 beta 不发布 |
+
+全部容器门禁通过后，带版本的镜像引用将是
+`docker.io/motrixapp/motrix-server:2.0.0-beta.19` 与
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.19`。存储、网络与升级说明请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.19/docs/docker-server.zh-CN.md)。
+
+## 分发说明
+
+- 本 beta 不发布 AppImage。
+- Flatpak 会单独验证，不会随版本 tag 发布；GitHub 预发布版包含对应的 Native
+  Host companion archive。
+- 不提供 Windows `arm64` 与任何 32 位安装包。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅在官方
+  GitHub 预发布版发布后下载。
+- Beta 容器 tag 不可变，不会更新 `latest`、`stable` 或其他稳定浮动 tag。
+- 本 beta 不发布 Snap。预发布 Snap run 会在 source validation 后停止，不会
+  构建 Snap artifact、上传 Store revision，也不会更改 `latest/edge`。
+
+## 问题反馈
+
+请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现问题，
+并提供操作系统、架构、安装包类型与复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -76,6 +76,20 @@
   <releases>
     <!-- Update this list on every release; Flathub linter requires the most
          recent version listed here to match the manifest's source tag. -->
+    <release version="2.0.0-beta.19" date="2026-08-19">
+      <description>
+        <p>
+          The in-app updater now hands off to the installer reliably even when
+          windows hide to the tray. New Task autofills downloadable links from
+          the clipboard, each pasted link line becomes an independent task,
+          and removing tasks never pre-selects file deletion. Plugin HTTP
+          access is limited to declared hosts, HTTP downloads show piece
+          progress, and tray and window-control behavior is corrected across
+          platforms. Windows packages remain unsigned, and prerelease Snap
+          runs stop after source validation.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.18" date="2026-08-17">
       <description>
         <p>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.18",
+  "version": "2.0.0-beta.19",
   "packageManager": "pnpm@11.22.0+sha512.1ff870c4c6133dfd88fb2afc46dd13d47f09c9794b438c6fdb47ca98caf3bc16381ee0be93a091b8e3824cf01f889f46d7d9e20910fb0be1ab0fb5baa80dd621",
   "description": "A full-featured download manager",
   "keywords": [],


### PR DESCRIPTION
## What changed

- bump the application release version to `2.0.0-beta.19`
- add paired English and Simplified Chinese release notes
- update README release and container references
- add the beta.19 Flatpak metainfo entry

## Why

This beta publishes the updater handoff fix (Restart and install now closes
hide-to-tray windows and hands off to the installer), the New Task clipboard
link autofill restored from v1, per-line task creation on the Links tab,
manifest-enforced plugin host permissions, the safe remove default, HTTP piece
progress, idempotent bridge download/add, and the tray and window-control
fixes merged since beta.18.

## User impact

In-app updates complete reliably. New Task autofills downloadable clipboard
links (gated by a General setting, default on), pasted link lines become
independent tasks, and removing tasks never pre-selects file deletion. Plugins
can only reach hosts they declared, HTTP downloads show piece progress, tray
left-click toggles the window again, and window controls follow the app theme.

## Verification

- `pnpm run check:file-names`
- `pnpm run check:boundaries`
- `pnpm run lint`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run tests/scripts/release-version-contract.test.ts` (22 tests)
- `pnpm run check:flatpak`
- `git diff --cached --check`