### PR TITLE
fix(add-task): restore window height after collapsing advanced

### DIFF
--- a/src/renderer/components/add-task/add-task-form.test.tsx
+++ b/src/renderer/components/add-task/add-task-form.test.tsx
@@ -47,6 +47,15 @@ describe('AddTaskForm', () => {
     expect(screen.getByRole('textbox')).toBeInTheDocument()
   })
 
+  it('measures natural content separately from the scroll viewport', () => {
+    const { container } = renderForm()
+    const content = container.querySelector('[data-adaptive-content]')
+
+    expect(content).toBeInTheDocument()
+    expect(content).not.toHaveClass('overflow-y-auto')
+    expect(content?.parentElement).toHaveClass('overflow-y-auto')
+  })
+
   it('disables submit when urls are empty', () => {
     renderForm()
     const submit = screen.getByRole('button', { name: /download/i })

--- a/src/renderer/components/add-task/add-task-form.tsx
+++ b/src/renderer/components/add-task/add-task-form.tsx
@@ -183,11 +183,8 @@ export function AddTaskForm({
 
   return (
     <FormProvider {...form}>
-      <div
-        data-adaptive-content
-        className="flex max-h-[calc(100vh-40px)] flex-col overflow-y-auto"
-      >
-        <div className="mb-16 px-4 py-2">
+      <div className="flex max-h-[calc(100vh-40px)] flex-col overflow-y-auto">
+        <div data-adaptive-content className="px-4 pt-2 pb-[72px]">
           <TabsSection />
         </div>
       </div>

--- a/src/renderer/hooks/use-adaptive-window-height.test.ts
+++ b/src/renderer/hooks/use-adaptive-window-height.test.ts
@@ -175,7 +175,7 @@ describe('useAdaptiveWindowHeight', () => {
     cleanup()
   })
 
-  it('re-measures when ResizeObserver fires', async () => {
+  it('restores the smaller height after content expands and collapses', async () => {
     const { transport } = await import('@renderer/lib/transport')
     const { setScrollHeight, cleanup } = mountContentElement(400)
     renderHook(() =>
@@ -197,6 +197,14 @@ describe('useAdaptiveWindowHeight', () => {
     expect(transport.invoke).toHaveBeenLastCalledWith(Commands.ResizeWindow, {
       width: 520,
       height: 650,
+    })
+    setScrollHeight(320)
+    act(() => {
+      MockResizeObserver.instances[0].trigger()
+    })
+    expect(transport.invoke).toHaveBeenLastCalledWith(Commands.ResizeWindow, {
+      width: 520,
+      height: 360,
     })
     cleanup()
   })

--- a/src/renderer/hooks/use-adaptive-window-height.ts
+++ b/src/renderer/hooks/use-adaptive-window-height.ts
@@ -16,8 +16,9 @@ interface Options {
 /**
  * Adaptively resizes the host Electron window to fit the form's natural
  * content height, clamped to `[minHeight, maxHeight]`. Above `maxHeight`,
- * content scrolls internally (the form root owns an `overflow-y-auto`
- * container whose `scrollHeight` still reports natural content).
+ * content scrolls internally. The measured element must sit inside that
+ * scroll viewport so its `scrollHeight` can shrink with the natural content
+ * instead of being floored by the viewport's current height.
  *
  * Measures the element matching `contentSelector` (default
  * `[data-adaptive-content]`) via `scrollHeight`. Adds `chromeHeight` to


### PR DESCRIPTION
## Summary

- measure the New Task form's natural content independently from its scroll viewport
- allow the window height to shrink after Advanced is collapsed while preserving footer clearance
- cover the content/viewport separation and expanded-to-collapsed height restoration

## Testing

- pnpm run check:boundaries
- pnpm run lint
- pnpm exec tsc --noEmit
- pnpm exec vitest run src/renderer/hooks/use-adaptive-window-height.test.ts src/renderer/components/add-task/add-task-form.test.tsx
- production Electron build completed during the E2E setup; full Electron E2E is delegated to PR CI

Closes #1879
