### PR TITLE
feat(appearance): add option to set custom fonts

### DIFF
--- a/src/renderer/components/font-sync.test.tsx
+++ b/src/renderer/components/font-sync.test.tsx
@@ -1,0 +1,209 @@
+import { transport } from '@renderer/lib/transport'
+import { Events } from '@shared/protocol/events'
+import { Queries } from '@shared/protocol/queries'
+import { act, render, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { applyFontFamily, FontSync } from './font-sync'
+
+const mocks = vi.hoisted(() => ({
+  listeners: new Map<string, (...args: unknown[]) => void>(),
+  platform: 'darwin' as NodeJS.Platform | 'web',
+  connectionListener: undefined as
+    | ((event: { state: 'connecting' | 'connected' | 'disconnected' }) => void)
+    | undefined,
+  stopConnectionSync: vi.fn(),
+}))
+
+vi.mock('@renderer/lib/transport', () => ({
+  transport: {
+    invoke: vi.fn(),
+    on: vi.fn((channel: string, callback: (...args: unknown[]) => void) => {
+      mocks.listeners.set(channel, callback)
+    }),
+    off: vi.fn(),
+    onConnectionChange: vi.fn((callback) => {
+      mocks.connectionListener = callback
+      return mocks.stopConnectionSync
+    }),
+    get platform() {
+      return mocks.platform
+    },
+  },
+}))
+
+describe('applyFontFamily', () => {
+  beforeEach(() => {
+    document.documentElement.style.removeProperty('--app-font-family')
+  })
+
+  it('removes CSS custom property when font is null, empty, or whitespace', () => {
+    document.documentElement.style.setProperty('--app-font-family', 'Roboto')
+
+    applyFontFamily(null)
+    expect(
+      document.documentElement.style.getPropertyValue('--app-font-family')
+    ).toBe('')
+
+    applyFontFamily('')
+    expect(
+      document.documentElement.style.getPropertyValue('--app-font-family')
+    ).toBe('')
+
+    applyFontFamily('   ')
+    expect(
+      document.documentElement.style.getPropertyValue('--app-font-family')
+    ).toBe('')
+  })
+
+  it('quotes font names and appends default fallback fonts', () => {
+    applyFontFamily('Fira Code')
+    expect(
+      document.documentElement.style.getPropertyValue('--app-font-family')
+    ).toBe('"Fira Code", "Inter Variable", sans-serif')
+  })
+
+  it('preserves pre-quoted names and unquoted CSS generic families', () => {
+    applyFontFamily('"Custom Font", monospace, sans-serif')
+    expect(
+      document.documentElement.style.getPropertyValue('--app-font-family')
+    ).toBe('"Custom Font", "Inter Variable", sans-serif')
+  })
+
+  it('handles comma-separated font strings by taking only the primary font', () => {
+    applyFontFamily('Roboto, , sans-serif')
+    expect(
+      document.documentElement.style.getPropertyValue('--app-font-family')
+    ).toBe('"Roboto", "Inter Variable", sans-serif')
+  })
+})
+
+describe('FontSync', () => {
+  beforeEach(() => {
+    mocks.listeners.clear()
+    mocks.platform = 'darwin'
+    mocks.connectionListener = undefined
+    document.documentElement.style.removeProperty('--app-font-family')
+    vi.clearAllMocks()
+    vi.mocked(transport.invoke).mockReset()
+    vi.mocked(transport.invoke).mockResolvedValue({
+      app: { fontFamily: 'Roboto' },
+    })
+  })
+
+  it('applies host settings events and unsubscribes on unmount', () => {
+    const view = render(<FontSync />)
+    const listener = mocks.listeners.get(Events.SettingsChanged)
+
+    expect(listener).toBeDefined()
+    act(() => listener?.({ app: { fontFamily: 'Open Sans' } }))
+
+    expect(
+      document.documentElement.style.getPropertyValue('--app-font-family')
+    ).toBe('"Open Sans", "Inter Variable", sans-serif')
+
+    view.unmount()
+    expect(transport.off).toHaveBeenCalledWith(Events.SettingsChanged, listener)
+  })
+
+  it('handles top-level vs nested fontFamily in event payloads', () => {
+    render(<FontSync />)
+    const listener = mocks.listeners.get(Events.SettingsChanged)
+
+    act(() => listener?.({ fontFamily: 'JetBrains Mono' }))
+    expect(
+      document.documentElement.style.getPropertyValue('--app-font-family')
+    ).toBe('"JetBrains Mono", "Inter Variable", sans-serif')
+
+    // Invalid / Unrelated payloads should be ignored
+    act(() => {
+      listener?.(null)
+      listener?.({})
+      listener?.({ app: { theme: 'dark' } })
+    })
+    expect(
+      document.documentElement.style.getPropertyValue('--app-font-family')
+    ).toBe('"JetBrains Mono", "Inter Variable", sans-serif')
+  })
+
+  it('reconciles persisted settings on desktop mount', async () => {
+    vi.mocked(transport.invoke).mockResolvedValue({
+      app: { fontFamily: 'Fira Code' },
+    })
+
+    render(<FontSync />)
+
+    await waitFor(() => {
+      expect(transport.invoke).toHaveBeenCalledWith(Queries.GetSettings)
+      expect(
+        document.documentElement.style.getPropertyValue('--app-font-family')
+      ).toBe('"Fira Code", "Inter Variable", sans-serif')
+    })
+
+    expect(transport.onConnectionChange).not.toHaveBeenCalled()
+  })
+
+  it('reconciles settings on web connection changes', async () => {
+    mocks.platform = 'web'
+    vi.mocked(transport.invoke)
+      .mockResolvedValueOnce({ app: { fontFamily: 'Lato' } })
+      .mockResolvedValueOnce({ app: { fontFamily: 'Roboto' } })
+
+    render(<FontSync />)
+
+    // Connecting or disconnected states should not trigger reconciliation
+    act(() => {
+      mocks.connectionListener?.({ state: 'connecting' })
+      mocks.connectionListener?.({ state: 'disconnected' })
+    })
+    expect(transport.invoke).not.toHaveBeenCalled()
+
+    // Connected state triggers reconciliation
+    act(() => mocks.connectionListener?.({ state: 'connected' }))
+
+    await waitFor(() => {
+      expect(transport.invoke).toHaveBeenCalledWith(Queries.GetSettings)
+      expect(
+        document.documentElement.style.getPropertyValue('--app-font-family')
+      ).toBe('"Lato", "Inter Variable", sans-serif')
+    })
+  })
+
+  it('prevents stale reconciliation responses from overwriting newer updates', async () => {
+    mocks.platform = 'web'
+    let resolveSettings: ((value: unknown) => void) | undefined
+    vi.mocked(transport.invoke).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveSettings = resolve
+        })
+    )
+    render(<FontSync />)
+
+    act(() => mocks.connectionListener?.({ state: 'connected' }))
+    const listener = mocks.listeners.get(Events.SettingsChanged)
+    act(() => listener?.({ app: { fontFamily: 'Comic Sans MS' } }))
+
+    expect(
+      document.documentElement.style.getPropertyValue('--app-font-family')
+    ).toBe('"Comic Sans MS", "Inter Variable", sans-serif')
+
+    await act(async () => {
+      resolveSettings?.({ app: { fontFamily: 'Times New Roman' } })
+      await Promise.resolve()
+    })
+
+    // Should retain Comic Sans MS because it was set by a newer generation event
+    expect(
+      document.documentElement.style.getPropertyValue('--app-font-family')
+    ).toBe('"Comic Sans MS", "Inter Variable", sans-serif')
+  })
+
+  it('handles transport.invoke rejection gracefully', async () => {
+    vi.mocked(transport.invoke).mockRejectedValueOnce(new Error('IPC Error'))
+
+    expect(() => render(<FontSync />)).not.toThrow()
+    await waitFor(() => {
+      expect(transport.invoke).toHaveBeenCalledWith(Queries.GetSettings)
+    })
+  })
+})

