### PR TITLE
fix(release): prepare beta.25 AppImage recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -417,8 +417,8 @@ jobs:
               actual="$($APPIMAGE_FILE --appimage-updateinformation)"
               [[ "$actual" == "$EXPECTED_UPDATE" ]]
               "$APPIMAGE_FILE" --appimage-extract \
-                app.motrix.native.desktop >/tmp/appimage-extract.log
-              test -f squashfs-root/app.motrix.native.desktop
+                motrix.desktop >/tmp/appimage-extract.log
+              test -f squashfs-root/motrix.desktop
             '
 
       - name: Package Flatpak native host companion

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. After its remaining release gates pass,
-download [v2.0.0-beta.24 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.24)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.24.md) before
+download [v2.0.0-beta.25 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.25)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.25.md) before
 installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -162,7 +162,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.24'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.25'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。剩余发布门禁通过后，请从 GitHub Releases
-下载 [v2.0.0-beta.24](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.24)，
-并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.24.zh-CN.md)。
+下载 [v2.0.0-beta.25](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.25)，
+并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.25.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -153,7 +153,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.24'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.25'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.25.md
+++ b/docs/release-notes/2.0.0-beta.25.md
@@ -1,0 +1,107 @@
+# Motrix 2.0.0-beta.25
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.25/docs/release-notes/2.0.0-beta.25.zh-CN.md)
+
+Motrix 2.0.0-beta.25 strengthens BitTorrent and Magnet task identity, recovery,
+and storage safety; modernizes AppImage distribution; and refines several
+desktop controls. It is intended for public distribution only after every
+protected release gate passes.
+
+Beta.24 did not reach public distribution because the protected Linux smoke
+test looked for the AppStream application ID (`app.motrix.native.desktop`)
+instead of electron-builder's actual AppImage desktop entry
+(`motrix.desktop`). Beta.25 carries the same user-facing changes and corrects
+that release-only assertion; both AppImage architectures must still pass the
+complete no-FUSE extraction gate before publication.
+
+## Highlights
+
+- BitTorrent payloads now use a fixed-length internal staging workspace with
+  validated per-file output mappings. Final names are restored after
+  completion, and failed Magnet metadata resolution can be retried safely with
+  a fresh engine task ([#1930](https://github.com/agalwood/Motrix/issues/1930),
+  [#1932](https://github.com/agalwood/Motrix/pull/1932)).
+- Magnet-to-BT conversion immediately persists aria2's authoritative file
+  paths, sizes, and selection state. Domain file indexes consistently remain
+  zero-based, including restore and reseed paths
+  ([#1934](https://github.com/agalwood/Motrix/issues/1934),
+  [#1937](https://github.com/agalwood/Motrix/pull/1937)).
+- Re-adding the same torrent now compares its info hash, destination, and file
+  selection. Motrix reuses or focuses a compatible task, verifies completed
+  data before reuse, and reports explicit conflicts for incompatible copies or
+  leftover files instead of silently downloading a numbered duplicate. The
+  internal staging path no longer leaks a bare aria2 GID
+  ([#1939](https://github.com/agalwood/Motrix/pull/1939)).
+- AppImages now use static x64 and arm64 runtimes, include native zsync update
+  metadata, and support extraction on current Linux systems without depending
+  on FUSE 2 ([#1898](https://github.com/agalwood/Motrix/issues/1898),
+  [#1899](https://github.com/agalwood/Motrix/issues/1899),
+  [#1933](https://github.com/agalwood/Motrix/pull/1933)).
+- Windows caption controls use compact Chromium-inspired glyphs and stay in
+  sync when the window is maximized, restored, or resized
+  ([#1925](https://github.com/agalwood/Motrix/issues/1925),
+  [#1935](https://github.com/agalwood/Motrix/pull/1935)).
+- The activity heatmap omits a partial leading month label when it would
+  overlap the next month ([#1936](https://github.com/agalwood/Motrix/issues/1936),
+  [#1938](https://github.com/agalwood/Motrix/pull/1938)).
+- New Task file-type filters now show consistent tooltips
+  ([#1939](https://github.com/agalwood/Motrix/pull/1939)).
+
+## Before testing
+
+This is prerelease software. Back up existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Do not rely on this beta for your only copy of important
+downloads.
+
+For BitTorrent testing, add the same Magnet link more than once with matching
+and different destinations or file selections. Confirm that compatible tasks
+are reused, incompatible copies require an explicit choice, and completed data
+is checked before reuse. Historical tasks with empty file metadata can only be
+repaired while aria2 still retains their result; otherwise remove the old task
+and re-add the Magnet link. On Linux, also verify AppImage extraction, desktop
+integration, and update checks on the architectures you use.
+
+## Planned downloads after release gates pass
+
+| Distribution | Architectures | Planned output |
+|--------------|---------------|----------------|
+| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | AppImage, DEB, and RPM |
+| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.25-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.25` tag in both registries |
+| Snap Store | — | Not published for this beta |
+
+After every container gate passes, the versioned image references will be
+`docker.io/motrixapp/motrix-server:2.0.0-beta.25` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.25`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.25/docs/docker-server.md)
+for storage, networking, and upgrade guidance.
+
+## Distribution notes
+
+- AppImage desktop integration is opt-in and confined to the current user's
+  XDG data directory. Browser-extension hand-off is not yet available from the
+  AppImage package because its Native Messaging host does not have a stable
+  path outside the mounted image.
+- Flatpak is validated separately and is not published by the release tag; the
+  GitHub prerelease includes its Native Host companion archives.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
+  Download them only from the official GitHub prerelease after it is published.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+- Snap is not published for this beta. Prerelease Snap runs stop after source
+  validation, so they do not build Snap artifacts, upload Store revisions, or
+  change `latest/edge`.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.25.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.25.zh-CN.md
@@ -1,0 +1,90 @@
+# Motrix 2.0.0-beta.25
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.25/docs/release-notes/2.0.0-beta.25.md) | 简体中文
+
+Motrix 2.0.0-beta.25 强化了 BitTorrent 与 Magnet 任务的身份识别、恢复和存储安全，
+更新了 AppImage 分发方式，并改进了多处桌面控件。只有在全部受保护发布门禁通过后，
+本版本才适合公开分发。
+
+Beta.24 因受保护的 Linux smoke test 查找了 AppStream 应用 ID
+（`app.motrix.native.desktop`），而不是 electron-builder 在 AppImage 中实际生成的
+桌面入口（`motrix.desktop`），因此未进入公开分发。Beta.25 包含相同的用户功能并
+修正了这项仅用于发布的断言；两个 AppImage 架构仍须完整通过无 FUSE 提取门禁后
+才能发布。
+
+## 主要改进
+
+- BitTorrent 内容现在使用长度固定的内部暂存工作区，并通过经过验证的逐文件输出映射
+  避免过长路径。任务完成后会恢复最终名称；Magnet 元数据解析失败时，也可以使用新的
+  引擎任务安全重试（[#1930](https://github.com/agalwood/Motrix/issues/1930)、
+  [#1932](https://github.com/agalwood/Motrix/pull/1932)）。
+- Magnet 转换为 BT 后，会立即持久化 aria2 返回的真实文件路径、大小和选择状态。
+  领域层文件索引统一为从零开始，恢复和重新做种路径也遵循相同约定
+  （[#1934](https://github.com/agalwood/Motrix/issues/1934)、
+  [#1937](https://github.com/agalwood/Motrix/pull/1937)）。
+- 再次添加相同种子时，Motrix 会综合比较 info hash、下载目录和选中文件集合。
+  兼容的现有任务会被复用或聚焦，已完成的数据会先经过完整性校验；目录、选择集合不兼容
+  或磁盘仍有遗留文件时，会显示明确冲突，而不是静默创建带编号的重复下载。内部暂存路径
+  也不会再向用户暴露裸 aria2 GID（[#1939](https://github.com/agalwood/Motrix/pull/1939)）。
+- AppImage 现在使用 x64 与 arm64 静态运行时，包含原生 zsync 更新元数据，并可在当前
+  Linux 系统上不依赖 FUSE 2 完成提取
+  （[#1898](https://github.com/agalwood/Motrix/issues/1898)、
+  [#1899](https://github.com/agalwood/Motrix/issues/1899)、
+  [#1933](https://github.com/agalwood/Motrix/pull/1933)）。
+- Windows 标题栏按钮改用紧凑的 Chromium 风格图标，并会在窗口最大化、还原和手动调整
+  大小时保持状态同步（[#1925](https://github.com/agalwood/Motrix/issues/1925)、
+  [#1935](https://github.com/agalwood/Motrix/pull/1935)）。
+- 活动热力图会在月初残缺标签与下一个月份重叠时省略该标签
+  （[#1936](https://github.com/agalwood/Motrix/issues/1936)、
+  [#1938](https://github.com/agalwood/Motrix/pull/1938)）。
+- 新建任务中的文件类型筛选按钮增加了统一的悬停提示
+  （[#1939](https://github.com/agalwood/Motrix/pull/1939)）。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1 数据的迁移路径
+尚未经过验证，请勿让本 beta 使用您唯一的一份 v1 数据。
+
+条件允许时，请使用独立的操作系统账号、设备或 Docker 数据目录并行测试 v2。不要依赖
+本 beta 保存唯一一份重要下载内容。
+
+测试 BitTorrent 时，请使用相同与不同的下载目录或文件选择，重复添加同一个 Magnet。
+确认兼容任务会被复用，不兼容副本需要明确选择，并且已完成的数据会在复用前接受校验。
+历史任务如果只保存了空文件元数据，只有在 aria2 仍保留对应结果时才能修复；否则需要
+删除旧任务并重新添加 Magnet。Linux 用户还应在实际使用的架构上验证 AppImage 提取、
+桌面集成和更新检查。
+
+## 发布门禁通过后计划提供的下载
+
+| 分发方式 | 架构 | 计划产物 |
+|---------|------|---------|
+| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
+| Windows | `x64` | 未签名 NSIS 安装程序（`.exe`）和 ZIP |
+| Linux | `x64`、`arm64` | AppImage、DEB 和 RPM |
+| Flatpak Native Host companion | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.25-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个仓库中的不可变 `2.0.0-beta.25` 标签 |
+| Snap Store | — | 本 beta 不发布 |
+
+所有容器门禁通过后，可使用以下带版本镜像：
+`docker.io/motrixapp/motrix-server:2.0.0-beta.25` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.25`。存储、网络与升级说明请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.25/docs/docker-server.zh-CN.md)。
+
+## 分发说明
+
+- AppImage 桌面集成需要用户主动启用，且只会写入当前用户的 XDG 数据目录。由于 Native
+  Messaging host 在挂载镜像之外没有稳定路径，浏览器扩展暂时无法向 AppImage 安装包
+  转交下载任务。
+- Flatpak 单独验证，不由 release tag 发布；GitHub 预发布版会包含它的 Native Host
+  companion 压缩包。
+- 不提供 Windows `arm64` 和所有 32 位安装包。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅从官方 GitHub
+  预发布版下载。
+- Beta 容器标签不可变，也不会更新 `latest`、`stable` 或其他稳定通道浮动标签。
+- 本 beta 不发布 Snap。预发布 Snap 流程会在 source validation 后停止，不会构建或
+  上传 Snap 产物，也不会改动 `latest/edge`。
+
+## 反馈
+
+如遇到可复现的问题，请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues)
+反馈，并附上操作系统、架构、安装包类型和复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -76,6 +76,15 @@
   <releases>
     <!-- Update this list on every release; Flathub linter requires the most
          recent version listed here to match the manifest's source tag. -->
+    <release version="2.0.0-beta.25" date="2026-08-24">
+      <description>
+        <p>
+          Carries the beta.24 user-facing changes and corrects the protected
+          AppImage no-FUSE smoke test to verify electron-builder's actual
+          motrix.desktop entry before publication.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.24" date="2026-08-24">
       <description>
         <p>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.24",
+  "version": "2.0.0-beta.25",
   "packageManager": "pnpm@11.22.0+sha512.1ff870c4c6133dfd88fb2afc46dd13d47f09c9794b438c6fdb47ca98caf3bc16381ee0be93a091b8e3824cf01f889f46d7d9e20910fb0be1ab0fb5baa80dd621",
   "description": "A full-featured download manager",
   "keywords": [],

--- a/tests/scripts/workflow-release-matrix.test.ts
+++ b/tests/scripts/workflow-release-matrix.test.ts
@@ -1384,7 +1384,11 @@ describe('release workflow publication contract', () => {
     expect(cleanSmokeCommand).toContain('[[ ! -e /dev/fuse ]]')
     expect(cleanSmokeCommand).toContain('libfuse.so.2')
     expect(cleanSmokeCommand).toContain('--appimage-updateinformation')
-    expect(cleanSmokeCommand).toContain('--appimage-extract')
+    expect(cleanSmokeCommand).toMatch(
+      /--appimage-extract \\\n\s+motrix\.desktop/
+    )
+    expect(cleanSmokeCommand).toContain('test -f squashfs-root/motrix.desktop')
+    expect(cleanSmokeCommand).not.toContain('app.motrix.native.desktop')
 
     const upload = buildSteps.find(
       (step) => step.name === 'Upload target release input'


### PR DESCRIPTION
## Summary
- correct the protected no-FUSE AppImage smoke test to extract electron-builder’s actual `motrix.desktop` entry
- add a regression contract that rejects the incorrect AppStream application-ID filename
- prepare `2.0.0-beta.25` as a full recovery release because beta.24 failed before publication and its immutable tag will not be moved
- carry forward the complete beta.24 user-facing notes and update README/AppStream release metadata

## Root cause
Both Linux builds produced valid static AppImages, passed structural/runtime/update-info verification, and ran without `/dev/fuse` or `libfuse.so.2`. The release-only smoke test then requested `app.motrix.native.desktop`, but electron-builder packages the desktop entry as `motrix.desktop` from `linux.executableName`. The static runtime correctly extracted nothing for the non-existent prefix, causing the final file assertion to fail on x64 and arm64.

## Verification
- reproduced beta.24 x64 artifact in an isolated Ubuntu 24.04 container with no network, `/dev/fuse`, or FUSE2
- verified update information exactly matches the beta zsync channel
- verified `--appimage-extract motrix.desktop` succeeds and produces `squashfs-root/motrix.desktop`
- `pnpm run check:boundaries`
- `pnpm run lint`
- `pnpm exec tsc --noEmit`
- `pnpm run check:file-names`
- `pnpm run check:i18n`
- `pnpm run check:flatpak`
- `pnpm run check:third-party-notices` (547 packages; 21 tests)
- `pnpm exec vitest run tests/scripts` (598 tests; sandbox-only loopback EPERM excluded)
- `pnpm exec vitest run tests/scripts/smoke-server-package.test.ts` outside the restricted loopback sandbox (2 tests)
- protected tag and container release metadata preflights for `v2.0.0-beta.25`