### PR TITLE
chore(release): prepare 2.0.0-beta.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. After its remaining release gates pass,
-download [v2.0.0-beta.22 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.22)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.22.md) before
+download [v2.0.0-beta.23 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.23)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.23.md) before
 installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -162,7 +162,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.22'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.23'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。剩余发布门禁通过后，请从 GitHub Releases
-下载 [v2.0.0-beta.22](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.22)，
-并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.22.zh-CN.md)。
+下载 [v2.0.0-beta.23](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.23)，
+并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.23.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -153,7 +153,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.22'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.23'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.23.md
+++ b/docs/release-notes/2.0.0-beta.23.md
@@ -1,0 +1,88 @@
+# Motrix 2.0.0-beta.23
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.23/docs/release-notes/2.0.0-beta.23.zh-CN.md)
+
+Motrix 2.0.0-beta.23 adds control over downloaded-file modification times,
+aligns launch and tray behavior with each desktop operating system, makes
+Settings controls more compact and consistent, and fixes New Task window
+shrinking on Windows. It is intended for public distribution only after every
+protected release gate passes.
+
+## Highlights
+
+- Downloads can now choose the modification time used for completed HTTP and
+  FTP files. **Local** is the default and keeps the download completion time;
+  **Server** applies the remote `Last-Modified` timestamp when one is available
+  ([#1542](https://github.com/agalwood/Motrix/issues/1542)).
+- Appearance now uses platform-native launch terminology. macOS offers Dock
+  and Menu Bar combinations, while Windows and Linux offer opening the main
+  window or starting in the system tray. Linux also explains that tray support
+  depends on the desktop environment.
+- Windows and Linux always retain a tray entry as a reliable way to reopen
+  Motrix, including when an old settings file contains the macOS-only hidden
+  tray value. A Linux tray click now toggles the main window, and context-menu
+  handling uses the events supported by each operating system.
+- Settings use more consistent widths for short numeric fields and compact
+  selectors. Speed-limit reset actions are grouped before their values, with
+  separate meanings for unlimited standard limits and inherited low-speed
+  limits.
+- The non-resizable New Task window now shrinks through a bounds update that
+  preserves its current position. This fixes the collapsed window height on
+  Windows while preserving the existing macOS animation behavior
+  ([#1879](https://github.com/agalwood/Motrix/issues/1879)).
+
+## Before testing
+
+This is prerelease software. Back up existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Do not rely on this beta for your only copy of important
+downloads.
+
+To test file times, download an HTTP or FTP resource that supplies a
+`Last-Modified` value, then compare the **Local** and **Server** choices under
+Downloads settings. Also verify that the Appearance launch mode and tray click
+behavior match your desktop environment.
+
+## Planned downloads after release gates pass
+
+| Distribution | Architectures | Planned output |
+|--------------|---------------|----------------|
+| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | AppImage, DEB, and RPM |
+| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.23-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.23` tag in both registries |
+| Snap Store | — | Not published for this beta |
+
+After every container gate passes, the versioned image references will be
+`docker.io/motrixapp/motrix-server:2.0.0-beta.23` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.23`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.23/docs/docker-server.md)
+for storage, networking, and upgrade guidance.
+
+## Distribution notes
+
+- AppImage desktop integration is opt-in and confined to the current user's
+  XDG data directory. Browser-extension hand-off is not yet available from the
+  AppImage package because its Native Messaging host does not have a stable
+  path outside the mounted image.
+- Flatpak is validated separately and is not published by the release tag; the
+  GitHub prerelease includes its Native Host companion archives.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
+  Download them only from the official GitHub prerelease after it is published.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+- Snap is not published for this beta. Prerelease Snap runs stop after source
+  validation, so they do not build Snap artifacts, upload Store revisions, or
+  change `latest/edge`.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.23.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.23.zh-CN.md
@@ -1,0 +1,71 @@
+# Motrix 2.0.0-beta.23
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.23/docs/release-notes/2.0.0-beta.23.md) | 简体中文
+
+Motrix 2.0.0-beta.23 新增下载文件修改时间选项，使启动与托盘行为更符合各桌面
+操作系统的习惯，统一并收紧 Settings 控件布局，并修复 Windows 上新建任务窗口
+无法缩回紧凑高度的问题。只有全部受保护发布门禁通过后，本版本才会进入公开分发。
+
+## 主要变化
+
+- HTTP 与 FTP 下载完成后，现在可以选择文件使用哪一种修改时间。默认的
+  **本地修改时间**保留下载完成时刻；选择**服务器修改时间**后，会在服务器提供
+  `Last-Modified` 时应用该时间（[#1542](https://github.com/agalwood/Motrix/issues/1542)）。
+- 外观设置改用符合平台习惯的启动文案。macOS 提供程序坞与菜单栏的组合；
+  Windows 和 Linux 提供打开主窗口或在系统托盘中启动。Linux 还会说明托盘支持
+  取决于当前桌面环境。
+- Windows 与 Linux 始终保留托盘入口，确保用户可以重新打开 Motrix；即使旧设置
+  文件包含仅 macOS 支持的隐藏托盘值也不会失去入口。Linux 单击托盘现在会切换
+  主窗口，各平台也只使用 Electron 实际支持的托盘菜单事件。
+- Settings 中的短数字输入框与紧凑选择器采用更一致的宽度。速度限制的重置操作
+  组合在数值前方，并区分常规上限的“不限速”与低速上限的“沿用常规上限”。
+- 不可调整大小的新建任务窗口改用保留当前位置的边界更新来缩小。该改动修复了
+  Windows 上折叠后无法恢复紧凑高度的问题，同时保留 macOS 原有动画行为
+  （[#1879](https://github.com/agalwood/Motrix/issues/1879)）。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据与下载文件。Motrix v1 数据的
+迁移路径尚未经过验证，请勿让本 beta 使用您唯一一份 v1 数据。
+
+条件允许时，建议通过独立的系统账户、设备或 Docker 数据目录并行测试 v2。
+请勿仅依赖本 beta 保存重要下载文件。
+
+测试文件时间时，请下载一个带 `Last-Modified` 的 HTTP 或 FTP 资源，然后在下载
+设置中分别选择**本地修改时间**与**服务器修改时间**并比较结果。同时请确认外观
+设置中的启动方式和托盘单击行为符合当前桌面环境。
+
+## 发布门禁通过后的计划下载项
+
+| 分发方式 | 架构 | 计划产物 |
+|----------|------|----------|
+| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 与 ZIP |
+| Windows | `x64` | 未签名 NSIS 安装包（`.exe`）与 ZIP |
+| Linux | `x64`、`arm64` | AppImage、DEB 与 RPM |
+| Flatpak Native Host companion | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.23-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个 registry 中不可变的 `2.0.0-beta.23` tag |
+| Snap Store | — | 本 beta 不发布 |
+
+全部容器门禁通过后，带版本的镜像引用将是
+`docker.io/motrixapp/motrix-server:2.0.0-beta.23` 与
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.23`。存储、网络与升级说明请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.23/docs/docker-server.zh-CN.md)。
+
+## 分发说明
+
+- AppImage 桌面集成需要用户选择启用，并且只写入当前用户的 XDG 数据目录。
+  AppImage 内的 Native Messaging host 在挂载镜像外没有稳定路径，因此浏览器扩展
+  暂时还不能把下载任务移交给 AppImage 版本。
+- Flatpak 会单独验证，不会随该版本 tag 发布；GitHub 预发布版会包含对应的
+  Native Host companion 压缩包。
+- 不提供 Windows `arm64` 和任何 32 位安装包。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅在官方
+  GitHub 预发布版发布后下载。
+- Beta 容器 tag 不可变，也不会更新 `latest`、`stable` 或其他稳定版浮动 tag。
+- 本 beta 不发布 Snap。预发布 Snap run 会在 source validation 后停止，不会
+  构建 Snap、上传 Store revision 或修改 `latest/edge`。
+
+## 反馈
+
+请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues) 报告可复现问题，
+并附上操作系统、架构、安装包类型以及复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -76,6 +76,17 @@
   <releases>
     <!-- Update this list on every release; Flathub linter requires the most
          recent version listed here to match the manifest's source tag. -->
+    <release version="2.0.0-beta.23" date="2026-08-23">
+      <description>
+        <p>
+          Downloads can now use either the local completion time or the
+          server-provided modification time. Appearance settings and tray
+          behavior follow macOS, Windows, and Linux conventions more closely,
+          Settings controls use a more consistent compact layout, and the New
+          Task window can shrink correctly on Windows.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.22" date="2026-08-22">
       <description>
         <p>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.22",
+  "version": "2.0.0-beta.23",
   "packageManager": "pnpm@11.22.0+sha512.1ff870c4c6133dfd88fb2afc46dd13d47f09c9794b438c6fdb47ca98caf3bc16381ee0be93a091b8e3824cf01f889f46d7d9e20910fb0be1ab0fb5baa80dd621",
   "description": "A full-featured download manager",
   "keywords": [],


### PR DESCRIPTION
## Summary

- prepare Motrix 2.0.0-beta.23 metadata and bilingual release notes
- document downloaded-file modification time selection, platform-aware launch and tray behavior, compact Settings controls, and the Windows New Task window fix
- update README download and container references plus the AppStream release history
- include changes from #1926 and #1928; related issues: #1542 and #1879

## Validation

- `pnpm run check:file-names`
- `pnpm run check:i18n`
- `pnpm run check:flatpak`
- `pnpm run check:boundaries`
- `pnpm run lint`
- `pnpm exec tsc --noEmit`
- `pnpm run check:third-party-notices`
- `pnpm exec vitest run tests/scripts` (43 files, 582 tests)
- protected-tag release metadata preflight for `v2.0.0-beta.23`
- beta container metadata preflight (immutable version tag only)

## Distribution notes

- Windows packages remain unsigned and the release notes disclose the SmartScreen warning.
- Beta Snap runs stop after source validation and do not publish.
- Beta container tags are immutable and do not update stable floating tags.
- The protected release tag will be created only after this commit reaches `main`.