### PR TITLE
fix(dashboard): omit partial leading month label in activity heatmap

### DIFF
--- a/src/renderer/routes/dashboard/activity/activity-calendar-model.test.ts
+++ b/src/renderer/routes/dashboard/activity/activity-calendar-model.test.ts
@@ -142,6 +142,14 @@ describe('activity calendar day model', () => {
     expect(projected.at(-1)?.dateKey).toBe(cells.at(-1)?.dateKey)
   })
 
+  it('omits a short leading partial month that would overlap the next label', () => {
+    const cells = buildActivityCells(snapshot(), new Date(2026, 7, 23, 12))
+    const labels = activityMonthLabels(cells)
+
+    expect(new Date(labels[0]?.dateMs ?? 0).getMonth()).toBe(8)
+    expect(labels[0]?.cellIndex).toBe(7)
+  })
+
   it('omits the duplicated trailing month label only in a full-year view', () => {
     const cells = buildActivityCells(snapshot(), new Date(2026, 6, 29, 12))
     const fullYearLabels = activityMonthLabels(cells)

--- a/src/renderer/routes/dashboard/activity/activity-calendar-model.ts
+++ b/src/renderer/routes/dashboard/activity/activity-calendar-model.ts
@@ -504,6 +504,15 @@ export function activityMonthLabels(
     }
   }
 
+  // A partial month with fewer than three visible week columns does not leave
+  // enough room for both short labels, so prefer the next complete month.
+  const leadingLabelIsPartial =
+    labels[0] && new Date(labels[0].dateMs).getDate() !== 1
+
+  if (leadingLabelIsPartial && labels[1] && labels[1].cellIndex <= 14) {
+    labels.shift()
+  }
+
   // A 53-week projection commonly begins and ends in the same named month
   // across adjacent years. Repeating that month at both edges reads like a
   // duplicate heading, so keep the leading label only for the full-year view.


### PR DESCRIPTION
## Summary

This pull request improves the handling of month labels in the activity calendar to avoid overlapping or confusing labels, especially when a partial month appears at the start of the calendar view. The main changes ensure that short leading partial months are omitted when they would overlap with the next label, and these behaviors are now covered by new tests.

* Updated `activityMonthLabels` in `activity-calendar-model.ts` to omit a short leading partial month label if it would overlap the next label, preferring to show the label for the next complete month instead.
* Added a test in `activity-calendar-model.test.ts` to verify that short leading partial months are omitted when necessary to prevent label overlap.

**Before:**

<img width="1834" height="1350" alt="CleanShot 2026-08-23 at 19 49 30@2x" src="https://github.com/user-attachments/assets/48f30e4a-4ed4-4653-8f3f-c8c2cf97d910" />

**Now:**

<img width="1834" height="1350" alt="CleanShot 2026-08-23 at 20 24 51@2x" src="https://github.com/user-attachments/assets/b9310435-2b8d-4cf2-857b-f96d0b494a27" />

## Verification

- related tests: 28 passed
- full test suite: 7180 passed | 3 skipped 
- pnpm run check:boundaries
- pnpm run lint
- pnpm exec tsc --noEmit

Closes #1936
