### PR TITLE
chore(release): prepare 2.0.0-beta.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. After its remaining release gates pass,
-download [v2.0.0-beta.21 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.21)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.21.md) before
+download [v2.0.0-beta.22 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.22)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.22.md) before
 installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -162,7 +162,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.21'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.22'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。剩余发布门禁通过后，请从 GitHub Releases
-下载 [v2.0.0-beta.21](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.21)，
-并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.21.zh-CN.md)。
+下载 [v2.0.0-beta.22](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.22)，
+并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.22.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -153,7 +153,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.21'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.22'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.22.md
+++ b/docs/release-notes/2.0.0-beta.22.md
@@ -1,0 +1,90 @@
+# Motrix 2.0.0-beta.22
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.22/docs/release-notes/2.0.0-beta.22.zh-CN.md)
+
+Motrix 2.0.0-beta.22 updates the bundled download engine to aria2
+`1.37.0-motrix.10`, makes custom upstream aria2 replacements safe, fixes an
+engine task-adoption race, adds a lower-memory desktop mode, and polishes the
+New Task window. It is intended for public distribution only after every
+protected release gate passes.
+
+## Highlights
+
+- Desktop, Server, Docker, and Flatpak packages now use the verified Motrix
+  aria2 fork `1.37.0-motrix.10`. Every supported platform asset is pinned by
+  name, size, and SHA-256 digest in the engine lock.
+- Motrix checks `aria2c --version` before starting the engine. A version must
+  carry the Motrix suffix and the fork-only SQLite persistence feature to be
+  recognized as the bundled fork; this detection does not depend on RPC, so an
+  incompatible engine cannot crash before it is identified.
+- When an upstream or otherwise non-Motrix aria2 executable is detected,
+  Motrix warns the user and durably changes `max-connection-per-server` and
+  `split` to the upstream limit of 16. The adjusted settings use the Custom
+  performance profile so validation cannot restore an incompatible value.
+- URI creation also handles aria2 error code 28 defensively. If a custom
+  engine rejects connection options above 16, Motrix retries the request once
+  with compatible values instead of losing the task.
+- Engine-adopted parent tasks are persisted before task inspectors can save
+  child files or peers. This removes the SQLite foreign-key race that could
+  stop desktop or Server startup while recovering existing aria2 tasks
+  ([#1920](https://github.com/agalwood/Motrix/issues/1920)).
+- A new Lightweight mode can release the hidden main-window renderer while
+  downloads continue. Background startup can remain headless when safe;
+  Windows and Linux retain a tray entry, while macOS can reopen from the Dock.
+- The New Task window reads the clipboard only when it opens, so editing the
+  form no longer overwrites user input with later clipboard changes. Collapsing
+  Advanced options now restores the compact window height.
+
+## Before testing
+
+This is prerelease software. Back up existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Do not rely on this beta for your only copy of important
+downloads.
+
+If you replace the bundled `aria2c`, expect Motrix to limit connections to 16
+unless the executable reports the Motrix fork version and persistence feature.
+
+## Planned downloads after release gates pass
+
+| Distribution | Architectures | Planned output |
+|--------------|---------------|----------------|
+| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | AppImage, DEB, and RPM |
+| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.22-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.22` tag in both registries |
+| Snap Store | — | Not published for this beta |
+
+After every container gate passes, the versioned image references will be
+`docker.io/motrixapp/motrix-server:2.0.0-beta.22` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.22`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.22/docs/docker-server.md)
+for storage, networking, and upgrade guidance.
+
+## Distribution notes
+
+- AppImage desktop integration is opt-in and confined to the current user's
+  XDG data directory. Browser-extension hand-off is not yet available from the
+  AppImage package because its Native Messaging host does not have a stable
+  path outside the mounted image.
+- Flatpak is validated separately and is not published by the release tag; the
+  GitHub prerelease includes its Native Host companion archives.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
+  Download them only from the official GitHub prerelease after it is published.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+- Snap is not published for this beta. Prerelease Snap runs stop after source
+  validation, so they do not build Snap artifacts, upload Store revisions, or
+  change `latest/edge`.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.22.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.22.zh-CN.md
@@ -1,0 +1,76 @@
+# Motrix 2.0.0-beta.22
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.22/docs/release-notes/2.0.0-beta.22.md) | 简体中文
+
+Motrix 2.0.0-beta.22 将内置下载内核更新为 aria2
+`1.37.0-motrix.10`，安全兼容用户自行替换的官方 aria2，修复了内核
+任务接管的竞态问题，新增占用更低的桌面轻量模式，并改进新建任务
+窗口。只有全部受保护发布门禁通过后，本版本才会进入公开分发。
+
+## 主要变化
+
+- 桌面端、Server、Docker 与 Flatpak 统一使用已验证的 Motrix aria2 fork
+  `1.37.0-motrix.10`。所有支持平台的内核产物均在锁文件中固定了文件名、
+  大小与 SHA-256 摘要。
+- Motrix 会在启动内核前执行 `aria2c --version`。只有同时包含 Motrix
+  版本后缀与 fork 专属 SQLite 持久化特性的内核，才会被识别为内置 fork。
+  检测不依赖 RPC，因此不兼容的内核不会在被识别之前就因启动参数崩溃。
+- 检测到官方上游或其他非 Motrix aria2 时，Motrix 会提示用户，并将
+  `max-connection-per-server` 与 `split` 持久调整为官方内核上限 16。
+  调整后会切换为自定义性能配置，避免设置校验再次恢复不兼容的数值。
+- 创建 URI 任务时也会防御 aria2 错误码 28。如果自定义内核拒绝超过
+  16 的连接参数，Motrix 会以兼容值重试一次，不会直接丢失该任务。
+- Motrix 现在会先持久化从内核接管的父任务，然后才允许任务检查器保存
+  子文件或 Peer。这消除了恢复现有 aria2 任务时可能中止桌面端或 Server
+  启动的 SQLite 外键竞态（[#1920](https://github.com/agalwood/Motrix/issues/1920)）。
+- 新增轻量模式，可在继续下载时释放已隐藏主窗口的渲染进程。条件允许时，
+  后台启动无需创建渲染进程；Windows 与 Linux 保留托盘入口，macOS 可从
+  Dock 重新打开。
+- 新建任务窗口只在打开时读取剪贴板，编辑表单时不会再被后续剪贴板变化
+  覆盖用户输入。折叠高级选项后，窗口也会恢复紧凑高度。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据与下载文件。Motrix v1 数据的
+迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
+
+条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录并行测试 v2。
+请勿仅依赖本 beta 保存重要下载文件。
+
+如果您自行替换内置 `aria2c`，除非它同时报告 Motrix fork 版本与持久化特性，
+否则 Motrix 会将连接数限制为 16。
+
+## 发布门禁通过后的计划下载项
+
+| 分发方式 | 架构 | 计划产物 |
+|----------|------|----------|
+| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 与 ZIP |
+| Windows | `x64` | 未签名 NSIS 安装包（`.exe`）与 ZIP |
+| Linux | `x64`、`arm64` | AppImage、DEB 与 RPM |
+| Flatpak Native Host companion | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.22-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中不可变的 `2.0.0-beta.22` tag |
+| Snap Store | — | 本 beta 不发布 |
+
+全部容器门禁通过后，带版本的镜像引用将是
+`docker.io/motrixapp/motrix-server:2.0.0-beta.22` 与
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.22`。存储、网络与升级说明请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.22/docs/docker-server.zh-CN.md)。
+
+## 分发说明
+
+- AppImage 桌面集成需要用户选择启用，并且只写入当前用户的 XDG 数据目录。
+  AppImage 内的 Native Messaging host 在挂载镜像外没有稳定路径，因此浏览器扩展
+  暂时还不能把下载任务移交给 AppImage 版本。
+- Flatpak 会单独验证，不会随该版本 tag 发布；GitHub 预发布版会包含对应的
+  Native Host companion 压缩包。
+- 不提供 Windows `arm64` 和任何 32 位安装包。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅在官方
+  GitHub 预发布版发布后下载。
+- Beta 容器 tag 不可变，也不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
+- 本 beta 不发布 Snap。预发布 Snap run 会在 source validation 后停止，不会
+  构建 Snap、上传 Store revision 或修改 `latest/edge`。
+
+## 反馈
+
+请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现问题，
+并附上操作系统、架构、安装包类型以及复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -76,6 +76,17 @@
   <releases>
     <!-- Update this list on every release; Flathub linter requires the most
          recent version listed here to match the manifest's source tag. -->
+    <release version="2.0.0-beta.22" date="2026-08-22">
+      <description>
+        <p>
+          Bundled aria2 is updated to 1.37.0-motrix.10. Motrix now detects
+          non-Motrix aria2 builds before spawning them, warns the user, and
+          applies a durable 16-connection compatibility limit. This beta also
+          fixes engine task-adoption races, adds a lightweight desktop mode,
+          and improves the New Task window's clipboard and sizing behavior.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.21" date="2026-08-22">
       <description>
         <p>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.21",
+  "version": "2.0.0-beta.22",
   "packageManager": "pnpm@11.22.0+sha512.1ff870c4c6133dfd88fb2afc46dd13d47f09c9794b438c6fdb47ca98caf3bc16381ee0be93a091b8e3824cf01f889f46d7d9e20910fb0be1ab0fb5baa80dd621",
   "description": "A full-featured download manager",
   "keywords": [],


### PR DESCRIPTION
## Summary

- prepare Motrix 2.0.0-beta.22 metadata and bilingual release notes
- document aria2 1.37.0-motrix.10, non-fork compatibility fallback, task-adoption recovery, Lightweight mode, and New Task fixes
- update README download and container references plus AppStream release history

## Validation

- node scripts/check-boundaries.mjs
- node_modules/.bin/biome check .
- node_modules/.bin/tsc --noEmit -p tsconfig.json
- node scripts/check-file-names.mjs
- node --import tsx scripts/check-i18n.mjs
- node scripts/verify-flatpak-packaging.mjs
- node scripts/generate-third-party-notices.mjs --check
- node_modules/.bin/vitest run tests/scripts (582 tests; loopback smoke rerun outside the sandbox)
- node_modules/.bin/vitest run tests/check-third-party-notices.test.ts tests/generate-third-party-notices.test.ts
- release and container metadata preflight for protected v2.0.0-beta.22

## Distribution notes

- Windows packages remain unsigned.
- Beta Snap runs stop after source validation and do not publish.
- Beta container tags are immutable and do not update stable floating tags.
