### PR TITLE
fix(release): prepare beta.21 AppImage recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. After its remaining release gates pass,
-download [v2.0.0-beta.20 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.20)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.20.md) before
+download [v2.0.0-beta.21 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.21)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.21.md) before
 installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -162,7 +162,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.20'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.21'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。剩余发布门禁通过后，请从 GitHub Releases
-下载 [v2.0.0-beta.20](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.20)，
-并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.20.zh-CN.md)。
+下载 [v2.0.0-beta.21](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.21)，
+并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.21.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -153,7 +153,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.20'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.21'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.21.md
+++ b/docs/release-notes/2.0.0-beta.21.md
@@ -1,0 +1,100 @@
+# Motrix 2.0.0-beta.21
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.21/docs/release-notes/2.0.0-beta.21.zh-CN.md)
+
+Motrix 2.0.0-beta.21 restores verified HTTPS downloads across Linux
+distributions, adds performance profiles with up to 64 connections, makes
+settings and engine recovery more reliable, redacts sensitive log data, and
+returns AppImage packages with user-controlled desktop integration. It is
+intended for public distribution only after every protected release gate
+passes.
+
+Beta.20 did not reach public distribution because release assembly rejected
+electron-builder's valid AppImage-first Linux update metadata. Beta.21 carries
+the same user-facing changes and normalizes those compatibility fields to the
+DEB updater asset before final verification and publication.
+
+## Highlights
+
+- Linux launches aria2 with a fresh CA bundle assembled from the system trust
+  store on every run, falling back to bundled roots when necessary. This fixes
+  valid HTTPS downloads on distributions where the static engine's build-time
+  OpenSSL paths do not exist, without disabling certificate verification.
+- Desktop, Server, Docker, and Flatpak packages use the Motrix aria2 fork
+  `1.37.0-motrix.6`. Server and Docker packages carry the verified Motrix
+  binary instead of depending on a distribution-provided aria2 executable.
+- Download settings offer Automatic, Balanced, High speed, Maximum, and Custom
+  performance profiles. They coordinate connections, segments, minimum
+  segment size, and disk cache; the bundled engine supports up to 64
+  connections per server and Automatic mode applies disk-aware startup tuning.
+- Settings are saved before an engine restart is requested. Options that aria2
+  can apply immediately are updated in place, while settings requiring a
+  restart keep a durable reminder. Connection, allocation, and cache choices
+  remain consistent after saving and relaunching.
+- Application and plugin logs share a structured redaction boundary. Secrets,
+  credentials, cookies, request bodies, storage values, sensitive paths, and
+  URL query data are removed while safe diagnostic context is retained.
+- AppImage publishing is restored for Linux `x64` and `arm64`. On first launch,
+  users may opt in to a desktop entry, icon, and `motrix:`, `magnet:`, and
+  `.torrent` handlers under their own XDG data directory; the integration can
+  be enabled, repaired, or removed later from Settings.
+- Release assembly accepts electron-builder's AppImage-first source metadata,
+  validates every referenced Linux asset, and emits DEB-based compatibility
+  fields for the updater. Final release verification remains strict.
+- Tracker state cached before an engine interruption is reapplied after
+  recovery. Expected engine-shutdown errors are suppressed, NAT mappings retry
+  after discovery, and download counts follow Motrix task state.
+- Windows and Linux caption controls use consistent 28px targets and align
+  with sidebar and panel actions. Toast and content safe areas account for the
+  custom window chrome.
+
+## Before testing
+
+This is prerelease software. Back up existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Do not rely on this beta for your only copy of important
+downloads.
+
+## Planned downloads after release gates pass
+
+| Distribution | Architectures | Planned output |
+|--------------|---------------|----------------|
+| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | AppImage, DEB, and RPM |
+| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.21-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.21` tag in both registries |
+| Snap Store | — | Not published for this beta |
+
+After every container gate passes, the versioned image references will be
+`docker.io/motrixapp/motrix-server:2.0.0-beta.21` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.21`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.21/docs/docker-server.md)
+for storage, networking, and upgrade guidance.
+
+## Distribution notes
+
+- AppImage desktop integration is opt-in and confined to the current user's
+  XDG data directory. Browser-extension hand-off is not yet available from the
+  AppImage package because its Native Messaging host does not have a stable
+  path outside the mounted image.
+- Flatpak is validated separately and is not published by the release tag; the
+  GitHub prerelease includes its Native Host companion archives.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
+  Download them only from the official GitHub prerelease after it is published.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+- Snap is not published for this beta. Prerelease Snap runs stop after source
+  validation, so they do not build Snap artifacts, upload Store revisions, or
+  change `latest/edge`.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.21.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.21.zh-CN.md
@@ -1,0 +1,82 @@
+# Motrix 2.0.0-beta.21
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.21/docs/release-notes/2.0.0-beta.21.md) | 简体中文
+
+Motrix 2.0.0-beta.21 恢复了不同 Linux 发行版上的 HTTPS 证书验证下载，新增最高
+64 连接的性能配置，让设置保存与内核恢复更加可靠，对日志中的敏感数据进行脱敏，
+并恢复带有用户可控桌面集成的 AppImage 安装包。只有全部受保护发布门禁通过后，
+本版本才会进入公开分发。
+
+Beta.20 因发布组装程序拒绝了 electron-builder 合法的 AppImage-first Linux 更新
+元数据，未进入公开分发。Beta.21 包含相同的用户功能，并在最终校验与发布前将这些
+兼容字段规范化为 DEB 更新包。
+
+## 主要变化
+
+- Linux 每次启动 aria2 时都会从系统信任存储生成新的 CA bundle，必要时回退到
+  内置根证书。这解决了静态内核记录的 OpenSSL 构建期路径在部分发行版上不存在时，
+  合法 HTTPS 下载也会失败的问题，并且不会关闭证书验证。
+- 桌面端、Server、Docker 与 Flatpak 统一使用 Motrix aria2 fork
+  `1.37.0-motrix.6`。Server 与 Docker 安装包会携带经过校验的 Motrix 二进制，
+  不再依赖发行版提供的 aria2 可执行文件。
+- 下载设置新增自动、均衡、高速、极限与自定义性能配置，会联动连接数、分片数、
+  最小分片大小和磁盘缓存。内置内核支持单服务器最高 64 个连接；自动模式会在
+  内核启动时根据磁盘类型进行调优。
+- 请求重启下载内核前会先保存设置。aria2 支持即时应用的选项会直接生效，需要
+  重启的设置则保留持久提醒。连接数、文件分配与磁盘缓存等选项在保存和重新启动后
+  能保持一致。
+- 应用与插件日志共用结构化脱敏边界。凭据、密钥、Cookie、请求正文、存储值、
+  敏感路径与 URL 查询数据会被移除，同时保留安全且有用的诊断上下文。
+- 恢复发布 Linux `x64` 与 `arm64` AppImage。首次启动时，用户可以选择在自己的
+  XDG 数据目录注册桌面入口、图标以及 `motrix:`、`magnet:` 和 `.torrent`
+  处理程序；之后可随时在设置中启用、修复或移除这些集成。
+- 发布组装程序接受 electron-builder 的 AppImage-first 源元数据，校验每个被引用
+  的 Linux 产物，并输出以 DEB 为目标的更新器兼容字段；最终发布校验仍保持严格。
+- 下载内核中断前缓存的 Tracker 状态会在恢复后重新应用。正常关闭内核时的预期
+  错误不会再被报告为终止故障；NAT 映射会在发现设备后重试，下载数量也会以
+  Motrix 任务状态为准。
+- Windows 与 Linux 标题栏控件统一使用 28px 点击区域，并与侧边栏及面板操作
+  对齐。Toast 和内容安全区域也会正确避让自绘窗口标题栏。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据与下载文件。Motrix v1 数据的
+迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
+
+条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录并行测试 v2。
+请勿仅依赖本 beta 保存重要下载文件。
+
+## 发布门禁通过后的计划下载项
+
+| 分发方式 | 架构 | 计划产物 |
+|----------|------|----------|
+| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 与 ZIP |
+| Windows | `x64` | 未签名 NSIS 安装包（`.exe`）与 ZIP |
+| Linux | `x64`、`arm64` | AppImage、DEB 与 RPM |
+| Flatpak Native Host companion | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.21-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中不可变的 `2.0.0-beta.21` tag |
+| Snap Store | — | 本 beta 不发布 |
+
+全部容器门禁通过后，带版本的镜像引用将是
+`docker.io/motrixapp/motrix-server:2.0.0-beta.21` 与
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.21`。存储、网络与升级说明请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.21/docs/docker-server.zh-CN.md)。
+
+## 分发说明
+
+- AppImage 桌面集成需要用户选择启用，并且只写入当前用户的 XDG 数据目录。
+  AppImage 内的 Native Messaging host 在挂载镜像外没有稳定路径，因此浏览器扩展
+  暂时还不能把下载任务移交给 AppImage 版本。
+- Flatpak 会单独验证，不会随该版本 tag 发布；GitHub 预发布版会包含对应的
+  Native Host companion 压缩包。
+- 不提供 Windows `arm64` 和任何 32 位安装包。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅在官方
+  GitHub 预发布版发布后下载。
+- Beta 容器 tag 不可变，也不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
+- 本 beta 不发布 Snap。预发布 Snap run 会在 source validation 后停止，不会
+  构建 Snap、上传 Store revision 或修改 `latest/edge`。
+
+## 反馈
+
+请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现问题，
+并附上操作系统、架构、安装包类型以及复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -76,6 +76,18 @@
   <releases>
     <!-- Update this list on every release; Flathub linter requires the most
          recent version listed here to match the manifest's source tag. -->
+    <release version="2.0.0-beta.21" date="2026-08-22">
+      <description>
+        <p>
+          Release assembly now accepts the AppImage-first Linux metadata
+          emitted by electron-builder and normalizes updater compatibility
+          fields to the DEB package. This recovery beta also includes system
+          CA trust-store support, aria2 1.37.0-motrix.6, performance profiles,
+          reliable settings and engine recovery, structured log redaction,
+          and opt-in AppImage desktop integration from beta.20.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.20" date="2026-08-22">
       <description>
         <p>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.20",
+  "version": "2.0.0-beta.21",
   "packageManager": "pnpm@11.22.0+sha512.1ff870c4c6133dfd88fb2afc46dd13d47f09c9794b438c6fdb47ca98caf3bc16381ee0be93a091b8e3824cf01f889f46d7d9e20910fb0be1ab0fb5baa80dd621",
   "description": "A full-featured download manager",
   "keywords": [],

--- a/scripts/assemble-release-artifacts.mjs
+++ b/scripts/assemble-release-artifacts.mjs
@@ -375,11 +375,6 @@ async function verifyManifestAssets(
   const uniqueFiles = new Map()
 
   const expectedLegacyName = target.legacyAssetName(version)
-  if (manifest.legacyFile.url !== expectedLegacyName) {
-    throw new Error(
-      `${target.name}/${manifestName}: legacy path must reference ${expectedLegacyName}`
-    )
-  }
 
   for (const file of manifest.files) {
     const key = file.url.toLowerCase()

--- a/tests/scripts/assemble-release-artifacts.test.ts
+++ b/tests/scripts/assemble-release-artifacts.test.ts
@@ -533,33 +533,19 @@ describe('assembleReleaseArtifacts', () => {
     ).rejects.toThrow(/linux-x64: unexpected release asset .*arm64\.deb/)
   })
 
-  it('rejects a legacy path that is not the target updater asset', async () => {
+  it('normalizes Linux legacy metadata to the DEB updater asset', async () => {
     const fixture = await createFixture()
-    await writeManifest(
-      fixture.paths.linuxX64Manifest,
-      VERSION,
-      [
-        {
-          name: fixture.names.linuxX64Deb,
-          content: fixture.contents.linuxX64Deb,
-        },
-        {
-          name: fixture.names.linuxX64Rpm,
-          content: fixture.contents.linuxX64Rpm,
-        },
-      ],
-      fixture.names.linuxX64Rpm
-    )
+    await assembleReleaseArtifacts({
+      inputDirectory: fixture.input,
+      outputDirectory: fixture.output,
+      version: VERSION,
+    })
 
-    await expect(
-      assembleReleaseArtifacts({
-        inputDirectory: fixture.input,
-        outputDirectory: fixture.output,
-        version: VERSION,
-      })
-    ).rejects.toThrow(
-      'linux-x64/latest-linux.yml: legacy path must reference Motrix_2.0.0_amd64.deb'
-    )
+    const manifest = load(
+      await readFile(path.join(fixture.output, 'latest-linux.yml'), 'utf8')
+    ) as { path: string; sha512: string }
+    expect(manifest.path).toBe(fixture.names.linuxX64Deb)
+    expect(manifest.sha512).toBe(sha512(fixture.contents.linuxX64Deb))
   })
 
   it('does not delete or overwrite a non-empty output directory', async () => {
@@ -698,7 +684,7 @@ async function createFixture(version = VERSION) {
       { name: names.linuxX64AppImage, content: contents.linuxX64AppImage },
       { name: names.linuxX64Rpm, content: contents.linuxX64Rpm },
     ],
-    names.linuxX64Deb
+    names.linuxX64AppImage
   )
   await writeManifest(
     linuxX64BetaManifest,
@@ -709,7 +695,7 @@ async function createFixture(version = VERSION) {
       { name: names.linuxX64AppImage, content: contents.linuxX64AppImage },
       { name: names.linuxX64Rpm, content: contents.linuxX64Rpm },
     ],
-    names.linuxX64Deb
+    names.linuxX64AppImage
   )
 
   const linuxArm64 = await makeTarget(input, 'linux-arm64')
@@ -743,7 +729,7 @@ async function createFixture(version = VERSION) {
       { name: names.linuxArm64AppImage, content: contents.linuxArm64AppImage },
       { name: names.linuxArm64Rpm, content: contents.linuxArm64Rpm },
     ],
-    names.linuxArm64Deb
+    names.linuxArm64AppImage
   )
   await writeManifest(
     path.join(linuxArm64, 'beta-linux-arm64.yml'),
@@ -754,7 +740,7 @@ async function createFixture(version = VERSION) {
       { name: names.linuxArm64AppImage, content: contents.linuxArm64AppImage },
       { name: names.linuxArm64Rpm, content: contents.linuxArm64Rpm },
     ],
-    names.linuxArm64Deb
+    names.linuxArm64AppImage
   )
 
   const windows = await makeTarget(input, 'win32-x64')


### PR DESCRIPTION
## Summary

- accept the AppImage-first Linux updater metadata emitted by electron-builder
- continue normalizing published Linux compatibility fields to the canonical DEB asset and keep final verification strict
- prepare `2.0.0-beta.21` with paired release notes, README references, and Flatpak metadata

## Release recovery

`v2.0.0-beta.20` stopped in the protected release workflow before GitHub Release, feed, or container publication because artifact assembly rejected a valid AppImage legacy path. The existing tag remains unchanged. Beta.21 carries the same user-facing changes plus the release assembly fix.

## Verification

- `git diff --check`
- local CI intentionally not run per maintainer request; GitHub PR CI is the verification source

## Related

- #1914
- failed release run: https://github.com/agalwood/Motrix/actions/runs/32539518457