### PR TITLE
fix(settings): adapt select widths to localized text

### DIFF
--- a/src/renderer/components/settings-kit/settings-select-trigger.tsx
+++ b/src/renderer/components/settings-kit/settings-select-trigger.tsx
@@ -1,0 +1,25 @@
+import { SelectTrigger } from '@renderer/components/ui/select'
+import { cn } from '@renderer/lib/utils'
+import type * as React from 'react'
+
+type SettingsSelectTriggerProps = React.ComponentProps<typeof SelectTrigger>
+
+/**
+ * Keeps localized setting values compact without constraining them to the
+ * width of the source-language copy. The underlying SelectTrigger uses
+ * intrinsic width; these bounds preserve alignment and cap unusually long
+ * values before the select's overflow treatment takes over.
+ */
+export function SettingsSelectTrigger({
+  className,
+  size = 'sm',
+  ...props
+}: SettingsSelectTriggerProps) {
+  return (
+    <SelectTrigger
+      className={cn('min-w-30 max-w-64', className)}
+      size={size}
+      {...props}
+    />
+  )
+}

--- a/src/renderer/routes/settings/cards/appearance-dialog.tsx
+++ b/src/renderer/routes/settings/cards/appearance-dialog.tsx
@@ -1,3 +1,4 @@
+import { SettingsSelectTrigger } from '@renderer/components/settings-kit/settings-select-trigger'
 import { Button } from '@renderer/components/ui/button'
 import {
   Dialog,
@@ -20,7 +21,6 @@ import {
   SelectContent,
   SelectGroup,
   SelectItem,
-  SelectTrigger,
   SelectValue,
 } from '@renderer/components/ui/select'
 import { Switch } from '@renderer/components/ui/switch'
@@ -194,9 +194,9 @@ export function AppearanceDialog({
                           if (value !== null) field.onChange(value)
                         }}
                       >
-                        <SelectTrigger className="w-30" size="sm">
+                        <SettingsSelectTrigger>
                           <SelectValue />
-                        </SelectTrigger>
+                        </SettingsSelectTrigger>
                         <SelectContent>
                           <SelectGroup>
                             {themeOptions.map((option) => (
@@ -229,9 +229,9 @@ export function AppearanceDialog({
                           if (isSupportedLocale(value)) field.onChange(value)
                         }}
                       >
-                        <SelectTrigger className="min-w-30 max-w-64" size="sm">
+                        <SettingsSelectTrigger>
                           <SelectValue />
-                        </SelectTrigger>
+                        </SettingsSelectTrigger>
                         <SelectContent>
                           <SelectGroup>
                             {LANGUAGE_OPTIONS.map((option) => (
@@ -330,9 +330,9 @@ export function AppearanceDialog({
                             }
                           }}
                         >
-                          <SelectTrigger className="w-48" size="sm">
+                          <SettingsSelectTrigger className="min-w-48">
                             <SelectValue />
-                          </SelectTrigger>
+                          </SettingsSelectTrigger>
                           <SelectContent>
                             <SelectGroup>
                               {runModeOptions.map((option) => (

--- a/src/renderer/routes/settings/cards/bt-peer-geo-section.tsx
+++ b/src/renderer/routes/settings/cards/bt-peer-geo-section.tsx
@@ -1,3 +1,4 @@
+import { SettingsSelectTrigger } from '@renderer/components/settings-kit/settings-select-trigger'
 import { Button } from '@renderer/components/ui/button'
 import {
   Form,
@@ -13,7 +14,6 @@ import {
   SelectContent,
   SelectGroup,
   SelectItem,
-  SelectTrigger,
   SelectValue,
 } from '@renderer/components/ui/select'
 import { Spinner } from '@renderer/components/ui/spinner'
@@ -227,9 +227,9 @@ export function BtPeerGeoSection() {
                     }}
                     disabled={!enabled}
                   >
-                    <SelectTrigger className="w-56" size="sm">
+                    <SettingsSelectTrigger className="min-w-56 max-w-80">
                       <SelectValue />
-                    </SelectTrigger>
+                    </SettingsSelectTrigger>
                     <SelectContent>
                       <SelectGroup>
                         {sourceOptions.map(({ disabled, label, value }) => (

--- a/src/renderer/routes/settings/cards/downloads-dialog.test.tsx
+++ b/src/renderer/routes/settings/cards/downloads-dialog.test.tsx
@@ -1,5 +1,5 @@
-import '@renderer/lib/i18n'
 import '@testing-library/jest-dom/vitest'
+import { i18n } from '@renderer/lib/i18n'
 import { transport } from '@renderer/lib/transport'
 import { ENGINE_PERFORMANCE_PROFILES } from '@shared/constants/engine-performance-profiles'
 import { Commands } from '@shared/protocol/commands'
@@ -68,7 +68,8 @@ const FIXTURE = {
 }
 
 describe('<DownloadsDialog>', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('en-US')
     vi.mocked(transport.invoke).mockReset()
     toastAddMock.mockReset()
     vi.mocked(transport.invoke).mockImplementation(async (channel) => {
@@ -242,6 +243,8 @@ describe('<DownloadsDialog>', () => {
       name: /file modification time/i,
     })
     expect(modifiedTime).toHaveTextContent(/^local$/i)
+    expect(modifiedTime).toHaveClass('min-w-30', 'max-w-64')
+    expect(modifiedTime).not.toHaveClass('w-30')
 
     await user.click(modifiedTime)
     await user.click(await screen.findByRole('option', { name: /^server$/i }))
@@ -250,6 +253,25 @@ describe('<DownloadsDialog>', () => {
     expect(transport.invoke).toHaveBeenCalledWith(Commands.UpdateSettings, {
       engine: { remoteTime: true },
     })
+  })
+
+  it('allows the localized file modification value to size intrinsically', async () => {
+    await i18n.changeLanguage('zh-CN')
+    render(
+      <DownloadsDialog
+        open
+        onClose={vi.fn()}
+        labelKey="settings.cards.downloads.title"
+        descKey="settings.cards.downloads.desc"
+      />
+    )
+
+    const modifiedTime = await screen.findByRole('combobox', {
+      name: '文件修改时间',
+    })
+    expect(modifiedTime).toHaveTextContent('本地修改时间')
+    expect(modifiedTime).toHaveClass('min-w-30', 'max-w-64')
+    expect(modifiedTime).not.toHaveClass('w-30')
   })
 
   it('renders the speed modes with user-facing names', async () => {

--- a/src/renderer/routes/settings/cards/engine-tuning-section.tsx
+++ b/src/renderer/routes/settings/cards/engine-tuning-section.tsx
@@ -1,4 +1,5 @@
 import { PresetChips } from '@renderer/components/settings-kit/preset-chips'
+import { SettingsSelectTrigger } from '@renderer/components/settings-kit/settings-select-trigger'
 import {
   FormControl,
   FormDescription,
@@ -12,7 +13,6 @@ import {
   SelectContent,
   SelectGroup,
   SelectItem,
-  SelectTrigger,
   SelectValue,
 } from '@renderer/components/ui/select'
 import { Separator } from '@renderer/components/ui/separator'
@@ -164,8 +164,8 @@ export function EngineTuningSection({
         control={form.control}
         name="engine.fileAllocation"
         render={({ field }) => (
-          <FormItem className="flex items-start justify-between gap-4">
-            <div className="space-y-1">
+          <FormItem className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+            <div className="min-w-0 flex-1 space-y-1">
               <FormLabel>
                 {t('settings.downloads.disk.fileAllocation')}
               </FormLabel>
@@ -181,9 +181,9 @@ export function EngineTuningSection({
                   if (value !== null) field.onChange(value)
                 }}
               >
-                <SelectTrigger className="w-30" size="sm">
+                <SettingsSelectTrigger>
                   <SelectValue />
-                </SelectTrigger>
+                </SettingsSelectTrigger>
                 <SelectContent>
                   <SelectGroup>
                     {fileAllocationOptions.map(({ label, value }) => (
@@ -202,8 +202,8 @@ export function EngineTuningSection({
         control={form.control}
         name="engine.remoteTime"
         render={({ field }) => (
-          <FormItem className="flex items-start justify-between gap-4">
-            <div className="space-y-1">
+          <FormItem className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+            <div className="min-w-0 flex-1 space-y-1">
               <FormLabel>{t('settings.downloads.disk.modifiedTime')}</FormLabel>
               <FormDescription className="text-xs">
                 {t('settings.downloads.disk.modifiedTimeDesc')}
@@ -217,9 +217,9 @@ export function EngineTuningSection({
                   if (value !== null) field.onChange(value === 'server')
                 }}
               >
-                <SelectTrigger className="w-30" size="sm">
+                <SettingsSelectTrigger>
                   <SelectValue />
-                </SelectTrigger>
+                </SettingsSelectTrigger>
                 <SelectContent>
                   <SelectGroup>
                     {modifiedTimeOptions.map(({ label, value }) => (

--- a/src/renderer/routes/settings/cards/network-dialog.test.tsx
+++ b/src/renderer/routes/settings/cards/network-dialog.test.tsx
@@ -1,5 +1,5 @@
-import '@renderer/lib/i18n'
 import '@testing-library/jest-dom/vitest'
+import { i18n } from '@renderer/lib/i18n'
 import { Commands } from '@shared/protocol/commands'
 import { Queries } from '@shared/protocol/queries'
 import { render, screen, waitFor } from '@testing-library/react'
@@ -56,7 +56,8 @@ const FIXTURE = {
 }
 
 describe('<NetworkDialog>', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('en-US')
     vi.stubGlobal('ResizeObserver', MockResizeObserver)
     vi.mocked(transport.invoke).mockReset()
     vi.mocked(transport.invoke).mockImplementation(async (channel: string) => {
@@ -113,7 +114,10 @@ describe('<NetworkDialog>', () => {
       ).toBeInTheDocument()
     )
     const user = userEvent.setup()
-    await user.click(screen.getByRole('combobox', { name: /dns lookup/i }))
+    const dnsMode = screen.getByRole('combobox', { name: /dns lookup/i })
+    expect(dnsMode).toHaveClass('min-w-30', 'max-w-64')
+    expect(dnsMode).not.toHaveClass('w-35')
+    await user.click(dnsMode)
     await user.click(await screen.findByRole('option', { name: /system dns/i }))
     await user.click(screen.getByRole('button', { name: /save/i }))
     await waitFor(() => {
@@ -122,6 +126,32 @@ describe('<NetworkDialog>', () => {
       })
     })
     expect(onClose).toHaveBeenCalled()
+  })
+
+  it('allows the longest localized DNS value to size intrinsically', async () => {
+    await i18n.changeLanguage('zh-CN')
+    vi.mocked(transport.invoke).mockImplementation(async (channel: string) => {
+      if (channel === Queries.GetSettings) {
+        return { ...FIXTURE, engine: { dnsMode: 'engine' } }
+      }
+      return { saved: true, requiresRestart: false, changedRestartKeys: [] }
+    })
+
+    render(
+      <NetworkDialog
+        open
+        onClose={vi.fn()}
+        labelKey="settings.cards.network.title"
+        descKey="settings.cards.network.desc"
+      />
+    )
+
+    const dnsMode = await screen.findByRole('combobox', {
+      name: 'DNS 解析方式',
+    })
+    expect(dnsMode).toHaveTextContent('引擎内置解析器')
+    expect(dnsMode).toHaveClass('min-w-30', 'max-w-64')
+    expect(dnsMode).not.toHaveClass('w-35')
   })
 
   it('Import from system populates host/port/protocol', async () => {

--- a/src/renderer/routes/settings/cards/network-dialog.tsx
+++ b/src/renderer/routes/settings/cards/network-dialog.tsx
@@ -1,4 +1,5 @@
 import { EndpointList } from '@renderer/components/settings-kit/endpoint-list'
+import { SettingsSelectTrigger } from '@renderer/components/settings-kit/settings-select-trigger'
 import { Button } from '@renderer/components/ui/button'
 import {
   Dialog,
@@ -163,8 +164,8 @@ export function NetworkDialog({
                 control={form.control}
                 name="engine.dnsMode"
                 render={({ field }) => (
-                  <FormItem className="flex items-start justify-between gap-4">
-                    <div className="space-y-1">
+                  <FormItem className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+                    <div className="min-w-0 flex-1 space-y-1">
                       <FormLabel>{t('settings.network.dns.mode')}</FormLabel>
                       <FormDescription className="text-xs">
                         {t('settings.network.dns.modeDesc')}
@@ -178,9 +179,9 @@ export function NetworkDialog({
                           if (value !== null) field.onChange(value)
                         }}
                       >
-                        <SelectTrigger className="w-35" size="sm">
+                        <SettingsSelectTrigger>
                           <SelectValue />
-                        </SelectTrigger>
+                        </SettingsSelectTrigger>
                         <SelectContent>
                           <SelectGroup>
                             {dnsModeOptions.map(({ label, value }) => (

--- a/src/renderer/routes/settings/cards/performance-section.tsx
+++ b/src/renderer/routes/settings/cards/performance-section.tsx
@@ -1,3 +1,4 @@
+import { SettingsSelectTrigger } from '@renderer/components/settings-kit/settings-select-trigger'
 import { Badge } from '@renderer/components/ui/badge'
 import {
   FormControl,
@@ -11,7 +12,6 @@ import {
   SelectContent,
   SelectGroup,
   SelectItem,
-  SelectTrigger,
   SelectValue,
 } from '@renderer/components/ui/select'
 import {
@@ -134,9 +134,9 @@ export function PerformanceSection({
                     applyPerformanceProfile(profile)
                   }}
                 >
-                  <SelectTrigger className="w-40" size="sm">
+                  <SettingsSelectTrigger className="min-w-40">
                     <SelectValue />
-                  </SelectTrigger>
+                  </SettingsSelectTrigger>
                   <SelectContent>
                     <SelectGroup>
                       {performanceProfileOptions.map(({ label, value }) => (


### PR DESCRIPTION
## Summary

- add a reusable settings select trigger with intrinsic, bounded width for localized values
- let the file modification time and DNS setting rows reflow on narrow viewports
- migrate other localized settings selects away from source-language fixed widths
- cover the Simplified Chinese values reported in #1945 with regression tests

Closes #1945

## Verification

- `pnpm exec vitest run src/renderer/routes/settings/cards/downloads-dialog.test.tsx src/renderer/routes/settings/cards/network-dialog.test.tsx src/renderer/routes/settings/cards/appearance-dialog.test.tsx src/renderer/routes/settings/cards/bt-peer-geo-section.test.tsx`
- `pnpm run check:boundaries`
- `pnpm run lint`
- `pnpm exec tsc --noEmit`
- `pnpm run check:file-names`
