### PR TITLE
fix(security): avoid logging sensitive download data

### DIFF
--- a/src/core/task/create-task-handler.test.ts
+++ b/src/core/task/create-task-handler.test.ts
@@ -5,6 +5,21 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Aria2Adapter } from '../engine/aria2/aria2-adapter'
 import { handleCreateTask } from './create-task-handler'
 
+const { logInfo, logWarn, logError, logDebug } = vi.hoisted(() => ({
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+  logError: vi.fn(),
+  logDebug: vi.fn(),
+}))
+
+vi.mock('@core/logger', () => ({
+  getLogger: () => ({
+    info: logInfo,
+    warn: logWarn,
+    error: logError,
+    debug: logDebug,
+  }),
+}))
 // Stub `mkdir` (and the other `fs.*` calls inadvertently dragged
 // in via TorrentMetaStore) so unit tests don't touch the real
 // filesystem. The production code calls
@@ -224,6 +239,53 @@ describe('handleCreateTask', () => {
     await expect(handleCreateTask({ junk: true }, makeDeps())).rejects.toThrow(
       AppError
     )
+  })
+
+  it('does not expose sensitive download credentials in structured logs', async () => {
+    logInfo.mockClear()
+
+    const secrets = {
+      urlToken: 'URL_SECRET_123',
+      authorization: 'AUTH_SECRET_456',
+      cookie: 'COOKIE_SECRET_789',
+      proxy: 'PROXY_SECRET_321',
+      referer: 'REFERER_SECRET_654',
+      cookieJar: 'COOKIE_JAR_SECRET_987',
+    }
+
+    await handleCreateTask(
+      {
+        type: 'http',
+        uris: [`https://example.com/file.zip?token=${secrets.urlToken}`],
+        saveDir: '/d',
+        headers: [
+          {
+            name: 'Authorization',
+            value: `Bearer ${secrets.authorization}`,
+          },
+          {
+            name: 'Cookie',
+            value: `session=${secrets.cookie}`,
+          },
+        ],
+        proxy: `http://user:${secrets.proxy}@proxy.example:8080`,
+      },
+      makeDeps(),
+      {
+        extraEngineOptions: {
+          referer: `https://origin.example/?token=${secrets.referer}`,
+          'load-cookies': `/tmp/${secrets.cookieJar}.txt`,
+        },
+      }
+    )
+
+    const serializedLogs = JSON.stringify(logInfo.mock.calls)
+
+    expect(serializedLogs).toContain('createDownload')
+
+    for (const secret of Object.values(secrets)) {
+      expect(serializedLogs).not.toContain(secret)
+    }
   })
 
   it('dispatches http request via rpcClient.addUri', async () => {

--- a/src/core/task/create-task-handler.ts
+++ b/src/core/task/create-task-handler.ts
@@ -285,7 +285,18 @@ export async function handleCreateTask(
     async (reservedGid: string): Promise<string> => {
       params.gid = reservedGid
       log.info(
-        { method: 'createDownload', uriCount: params.uris.length, params },
+        {
+          method: 'createDownload',
+          uriCount: params.uris.length,
+          hasHeaders: Boolean(
+            params.headers && Object.keys(params.headers).length > 0
+          ),
+          hasProxy: Boolean(params.proxy),
+          hasExtraEngineOptions: Boolean(
+            params.extraEngineOptions &&
+              Object.keys(params.extraEngineOptions).length > 0
+          ),
+        },
         'dispatching to engine'
       )
       return deps.adapter.createDownload(params)
@@ -393,7 +404,7 @@ export async function handleCreateTask(
         taskId,
         hasOrchestrator: Boolean(deps.orchestrator),
         reqType: req.type,
-        uris: req.uris,
+        uriCount: req.uris.length,
       },
       'beforeCreate hook chain pre-check'
     )
@@ -415,7 +426,9 @@ export async function handleCreateTask(
         {
           taskId,
           aborted: result.aborted === true,
-          rewrittenUris: result.aborted ? undefined : result.final.uris,
+          rewrittenUriCount: result.aborted
+            ? undefined
+            : result.final.uris.length,
           contributors: result.aborted ? undefined : result.contributors,
         },
         'beforeCreate hook chain result'


### PR DESCRIPTION
## Summary

Avoid writing sensitive download request data into structured logs.

The create-task path previously logged full URIs and the complete `CreateDownloadParams` object. That could expose values such as signed URL query tokens, `Authorization` / `Cookie` header values, proxy credentials, referers, and cookie-jar paths.

This change keeps useful diagnostics while replacing raw values with non-sensitive metadata:

- log URI counts instead of full URIs
- log whether headers, proxy, and extra engine options are present instead of their values
- log rewritten URI counts instead of rewritten URIs
- add regression coverage with sentinel secrets for URL tokens, authorization, cookies, proxy credentials, referer values, and cookie-jar paths

## Verification

- The new regression test fails against the previous logging behavior because the sentinel secrets are present in the captured logs.
- After the fix, the regression test passes.
- `pnpm exec vitest run src/core/task/create-task-handler.test.ts` → 57 passed
- `pnpm exec biome check src/core/task/create-task-handler.ts src/core/task/create-task-handler.test.ts` → clean
- `git diff --check` → clean