--- a/src/renderer/components/font-sync.tsx
+++ b/src/renderer/components/font-sync.tsx
@@ -1,0 +1,110 @@
+import { transport } from '@renderer/lib/transport'
+import {
+  removeGlobalCssVar,
+  setGlobalCssVar,
+} from '@shared/constants/css-variables'
+import { Events } from '@shared/protocol/events'
+import { Queries } from '@shared/protocol/queries'
+import type { AppSettings } from '@shared/types/settings'
+import { useEffect } from 'react'
+
+export function applyFontFamily(fontFamily?: string | null): void {
+  if (!fontFamily) {
+    removeGlobalCssVar('--app-font-family')
+    return
+  }
+
+  // Extract only the primary font family before any comma and collapse whitespace
+  const customFont = fontFamily.split(',')[0].replace(/\s+/g, ' ').trim()
+
+  if (!customFont) {
+    removeGlobalCssVar('--app-font-family')
+    return
+  }
+
+  const lower = customFont.toLowerCase()
+  const isQuoted =
+    (customFont.startsWith('"') && customFont.endsWith('"')) ||
+    (customFont.startsWith("'") && customFont.endsWith("'"))
+  const isGeneric = [
+    'sans-serif',
+    'serif',
+    'monospace',
+    'cursive',
+    'fantasy',
+    'system-ui',
+  ].includes(lower)
+
+  const formattedFont = isQuoted || isGeneric ? customFont : `"${customFont}"`
+
+  setGlobalCssVar(
+    '--app-font-family',
+    `${formattedFont}, "Inter Variable", sans-serif`
+  )
+}
+
+function fontFromSettings(payload: unknown): string | null | undefined {
+  if (typeof payload !== 'object' || !payload) return undefined
+  if ('fontFamily' in payload) {
+    return (payload as { fontFamily: string | null }).fontFamily
+  }
+  const app = (payload as { app?: unknown }).app
+  if (app && typeof app === 'object' && 'fontFamily' in app) {
+    return (app as { fontFamily: string | null }).fontFamily
+  }
+  return undefined
+}
+
+export function FontSync() {
+  useEffect(() => {
+    let active = true
+    let generation = 0
+
+    const queueFont = (
+      fontFamily: string | null | undefined,
+      fontGeneration: number
+    ): void => {
+      if (!active || fontGeneration !== generation) return
+      applyFontFamily(fontFamily)
+    }
+
+    const onSettingsChanged = (payload: unknown): void => {
+      const font = fontFromSettings(payload)
+      if (font === undefined) return
+      const fontGeneration = ++generation
+      queueFont(font, fontGeneration)
+    }
+
+    const reconcileHostFont = (): void => {
+      const fontGeneration = ++generation
+      void transport
+        .invoke(Queries.GetSettings)
+        .then((state) => {
+          if (!active || fontGeneration !== generation) return
+          const settings = state as AppSettings | undefined
+          const font = settings?.app?.fontFamily
+          queueFont(font, fontGeneration)
+        })
+        .catch(() => {})
+    }
+
+    transport.on(Events.SettingsChanged, onSettingsChanged)
+
+    const stopConnectionSync =
+      transport.platform === 'web'
+        ? transport.onConnectionChange?.((event) => {
+            if (event.state === 'connected') reconcileHostFont()
+          })
+        : undefined
+
+    if (transport.platform !== 'web') reconcileHostFont()
+
+    return () => {
+      active = false
+      generation += 1
+      transport.off(Events.SettingsChanged, onSettingsChanged)
+      stopConnectionSync?.()
+    }
+  }, [])
+  return null
+}

