### PR TITLE
fix(add-task): shrink non-resizable window on Windows

### DIFF
--- a/src/main/ipc/commands.test.ts
+++ b/src/main/ipc/commands.test.ts
@@ -643,14 +643,14 @@ describe('buildCommandHandlers', () => {
     expect(result).toEqual({ ok: true })
   })
 
-  it('ResizeWindow resolves sender to BrowserWindow and calls setSize', async () => {
-    const setSize = vi.fn()
+  it('ResizeWindow uses bounds so non-resizable windows can shrink', async () => {
+    const setBounds = vi.fn()
     const getSize = vi.fn(() => [800, 600])
     const isDestroyed = vi.fn(() => false)
     fromWebContentsMock.mockReturnValueOnce({
       isDestroyed,
       getSize,
-      setSize,
+      setBounds,
     })
     const ctx = fakeCtx()
     // @ts-expect-error partial ctx
@@ -661,7 +661,7 @@ describe('buildCommandHandlers', () => {
       height: 300,
     })
     expect(fromWebContentsMock).toHaveBeenCalledWith(fakeSender)
-    expect(setSize).toHaveBeenCalledWith(400, 300, true)
+    expect(setBounds).toHaveBeenCalledWith({ width: 400, height: 300 }, true)
     expect(result).toEqual({ ok: true })
   })
 

--- a/src/main/ipc/commands.ts
+++ b/src/main/ipc/commands.ts
@@ -1041,7 +1041,9 @@ export function buildCommandHandlers(ctx: CommandContext): CommandHandlerMap {
       if (win && !win.isDestroyed()) {
         const [currentWidth, currentHeight] = win.getSize()
         if (currentWidth !== params.width || currentHeight !== params.height) {
-          win.setSize(params.width, params.height, true)
+          // Electron #42258: setSize cannot shrink non-resizable windows on
+          // Windows and Linux. Partial bounds preserve the window position.
+          win.setBounds({ width: params.width, height: params.height }, true)
         }
       }
       return { ok: true }


### PR DESCRIPTION
## Summary

- replace BrowserWindow.setSize with partial setBounds for adaptive dialog resizing
- preserve the current window position and macOS animation behavior
- update the main-process regression test to cover shrinking a non-resizable window

## Root cause

Electron issue #42258 prevents setSize from shrinking BrowserWindow instances with resizable disabled on Windows and Linux. This is a follow-up to #1916 and the Windows 11 beta.22 verification feedback.

## Testing

- focused main-process test: 59 passed
- file-level Biome check passed
- full local CI skipped as requested; PR CI is authoritative

Fixes #1879