### PR TITLE
fix(window): refine Windows caption controls

### DIFF
--- a/src/main/window/window-manager.test.ts
+++ b/src/main/window/window-manager.test.ts
@@ -52,6 +52,7 @@ vi.mock('electron', () => {
     isDestroyed = vi.fn(() => this._destroyed)
     isVisible = vi.fn(() => this._visible)
     isFocused = vi.fn(() => true)
+    isMaximized = vi.fn(() => false)
     getBounds = vi.fn(() => ({ ...this._bounds }))
     setBounds = vi.fn(
       (b: { x: number; y: number; width: number; height: number }) => {
@@ -153,6 +154,65 @@ describe('WindowManager', () => {
       .options
     expect(options.titleBarStyle).toBe('hidden')
     expect(options.titleBarOverlay).toBeUndefined()
+  })
+
+  it('publishes the owning window maximize state after load and on changes', () => {
+    const wm = new WindowManager({
+      settingsManager: createMockSettingsManager(),
+      preloadPath: '/fake/preload.cjs',
+      loadUrl: vi.fn(),
+      platform: 'win32',
+    })
+
+    const win = wm.open('main')
+    const webContentsListeners = (
+      win.webContents.on as unknown as ReturnType<typeof vi.fn>
+    ).mock.calls
+    const windowListeners = (win.on as unknown as ReturnType<typeof vi.fn>).mock
+      .calls
+    const didFinishLoad = webContentsListeners.find(
+      ([event]) => event === 'did-finish-load'
+    )?.[1] as (() => void) | undefined
+    const maximize = windowListeners.find(
+      ([event]) => event === 'maximize'
+    )?.[1] as (() => void) | undefined
+    const unmaximize = windowListeners.find(
+      ([event]) => event === 'unmaximize'
+    )?.[1] as (() => void) | undefined
+    const resized = windowListeners.find(
+      ([event]) => event === 'resized'
+    )?.[1] as (() => void) | undefined
+
+    didFinishLoad?.()
+    expect(win.webContents.send).toHaveBeenLastCalledWith(
+      Events.WindowMaximizedChanged,
+      { maximized: false }
+    )
+
+    vi.mocked(win.isMaximized).mockReturnValue(true)
+    maximize?.()
+    expect(win.webContents.send).toHaveBeenLastCalledWith(
+      Events.WindowMaximizedChanged,
+      { maximized: true }
+    )
+
+    // macOS can finish a manual resize without sending unmaximize. The final
+    // geometry event must still reconcile the renderer caption state.
+    vi.mocked(win.isMaximized).mockReturnValue(false)
+    resized?.()
+    expect(win.webContents.send).toHaveBeenLastCalledWith(
+      Events.WindowMaximizedChanged,
+      { maximized: false }
+    )
+
+    vi.mocked(win.isMaximized).mockReturnValue(true)
+    maximize?.()
+    vi.mocked(win.isMaximized).mockReturnValue(false)
+    unmaximize?.()
+    expect(win.webContents.send).toHaveBeenLastCalledWith(
+      Events.WindowMaximizedChanged,
+      { maximized: false }
+    )
   })
 
   it('uses the explicit secure Electron renderer defaults', () => {

--- a/src/main/window/window-manager.ts
+++ b/src/main/window/window-manager.ts
@@ -1,6 +1,9 @@
 import { getLogger } from '@core/logger'
 import type { SettingsManager } from '@core/settings/settings-manager'
-import { Events } from '@shared/protocol/events'
+import {
+  Events,
+  type WindowMaximizedChangedPayload,
+} from '@shared/protocol/events'
 import type { AddTaskUrlParams } from '@shared/schemas/add-task'
 import type { WindowBounds } from '@shared/types/settings'
 import { BrowserWindow, screen, shell } from 'electron'
@@ -319,6 +322,7 @@ export class WindowManager {
       // buttons visible during attach(), so apply the preview override last.
       win.setWindowButtonVisibility(false)
     }
+    this.setupWindowStateTracking(win)
     this.deps.loadUrl(win, config.route)
     this.setupCloseHandler(id, win)
     win.once('closed', () => {
@@ -495,6 +499,25 @@ export class WindowManager {
       win.on('query-session-end', () => this.deps.onSessionEnd?.())
       win.on('session-end', () => this.deps.onSessionEnd?.())
     }
+  }
+
+  private setupWindowStateTracking(win: BrowserWindow): void {
+    const publish = () => {
+      if (win.isDestroyed()) return
+      const payload: WindowMaximizedChangedPayload = {
+        maximized: win.isMaximized(),
+      }
+      win.webContents.send(Events.WindowMaximizedChanged, payload)
+    }
+
+    // did-finish-load supplies the initial snapshot; maximize/unmaximize keep
+    // it correct for caption clicks, title-bar double-clicks, and OS actions.
+    // Cocoa can leave the maximized state via a manual resize without emitting
+    // unmaximize, so reconcile once the resize gesture finishes as well.
+    win.webContents.on('did-finish-load', publish)
+    win.on('maximize', publish)
+    win.on('unmaximize', publish)
+    win.on('resized', publish)
   }
 
   private setupBoundsTracking(id: WindowId, win: BrowserWindow): void {

--- a/src/preload/preload.test.ts
+++ b/src/preload/preload.test.ts
@@ -49,7 +49,7 @@ function emit(channel: string, ...args: unknown[]): void {
   }
 }
 
-describe('preload locale replay buffer', () => {
+describe('preload latest-value replay buffers', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
@@ -86,6 +86,19 @@ describe('preload locale replay buffer', () => {
     expect(callback).toHaveBeenLastCalledWith({ language: 'en-US' })
     await Promise.resolve()
     expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it('replays only the latest maximize state before chrome subscribes', async () => {
+    await import('./preload')
+    emit(Events.WindowMaximizedChanged, { maximized: false })
+    emit(Events.WindowMaximizedChanged, { maximized: true })
+
+    const callback = vi.fn()
+    mocks.exposed?.on(Events.WindowMaximizedChanged, callback)
+    await Promise.resolve()
+
+    expect(callback).toHaveBeenCalledOnce()
+    expect(callback).toHaveBeenCalledWith({ maximized: true })
   })
 })
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -81,8 +81,14 @@ const BUFFERED_CHANNELS = new Set<string>([
   // Window URLs carry the initial locale, but a change can still land between
   // navigation and LanguageSync's effect. Replay the latest change on mount.
   Events.LocaleChanged,
+  // The main process publishes the current value on did-finish-load. Buffer it
+  // until WindowChrome mounts so reloads while maximized render Restore.
+  Events.WindowMaximizedChanged,
 ])
-const REPLAY_LATEST_CHANNELS = new Set<string>([Events.LocaleChanged])
+const REPLAY_LATEST_CHANNELS = new Set<string>([
+  Events.LocaleChanged,
+  Events.WindowMaximizedChanged,
+])
 const replayBuffer = new Map<string, unknown[][]>()
 const eagerListeners = new Map<string, IpcListener>()
 

--- a/src/renderer/components/ui/sidebar.tsx
+++ b/src/renderer/components/ui/sidebar.tsx
@@ -273,7 +273,7 @@ function SidebarTrigger({
       variant="ghost"
       size="icon"
       className={cn(
-        'size-7 [&>svg]:opacity-50 hover:[&>svg]:opacity-75 focus-visible:[&>svg]:opacity-75',
+        'size-7 [&>svg]:opacity-65 hover:[&>svg]:opacity-90 focus-visible:[&>svg]:opacity-90',
         className
       )}
       onClick={(event) => {

--- a/src/renderer/components/window-chrome/add-task-trigger-button.test.tsx
+++ b/src/renderer/components/window-chrome/add-task-trigger-button.test.tsx
@@ -60,9 +60,9 @@ describe('AddTaskTriggerButton', () => {
   it('shares the window-chrome icon opacity treatment', () => {
     renderWithProviders()
     expect(screen.getByRole('button', { name: /new task/i })).toHaveClass(
-      '[&>svg]:opacity-50',
-      'hover:[&>svg]:opacity-75',
-      'focus-visible:[&>svg]:opacity-75'
+      '[&>svg]:opacity-65',
+      'hover:[&>svg]:opacity-90',
+      'focus-visible:[&>svg]:opacity-90'
     )
   })
 })

--- a/src/renderer/components/window-chrome/add-task-trigger-button.tsx
+++ b/src/renderer/components/window-chrome/add-task-trigger-button.tsx
@@ -26,7 +26,7 @@ export function AddTaskTriggerButton({
             size="icon"
             aria-label={t('chrome.newTask')}
             className={cn(
-              'app-no-drag size-7 bg-transparent [&>svg]:opacity-50 hover:bg-accent hover:[&>svg]:opacity-75 focus-visible:[&>svg]:opacity-75',
+              'app-no-drag size-7 bg-transparent [&>svg]:opacity-65 hover:bg-accent hover:[&>svg]:opacity-90 focus-visible:[&>svg]:opacity-90',
               className
             )}
             onClick={onClick}

--- a/src/renderer/components/window-chrome/sidebar-trigger-button.test.tsx
+++ b/src/renderer/components/window-chrome/sidebar-trigger-button.test.tsx
@@ -71,4 +71,13 @@ describe('SidebarTriggerButton', () => {
       'Toggle sidebar'
     )
   })
+
+  it('shares the window-chrome icon opacity treatment', () => {
+    renderWithProviders()
+    expect(screen.getByRole('button', { name: /toggle sidebar/i })).toHaveClass(
+      '[&>svg]:opacity-65',
+      'hover:[&>svg]:opacity-90',
+      'focus-visible:[&>svg]:opacity-90'
+    )
+  })
 })

--- a/src/renderer/components/window-chrome/window-chrome.test.tsx
+++ b/src/renderer/components/window-chrome/window-chrome.test.tsx
@@ -1,16 +1,39 @@
 import '@renderer/lib/i18n'
 import '@testing-library/jest-dom/vitest'
 import { Commands } from '@shared/protocol/commands'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { Events } from '@shared/protocol/events'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { shouldShowDesktopWindowControls, WindowChrome } from './window-chrome'
+
+type IpcListener = (...args: unknown[]) => void
+const ipcListeners = new Map<string, Set<IpcListener>>()
+
+function emit(channel: string, ...args: unknown[]): void {
+  for (const listener of ipcListeners.get(channel) ?? []) listener(...args)
+}
 
 beforeAll(() => {
   // stub the preload bridge read by the module on import
   vi.stubGlobal(
     'window',
     Object.assign(window, {
-      motrix: { platform: 'darwin', invoke: vi.fn() },
+      motrix: {
+        platform: 'darwin',
+        invoke: vi.fn(),
+        on: vi.fn((channel: string, listener: IpcListener) => {
+          let listeners = ipcListeners.get(channel)
+          if (!listeners) {
+            listeners = new Set()
+            ipcListeners.set(channel, listeners)
+          }
+          listeners.add(listener)
+        }),
+        off: vi.fn((channel: string, listener: IpcListener) => {
+          ipcListeners.get(channel)?.delete(listener)
+        }),
+        getPathForFile: vi.fn(),
+      },
     })
   )
 })
@@ -29,6 +52,7 @@ function setPlatform(platform: NodeJS.Platform) {
 
 beforeEach(() => {
   setPlatform('darwin')
+  ipcListeners.clear()
   vi.mocked(window.motrix?.invoke).mockClear()
 })
 
@@ -208,7 +232,7 @@ describe('WindowChrome', () => {
   )
 
   it.each(['linux', 'win32'] as const)(
-    'renders aligned 28 px %s caption hit targets with 16 px icons',
+    'renders aligned 28 px %s caption hit targets with 10 px glyphs',
     (platform) => {
       setPlatform(platform)
       const { container } = render(<WindowChrome variant="overlay" />)
@@ -220,15 +244,45 @@ describe('WindowChrome', () => {
       expect(controls).toHaveClass('gap-2', 'pe-3.5', 'pt-3.5')
       const buttons = [
         screen.getByRole('button', { name: 'Minimize' }),
-        screen.getByRole('button', { name: 'Maximize or restore' }),
+        screen.getByRole('button', { name: 'Maximize' }),
         screen.getByRole('button', { name: 'Close' }),
       ]
       for (const button of buttons) {
         expect(button).toHaveClass('size-7')
-        expect(button.querySelector('svg')).toHaveClass('size-4')
+        expect(button.querySelector('svg')).toHaveClass('size-2.5')
+        expect(button.querySelector('svg')).toHaveAttribute(
+          'viewBox',
+          '0 0 10 10'
+        )
       }
+      expect(
+        buttons.map((button) =>
+          button.querySelector('svg')?.getAttribute('data-caption-icon')
+        )
+      ).toEqual(['minimize', 'maximize', 'close'])
     }
   )
+
+  it('switches the maximize action and glyph to restore with window state', () => {
+    setPlatform('win32')
+    render(<WindowChrome variant="overlay" />)
+
+    expect(screen.getByRole('button', { name: 'Maximize' })).toHaveAttribute(
+      'title',
+      'Maximize'
+    )
+
+    act(() => {
+      emit(Events.WindowMaximizedChanged, { maximized: true })
+    })
+
+    const restore = screen.getByRole('button', { name: 'Restore' })
+    expect(restore).toHaveAttribute('title', 'Restore')
+    expect(restore.querySelector('svg')).toHaveAttribute(
+      'data-caption-icon',
+      'restore'
+    )
+  })
 
   it('uses theme-aware caption colors with a readable destructive hover', () => {
     setPlatform('win32')
@@ -239,15 +293,15 @@ describe('WindowChrome', () => {
 
     expect(minimize).toHaveClass(
       'text-foreground',
-      '[&>svg]:opacity-50',
+      '[&>svg]:opacity-65',
       'hover:bg-accent',
       'hover:text-accent-foreground',
-      'hover:[&>svg]:opacity-75',
+      'hover:[&>svg]:opacity-90',
       'dark:hover:bg-accent/50'
     )
     expect(close).toHaveClass(
       'text-foreground',
-      '[&>svg]:opacity-50',
+      '[&>svg]:opacity-65',
       'hover:bg-destructive',
       'hover:text-white',
       'hover:[&>svg]:opacity-100',
@@ -263,9 +317,7 @@ describe('WindowChrome', () => {
       render(<WindowChrome variant="overlay" />)
 
       fireEvent.click(screen.getByRole('button', { name: 'Minimize' }))
-      fireEvent.click(
-        screen.getByRole('button', { name: 'Maximize or restore' })
-      )
+      fireEvent.click(screen.getByRole('button', { name: 'Maximize' }))
       fireEvent.click(screen.getByRole('button', { name: 'Close' }))
 
       expect(window.motrix?.invoke).toHaveBeenNthCalledWith(
@@ -287,9 +339,7 @@ describe('WindowChrome', () => {
     setPlatform('win32')
     render(<WindowChrome variant="titled" maximizable={false} />)
 
-    expect(
-      screen.getByRole('button', { name: 'Maximize or restore' })
-    ).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Maximize' })).toBeDisabled()
   })
 
   it('aligns app and caption controls on the shared compact baseline', () => {

--- a/src/renderer/components/window-chrome/window-chrome.tsx
+++ b/src/renderer/components/window-chrome/window-chrome.tsx
@@ -1,10 +1,65 @@
+import { useIpcEvent } from '@renderer/hooks/use-ipc-event'
 import { transport } from '@renderer/lib/transport'
 import { cn } from '@renderer/lib/utils'
 import { DESKTOP_WINDOW_CHROME_HEIGHT } from '@shared/constants/window-chrome'
 import { Commands } from '@shared/protocol/commands'
-import { MinusIcon, SquareIcon, XIcon } from 'lucide-react'
+import {
+  Events,
+  type WindowMaximizedChangedPayload,
+} from '@shared/protocol/events'
 import type React from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+
+type CaptionIconName = 'close' | 'maximize' | 'minimize' | 'restore'
+
+function CaptionIcon({ name }: { name: CaptionIconName }) {
+  return (
+    <svg
+      aria-hidden
+      className="size-2.5"
+      data-caption-icon={name}
+      viewBox="0 0 10 10"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      {name === 'minimize' && <path d="M0 5h10v1H0z" fill="currentColor" />}
+      {name === 'maximize' && (
+        <rect
+          x="0.5"
+          y="0.5"
+          width="9"
+          height="9"
+          rx="1.5"
+          stroke="currentColor"
+        />
+      )}
+      {name === 'restore' && (
+        <>
+          <path
+            d="M2.5 2V1.5a1 1 0 0 1 1-1h4a2 2 0 0 1 2 2v4a1 1 0 0 1-1 1H8"
+            stroke="currentColor"
+          />
+          <rect
+            x="0.5"
+            y="2.5"
+            width="7"
+            height="7"
+            rx="1"
+            stroke="currentColor"
+          />
+        </>
+      )}
+      {name === 'close' && (
+        <path
+          d="m0.5 0.5 9 9m0-9-9 9"
+          stroke="currentColor"
+          strokeLinecap="round"
+        />
+      )}
+    </svg>
+  )
+}
 
 function DesktopWindowControls({
   maximizable,
@@ -14,6 +69,14 @@ function DesktopWindowControls({
   separateFromActions: boolean
 }) {
   const { t } = useTranslation()
+  const [maximized, setMaximized] = useState(false)
+  useIpcEvent(Events.WindowMaximizedChanged, (...args) => {
+    const payload = args[0] as WindowMaximizedChangedPayload | undefined
+    if (typeof payload?.maximized === 'boolean') {
+      setMaximized(payload.maximized)
+    }
+  })
+
   const minimize = () => {
     void transport.invoke(Commands.MinimizeCurrentWindow)
   }
@@ -25,11 +88,12 @@ function DesktopWindowControls({
   }
 
   const buttonClassName =
-    'app-no-drag flex size-7 shrink-0 items-center justify-center rounded-md border-0 bg-transparent text-foreground outline-none transition-colors [&>svg]:opacity-50 hover:[&>svg]:opacity-75 focus-visible:[&>svg]:opacity-75 focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-30'
+    'app-no-drag flex size-7 shrink-0 items-center justify-center rounded-md border-0 bg-transparent text-foreground outline-none transition-colors [&>svg]:opacity-65 hover:[&>svg]:opacity-90 focus-visible:[&>svg]:opacity-90 focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-30'
   const standardButtonClassName = cn(
     buttonClassName,
     'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50'
   )
+  const maximizeLabel = maximized ? t('chrome.restore') : t('chrome.maximize')
 
   return (
     <div
@@ -46,17 +110,17 @@ function DesktopWindowControls({
         aria-label={t('chrome.minimize')}
         title={t('chrome.minimize')}
       >
-        <MinusIcon aria-hidden className="size-4" strokeWidth={1.5} />
+        <CaptionIcon name="minimize" />
       </button>
       <button
         type="button"
         className={standardButtonClassName}
         disabled={!maximizable}
         onClick={toggleMaximize}
-        aria-label={t('chrome.toggleMaximize')}
-        title={t('chrome.toggleMaximize')}
+        aria-label={maximizeLabel}
+        title={maximizeLabel}
       >
-        <SquareIcon aria-hidden className="size-4" strokeWidth={1.5} />
+        <CaptionIcon name={maximized ? 'restore' : 'maximize'} />
       </button>
       <button
         type="button"
@@ -68,7 +132,7 @@ function DesktopWindowControls({
         aria-label={t('chrome.close')}
         title={t('chrome.close')}
       >
-        <XIcon aria-hidden className="size-4" strokeWidth={1.5} />
+        <CaptionIcon name="close" />
       </button>
     </div>
   )

--- a/src/shared/locales/en-US.json
+++ b/src/shared/locales/en-US.json
@@ -96,7 +96,8 @@
   },
   "chrome": {
     "minimize": "Minimize",
-    "toggleMaximize": "Maximize or restore",
+    "maximize": "Maximize",
+    "restore": "Restore",
     "close": "Close",
     "toggleSidebar": "Toggle sidebar",
     "newTask": "New task"

--- a/src/shared/locales/zh-CN.json
+++ b/src/shared/locales/zh-CN.json
@@ -95,7 +95,8 @@
   },
   "chrome": {
     "minimize": "最小化",
-    "toggleMaximize": "最大化或还原",
+    "maximize": "最大化",
+    "restore": "还原",
     "close": "关闭",
     "toggleSidebar": "切换边栏",
     "newTask": "新建任务"

--- a/src/shared/locales/zh-TW.json
+++ b/src/shared/locales/zh-TW.json
@@ -95,7 +95,8 @@
   },
   "chrome": {
     "minimize": "最小化",
-    "toggleMaximize": "最大化或還原",
+    "maximize": "最大化",
+    "restore": "還原",
     "close": "關閉",
     "toggleSidebar": "切換側邊欄",
     "newTask": "新增任務"

--- a/src/shared/protocol/events.ts
+++ b/src/shared/protocol/events.ts
@@ -4,6 +4,10 @@ export interface LocaleChangedPayload {
   language: SupportedLocale
 }
 
+export interface WindowMaximizedChangedPayload {
+  maximized: boolean
+}
+
 export const Events = {
   TaskUpdated: 'event:taskUpdated',
   TaskFilesUpdated: 'event:taskFilesUpdated',
@@ -100,6 +104,9 @@ export const Events = {
   // resulting durable NotificationAdded event is what reaches renderers.
   EngineCompatibilityWarning: 'event:engineCompatibilityWarning',
   ApplicationMenuChanged: 'event:applicationMenuChanged',
+  // Renderer-local shell state. Electron sends this directly to the owning
+  // BrowserWindow instead of broadcasting it through the core event bus.
+  WindowMaximizedChanged: 'event:windowMaximizedChanged',
 } as const
 
 export type EventChannel = (typeof Events)[keyof typeof Events]


### PR DESCRIPTION
## Summary

- replace Lucide caption icons with 10 px Chromium-inspired glyphs while preserving 28 px click targets
- synchronize maximize and restore state after load, native state changes, and manual window resizing
- align title-bar action icon opacity for clearer visual weight

## Testing

- pnpm run check:boundaries
- pnpm run lint
- pnpm exec tsc --noEmit
- pnpm run check:i18n
- pnpm exec vitest run src/main/window/window-manager.test.ts src/preload/preload.test.ts src/renderer/components/window-chrome/window-chrome.test.tsx src/renderer/components/window-chrome/add-task-trigger-button.test.tsx src/renderer/components/window-chrome/sidebar-trigger-button.test.tsx
- pnpm run build:electron
- manually verified maximize, resize, re-maximize, and restore with MOTRIX_PREVIEW_MAC_MENU=1 pnpm start

Fixes #1925