--- a/src/renderer/components/settings-kit/font-combobox.test.tsx
+++ b/src/renderer/components/settings-kit/font-combobox.test.tsx
@@ -1,0 +1,186 @@
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { FontCombobox } from './font-combobox'
+
+const mockFonts = ['Arial', 'Courier New', 'Fira Code', 'Inter', 'Roboto']
+
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+class MockIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+describe('<FontCombobox>', () => {
+  beforeEach(async () => {
+    window.ResizeObserver =
+      MockResizeObserver as unknown as typeof ResizeObserver
+    window.IntersectionObserver =
+      MockIntersectionObserver as unknown as typeof IntersectionObserver
+    window.HTMLElement.prototype.scrollIntoView = vi.fn()
+
+    // Floating UI requires non-zero element dimensions in JSDOM
+    Element.prototype.getBoundingClientRect = vi.fn(() => ({
+      width: 200,
+      height: 32,
+      top: 0,
+      left: 0,
+      bottom: 32,
+      right: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    }))
+  })
+
+  it('renders input with value and provided placeholder', () => {
+    render(
+      <FontCombobox
+        value="Inter"
+        onChange={vi.fn()}
+        systemFonts={mockFonts}
+        isLoading={false}
+        placeholder="Custom placeholder"
+      />
+    )
+    expect(screen.getByRole('combobox')).toHaveValue('Inter')
+    expect(
+      screen.getByPlaceholderText('Custom placeholder')
+    ).toBeInTheDocument()
+  })
+
+  it('displays loading spinner when isLoading is true', () => {
+    const { container } = render(
+      <FontCombobox
+        value=""
+        onChange={vi.fn()}
+        systemFonts={mockFonts}
+        isLoading={true}
+      />
+    )
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+
+  it('filters fonts list when user types', async () => {
+    const user = userEvent.setup()
+    render(
+      <FontCombobox
+        value="fir"
+        onChange={vi.fn()}
+        systemFonts={mockFonts}
+        isLoading={false}
+      />
+    )
+
+    const input = screen.getByRole('combobox')
+    await user.click(input)
+
+    expect(
+      screen.getByRole('option', { name: 'Fira Code' })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('option', { name: 'Arial' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('selects a font on option click and closes dropdown', async () => {
+    const handleChange = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <FontCombobox
+        value=""
+        onChange={handleChange}
+        systemFonts={mockFonts}
+        isLoading={false}
+      />
+    )
+
+    const input = screen.getByRole('combobox')
+    await user.click(input)
+
+    const option = screen.getByRole('option', { name: 'Roboto' })
+    await user.click(option)
+
+    expect(handleChange).toHaveBeenCalledWith('Roboto')
+    expect(
+      screen.queryByRole('option', { name: 'Roboto' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('navigates list with arrow keys and selects option with Enter', async () => {
+    const handleChange = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <FontCombobox
+        value=""
+        onChange={handleChange}
+        systemFonts={['Arial', 'Roboto']}
+        isLoading={false}
+      />
+    )
+
+    const input = screen.getByRole('combobox')
+    await user.click(input)
+
+    await user.keyboard('{ArrowDown}')
+    await user.keyboard('{ArrowDown}')
+    await user.keyboard('{Enter}')
+
+    expect(handleChange).toHaveBeenCalledWith('Roboto')
+    expect(
+      screen.queryByRole('option', { name: 'Roboto' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('closes dropdown on Escape key press', async () => {
+    const user = userEvent.setup()
+    render(
+      <FontCombobox
+        value=""
+        onChange={vi.fn()}
+        systemFonts={mockFonts}
+        isLoading={false}
+      />
+    )
+
+    const input = screen.getByRole('combobox')
+    await user.click(input)
+    expect(screen.getByRole('option', { name: 'Arial' })).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+    expect(
+      screen.queryByRole('option', { name: 'Arial' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('closes dropdown when clicking outside', async () => {
+    const user = userEvent.setup()
+    render(
+      <div>
+        <div data-testid="outside">Outside</div>
+        <FontCombobox
+          value=""
+          onChange={vi.fn()}
+          systemFonts={mockFonts}
+          isLoading={false}
+        />
+      </div>
+    )
+
+    const input = screen.getByRole('combobox')
+    await user.click(input)
+    expect(screen.getByRole('option', { name: 'Arial' })).toBeInTheDocument()
+
+    await user.click(screen.getByTestId('outside'))
+    expect(
+      screen.queryByRole('option', { name: 'Arial' })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/settings-kit/font-combobox.tsx
+++ b/src/renderer/components/settings-kit/font-combobox.tsx
@@ -1,0 +1,103 @@
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from '@renderer/components/ui/combobox'
+import { Loader2 } from 'lucide-react'
+import { useMemo, useState } from 'react'
+
+interface FontComboboxProps {
+  id?: string
+  value: string
+  onChange: (val: string) => void
+  systemFonts: string[]
+  isLoading?: boolean
+  placeholder?: string
+}
+
+export function FontCombobox({
+  id,
+  value,
+  onChange,
+  systemFonts,
+  isLoading = false,
+  placeholder,
+}: FontComboboxProps) {
+  const [open, setOpen] = useState(false)
+
+  const filteredFonts = useMemo(() => {
+    const query = (value || '').trim().toLowerCase()
+    if (!query) return systemFonts.slice(0, 100)
+    return systemFonts
+      .filter((font) => font.toLowerCase().includes(query))
+      .slice(0, 100)
+  }, [systemFonts, value])
+
+  return (
+    <Combobox
+      open={open}
+      onOpenChange={setOpen}
+      value={value ?? ''}
+      onValueChange={(val) => {
+        if (val) {
+          // Extract primary font, removing commas and extra spaces
+          const cleanFont = val.split(',')[0].replace(/\s+/g, ' ').trim()
+          onChange(cleanFont)
+        } else {
+          onChange('')
+        }
+        setOpen(false)
+      }}
+    >
+      <div className="relative w-56">
+        <ComboboxInput
+          id={id}
+          disabled={isLoading}
+          value={value ?? ''}
+          onChange={(e) => {
+            onChange(e.target.value)
+            setOpen(true)
+          }}
+          placeholder={placeholder}
+          className="h-8 text-xs"
+          showTrigger={!isLoading}
+          showClear={Boolean(value) && !isLoading}
+        />
+        {isLoading && (
+          <div className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2">
+            <Loader2 className="size-3.5 animate-spin text-muted-foreground opacity-60" />
+          </div>
+        )}
+      </div>
+
+      <ComboboxContent align="start" className="w-56">
+        <ComboboxList className="max-h-48 overflow-y-auto scrollbar-none hover:scrollbar-thin [&::-webkit-scrollbar]:hidden hover:[&::-webkit-scrollbar]:block [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-muted-foreground/30">
+          {isLoading ? (
+            <div className="py-3 text-center text-xs text-muted-foreground">
+              Loading system fonts...
+            </div>
+          ) : filteredFonts.length === 0 ? (
+            <div className="py-3 text-center text-xs text-muted-foreground">
+              No system fonts found
+            </div>
+          ) : (
+            filteredFonts.map((font) => (
+              <ComboboxItem
+                key={font}
+                value={font}
+                style={{
+                  fontFamily: `"${font.replace(/"/g, '\\"')}", monospace`,
+                }}
+                className="text-xs truncate"
+              >
+                {font}
+              </ComboboxItem>
+            ))
+          )}
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
+  )
+}

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -1,3 +1,4 @@
+import { FontSync } from '@renderer/components/font-sync'
 import { LanguageSync } from '@renderer/components/language-sync'
 import { LocaleDirectionProvider } from '@renderer/components/locale-direction-provider'
 import { OperatorUnlockGate } from '@renderer/components/operator-unlock-gate'
@@ -63,6 +64,7 @@ function Root({
     >
       <LocaleDirectionProvider>
         {syncSettings && <ThemeSync />}
+        {syncSettings && <FontSync />}
         <LanguageSync windowId={windowId} />
         {children}
       </LocaleDirectionProvider>

--- a/src/renderer/routes/settings/cards/appearance-dialog.test.tsx
+++ b/src/renderer/routes/settings/cards/appearance-dialog.test.tsx
@@ -1,3 +1,4 @@
+import { applyFontFamily } from '@renderer/components/font-sync'
 import '@testing-library/jest-dom/vitest'
 import { i18n } from '@renderer/lib/i18n'
 import { Commands } from '@shared/protocol/commands'
@@ -5,6 +6,10 @@ import { Queries } from '@shared/protocol/queries'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@renderer/components/font-sync', () => ({
+  applyFontFamily: vi.fn(),
+}))
 
 vi.mock('@renderer/lib/transport', () => ({
   transport: {
@@ -37,6 +42,7 @@ const FIXTURE = {
     protocols: { magnet: true },
     magnetFileSelection: true,
     liquidGlassEffect: false,
+    fontFamily: 'Arial',
   },
 }
 
@@ -60,7 +66,17 @@ beforeEach(async () => {
     value: 'darwin',
   })
   vi.stubGlobal('ResizeObserver', MockResizeObserver)
+  Object.defineProperty(window, 'queryLocalFonts', {
+    writable: true,
+    configurable: true,
+    value: vi.fn(async () => [
+      { family: 'Arial' },
+      { family: 'Fira Code' },
+      { family: 'Roboto' },
+    ]),
+  })
   vi.mocked(transport.invoke).mockReset()
+  vi.mocked(applyFontFamily).mockReset()
   vi.mocked(transport.invoke).mockImplementation(async (channel: string) => {
     if (channel === Queries.GetSettings) return FIXTURE
     return { saved: true, requiresRestart: false, changedRestartKeys: [] }
@@ -79,7 +95,7 @@ describe('<AppearanceDialog>', () => {
     )
 
     await waitFor(() => {
-      const [themeTrigger, languageTrigger, runModeTrigger] =
+      const [themeTrigger, languageTrigger, fontTrigger, runModeTrigger] =
         screen.getAllByRole('combobox')
 
       expect(themeTrigger).toHaveTextContent(/^System$/)
@@ -88,11 +104,14 @@ describe('<AppearanceDialog>', () => {
       expect(languageTrigger).not.toHaveTextContent(/^en-US$/)
       expect(languageTrigger).toHaveClass('min-w-30', 'max-w-64')
       expect(languageTrigger).not.toHaveClass('w-32')
+      expect(fontTrigger).not.toBeDisabled
+      expect(fontTrigger).toHaveValue('Arial')
       expect(runModeTrigger).toHaveTextContent(/^Dock & Menu Bar$/)
       expect(runModeTrigger).not.toHaveTextContent(/^1$/)
     })
 
     const user = userEvent.setup({ pointerEventsCheck: 0 })
+
     await user.click(
       screen.getByRole('combobox', {
         name: 'Show app in',
@@ -199,6 +218,62 @@ describe('<AppearanceDialog>', () => {
     expect(onClose).toHaveBeenCalled()
   })
 
+  it('updates font family input and filters options', async () => {
+    render(
+      <AppearanceDialog
+        open
+        onClose={vi.fn()}
+        labelKey="settings.cards.appearance.title"
+        descKey="settings.cards.appearance.desc"
+      />
+    )
+
+    const fontInput = await screen.findByLabelText('Font')
+    await waitFor(() => expect(fontInput).not.toBeDisabled())
+
+    expect(screen.getByPlaceholderText(/e\.g\. Roboto/i)).toBeInTheDocument()
+
+    const user = userEvent.setup({ pointerEventsCheck: 0 })
+    await user.clear(fontInput)
+    await user.type(fontInput, 'Fira')
+
+    expect(fontInput).toHaveValue('Fira')
+    expect(
+      await screen.findByRole('option', { name: 'Fira Code' })
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: 'Arial' })).toBeNull()
+  })
+
+  it('hydrates font family and submits dirty font changes optimistically', async () => {
+    const onClose = vi.fn()
+    render(
+      <AppearanceDialog
+        open
+        onClose={onClose}
+        labelKey="settings.cards.appearance.title"
+        descKey="settings.cards.appearance.desc"
+      />
+    )
+
+    const fontInput = await screen.findByLabelText('Font')
+    await waitFor(() => expect(fontInput).not.toBeDisabled())
+
+    const user = userEvent.setup({ pointerEventsCheck: 0 })
+    await user.clear(fontInput)
+    await user.type(fontInput, 'Roboto')
+
+    // Select the font option to close the combobox popover & remove inert state
+    const fontOption = await screen.findByRole('option', { name: 'Roboto' })
+    await user.click(fontOption)
+
+    await user.click(screen.getByRole('button', { name: /save/i }))
+
+    expect(transport.invoke).toHaveBeenCalledWith(Commands.UpdateSettings, {
+      app: { fontFamily: 'Roboto' },
+    })
+    expect(applyFontFamily).toHaveBeenCalledWith('Roboto')
+    expect(onClose).toHaveBeenCalled()
+  })
   it('hydrates and submits lightweight mode independently', async () => {
     render(
       <AppearanceDialog

--- a/src/renderer/routes/settings/cards/appearance-dialog.tsx
+++ b/src/renderer/routes/settings/cards/appearance-dialog.tsx
@@ -1,3 +1,5 @@
+import { applyFontFamily } from '@renderer/components/font-sync'
+import { FontCombobox } from '@renderer/components/settings-kit/font-combobox'
 import { SettingsSelectTrigger } from '@renderer/components/settings-kit/settings-select-trigger'
 import { Button } from '@renderer/components/ui/button'
 import {
@@ -33,7 +35,7 @@ import { Queries } from '@shared/protocol/queries'
 import { DEFAULT_APP_SETTINGS } from '@shared/schemas'
 import type { AppSettings, MotrixAppSettings } from '@shared/types/settings'
 import { useTheme } from 'next-themes'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import type { SettingsCardDialogProps } from './card-types'
@@ -46,6 +48,7 @@ type AppearanceFields = Pick<
   | 'runMode'
   | 'liquidGlassEffect'
   | 'lightweightMode'
+  | 'fontFamily'
 >
 
 // Source of truth: src/shared/schemas/app-settings.ts (DEFAULT_APP_SETTINGS).
@@ -58,6 +61,7 @@ const DEFAULTS: AppearanceFields = {
   runMode: DEFAULT_APP_SETTINGS.runMode,
   liquidGlassEffect: DEFAULT_APP_SETTINGS.liquidGlassEffect,
   lightweightMode: DEFAULT_APP_SETTINGS.lightweightMode,
+  fontFamily: DEFAULT_APP_SETTINGS.fontFamily,
 }
 
 const LANGUAGE_OPTIONS = SUPPORTED_LOCALES.map(({ code, nativeName }) => ({
@@ -77,14 +81,43 @@ export function AppearanceDialog({
   const { t } = useTranslation()
   const { setTheme } = useTheme()
   const form = useForm<AppearanceFields>({ defaultValues: DEFAULTS })
+  const [systemFonts, setSystemFonts] = useState<string[]>([])
+  const [isLoadingFonts, setIsLoadingFonts] = useState(true)
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: form is stable across renders; this is a mount-only fetch
   useEffect(() => {
+    async function loadSystemFonts() {
+      if ('queryLocalFonts' in window) {
+        try {
+          const fontData = await (
+            window as unknown as {
+              queryLocalFonts: () => Promise<Array<{ family: string }>>
+            }
+          ).queryLocalFonts()
+          const families = Array.from(
+            new Set(fontData.map((f: { family: string }) => f.family))
+          ).sort()
+          setSystemFonts(families)
+        } catch {
+          // Keep systemFonts empty if permission denied
+        } finally {
+          setIsLoadingFonts(false)
+        }
+      } else {
+        setIsLoadingFonts(false)
+      }
+    }
+    void loadSystemFonts()
+  }, [])
+
+  useEffect(() => {
+    if (!open) return
     let cancelled = false
     transport
       .invoke(Queries.GetSettings)
       .then((data) => {
         if (cancelled) return
+        if (form.formState.isDirty) return
+
         const all = data as AppSettings
         if (all?.app) {
           form.reset({
@@ -98,6 +131,7 @@ export function AppearanceDialog({
                 : all.app.runMode,
             liquidGlassEffect: all.app.liquidGlassEffect,
             lightweightMode: all.app.lightweightMode,
+            fontFamily: all.app.fontFamily,
           })
         }
       })
@@ -107,7 +141,7 @@ export function AppearanceDialog({
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [open, form])
 
   const onSubmit = form.handleSubmit(async (values) => {
     const dirty = pickDirty(values, form.formState.dirtyFields)
@@ -115,9 +149,14 @@ export function AppearanceDialog({
       onClose()
       return
     }
-    await transport.invoke(Commands.UpdateSettings, { app: dirty })
-    if (dirty.theme !== undefined) setTheme(dirty.theme)
-    onClose()
+    try {
+      await transport.invoke(Commands.UpdateSettings, { app: dirty })
+      if (dirty.theme !== undefined) setTheme(dirty.theme)
+      if (dirty.fontFamily !== undefined) applyFontFamily(dirty.fontFamily)
+      onClose()
+    } catch (error) {
+      console.error('Failed to update settings:', error)
+    }
   })
 
   const themeOptions = [
@@ -169,7 +208,7 @@ export function AppearanceDialog({
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
       <DialogContent
-        className="flex max-h-[85vh] flex-col gap-0 p-0 sm:max-w-[700px]"
+        className="flex max-h-[85vh] flex-col gap-0 p-0 sm:max-w-175"
         initialFocus={false}
       >
         <DialogHeader className="shrink-0 px-6 pt-6">
@@ -179,7 +218,7 @@ export function AppearanceDialog({
 
         <div className="min-h-0 flex-1 overflow-y-auto px-6 py-4">
           <Form {...form}>
-            <form className="space-y-4">
+            <form onSubmit={(e) => e.preventDefault()} className="space-y-4">
               <FormField
                 control={form.control}
                 name="theme"
@@ -245,6 +284,34 @@ export function AppearanceDialog({
                           </SelectGroup>
                         </SelectContent>
                       </Select>
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="fontFamily"
+                render={({ field }) => (
+                  <FormItem className="flex items-start justify-between gap-4">
+                    <div className="space-y-1">
+                      <FormLabel>
+                        {t('settings.appearance.fontFamily')}
+                      </FormLabel>
+                      <FormDescription className="text-xs">
+                        {t('settings.appearance.fontFamilyDesc')}
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <FontCombobox
+                        value={field.value ?? ''}
+                        onChange={field.onChange}
+                        systemFonts={systemFonts}
+                        isLoading={isLoadingFonts}
+                        placeholder={t(
+                          'settings.appearance.fontFamilyPlaceholder'
+                        )}
+                      />
                     </FormControl>
                   </FormItem>
                 )}

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -88,13 +88,16 @@
   --radius-xl: calc(var(--radius) + 4px);
   --color-tab-background: var(--tab-background);
   --font-heading: var(--font-sans);
-  --font-sans: "Inter Variable", sans-serif;
+  --font-sans: var(--app-font-family), "Inter Variable", sans-serif;
   --radius-2xl: calc(var(--radius) * 1.8);
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
 }
 
 :root {
+  --app-font-family:
+    "Inter Variable", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    sans-serif;
   --radius: 0.625rem;
   --dashboard-tile-radius: 18px;
   --window-chrome-safe-area-leading: 77px;
@@ -209,8 +212,8 @@
   body {
     @apply bg-background text-foreground;
     font-family:
-      -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
-      sans-serif;
+      var(--app-font-family), -apple-system, BlinkMacSystemFont, "Segoe UI",
+      Roboto, Helvetica, Arial, sans-serif;
     margin: 0;
     padding: 0;
   }

--- a/src/shared/constants/css-variables.ts
+++ b/src/shared/constants/css-variables.ts
@@ -1,0 +1,13 @@
+export const CSS_VARS = {
+  APP_FONT_FAMILY: '--app-font-family',
+} as const
+
+type CssVar = (typeof CSS_VARS)[keyof typeof CSS_VARS]
+
+export function setGlobalCssVar(name: CssVar, value: string): void {
+  document.documentElement.style.setProperty(name, value)
+}
+
+export function removeGlobalCssVar(name: CssVar): void {
+  document.documentElement.style.removeProperty(name)
+}

--- a/src/shared/locales/en-US.json
+++ b/src/shared/locales/en-US.json
@@ -976,7 +976,10 @@
       "runModeTrayDesktop": "Start in System Tray",
       "runModeLinuxDesc": "System tray availability and activation behavior depend on your desktop environment.",
       "lightweightMode": "Lightweight mode",
-      "lightweightModeDesc": "Release interface memory after the main window closes. Background downloads continue; Windows and Linux keep a tray entry for reopening. Reopening takes a little longer and unsaved interface state is discarded."
+      "lightweightModeDesc": "Release interface memory after the main window closes. Background downloads continue; Windows and Linux keep a tray entry for reopening. Reopening takes a little longer and unsaved interface state is discarded.",
+      "fontFamily": "Font",
+      "fontFamilyDesc": "Specify a custom font to override the default font.",
+      "fontFamilyPlaceholder": "e.g. Roboto"
     },
     "advanced": {
       "rpc": {

--- a/src/shared/locales/zh-CN.json
+++ b/src/shared/locales/zh-CN.json
@@ -963,7 +963,10 @@
       "runModeTrayDesktop": "在系统托盘中启动",
       "runModeLinuxDesc": "系统托盘的可用性和激活方式取决于桌面环境。",
       "lightweightMode": "轻量模式",
-      "lightweightModeDesc": "关闭主窗口后释放界面内存，后台下载继续运行。Windows 和 Linux 会保留托盘入口；重新打开会稍慢，未保存的界面状态将被丢弃。"
+      "lightweightModeDesc": "关闭主窗口后释放界面内存，后台下载继续运行。Windows 和 Linux 会保留托盘入口；重新打开会稍慢，未保存的界面状态将被丢弃。",
+      "fontFamily": "字体",
+      "fontFamilyDesc": "指定自定义字体以覆盖默认字体。",
+      "fontFamilyPlaceholder": "例如 Roboto"
     },
     "about": {
       "appIconAlt": "Motrix 应用图标",

--- a/src/shared/locales/zh-TW.json
+++ b/src/shared/locales/zh-TW.json
@@ -963,7 +963,10 @@
       "runModeTrayDesktop": "在系統匣中啟動",
       "runModeLinuxDesc": "系統匣的可用性和啟用方式取決於桌面環境。",
       "lightweightMode": "輕量模式",
-      "lightweightModeDesc": "關閉主視窗後釋放介面記憶體，背景下載會繼續運作。Windows 和 Linux 會保留系統匣入口；重新開啟會稍慢，未儲存的介面狀態將被捨棄。"
+      "lightweightModeDesc": "關閉主視窗後釋放介面記憶體，背景下載會繼續運作。Windows 和 Linux 會保留系統匣入口；重新開啟會稍慢，未儲存的介面狀態將被捨棄。",
+      "fontFamily": "字型",
+      "fontFamilyDesc": "指定自訂字型以覆蓋預設字型。",
+      "fontFamilyPlaceholder": "例如 Roboto"
     },
     "advanced": {
       "rpc": {

--- a/src/shared/schemas/app-settings.ts
+++ b/src/shared/schemas/app-settings.ts
@@ -31,6 +31,7 @@ export const appSettingsSchema = z.object({
   warnBeforeQuit: z.boolean().catch(true),
   checkForUpdatesOnLaunch: z.boolean().catch(true),
   updateChannel: appUpdateChannelSchema.catch('stable'),
+  fontFamily: z.string().catch(''),
 })
 
 export const DEFAULT_APP_SETTINGS: MotrixAppSettings = appSettingsSchema.parse(

--- a/src/shared/types/settings.ts
+++ b/src/shared/types/settings.ts
@@ -239,6 +239,7 @@ export interface MotrixAppSettings {
   /** Application release channel. Stable never accepts prerelease versions;
    *  beta accepts beta and subsequent stable versions. Default stable. */
   updateChannel: AppUpdateChannel
+  fontFamily: string
 }
 
 export interface NatSettings {


### PR DESCRIPTION
## Summary

Adds custom font selection to appearance settings. It reads installed fonts using the local font API, updates `--app-font-family` live across open windows via IPC, and falls back to Inter if a font is cleared or missing.

## Changes

* **Font sync:** Added `FontSync` and `applyFontFamily` (`src/renderer/components/font-sync.tsx`) to update global CSS variables and discard out-of-order IPC responses. Rendered in `src/renderer/index.tsx`.
* **Font selection UI:** Added `FontCombobox` (`src/renderer/components/settings-kit/font-combobox.tsx`) to search and preview system fonts. Integrated into `AppearanceDialog`.
* **Schema & locales:** Updated `appSettingsSchema` with `fontFamily` defaults and added translation keys for `en-US`, `zh-CN`, and `zh-TW`.
* **Tests:** Added unit tests for `FontSync` and `FontCombobox`, and updated `appearance-dialog.test.tsx` to cover font selection and settings persistence.

> [!NOTE]
> Unfortunately,  I don't speak Chinese (Simplified or Traditional), so the `zh-CN` and `zh-TW` translations were made using Google Translate. Please double-check the translations.


Closes #1883 