### PR TITLE
fix(settings): use platform downloads directory

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -122,7 +122,6 @@ import { BridgeManager } from './bridge/bridge-manager'
 import { isPackagedLinuxFlatpak } from './bridge/flatpak-environment'
 import {
   isElectronSelfUpdateSupported,
-  isLegacySnapDefaultSaveDir,
   resolvePackagedLinuxSnapEnvironment,
 } from './bridge/snap-environment'
 import { CliToolService } from './cli/cli-tool-service'
@@ -156,6 +155,7 @@ import { createOsNotificationBridge } from './notifications/os-bridge'
 import { DisclaimerGate } from './onboarding/disclaimer-gate'
 import { setupAppImageIntegration } from './platform/appimage-integration-host'
 import { syncAutoLaunch } from './platform/auto-launch'
+import { resolveDefaultSaveDirOptions } from './platform/default-save-dir'
 import { resolveDesktopBackgroundPolicy } from './platform/desktop-background-policy'
 import { removePathRecursive, renameAtomic } from './platform/fs-helpers'
 import { setupNativeThemeSync } from './platform/native-theme-sync'
@@ -278,6 +278,10 @@ const settingsFlatpakEnvironment =
     isPackaged: app.isPackaged,
     env: process.env,
   })
+const defaultSaveDirOptions = resolveDefaultSaveDirOptions({
+  snapEnvironment: settingsSnapEnvironment,
+  getSystemDownloadsDir: () => app.getPath('downloads'),
+})
 const cliToolService = new CliToolService({
   directInstallSupported:
     !settingsFlatpakEnvironment && settingsSnapEnvironment === null,
@@ -286,18 +290,7 @@ const settingsManager = new SettingsManager(settingsPath, {
   liquidGlassEffectDefault: shouldEnableLiquidGlassByDefault({
     isDev: platform.isDev,
   }),
-  ...(settingsFlatpakEnvironment
-    ? { defaultSaveDir: app.getPath('downloads') }
-    : settingsSnapEnvironment
-      ? {
-          defaultSaveDir: path.join(
-            settingsSnapEnvironment.realHome,
-            'Downloads'
-          ),
-          isLegacyDefaultSaveDir: (value: string) =>
-            isLegacySnapDefaultSaveDir(value, settingsSnapEnvironment),
-        }
-      : {}),
+  ...defaultSaveDirOptions,
   onChange: (old, updated) => {
     eventBus.emit(Events.SettingsChanged, { old, updated })
     // Forward GeoIP changes to the manager so it can swap the in-memory
@@ -1391,10 +1384,10 @@ async function initializeMainProcess(): Promise<void> {
   //
   // - MOTRIX_RPC_PORT lets each test pick a free random port so it
   //   doesn't clash with a developer's running aria2 instance.
-  // - MOTRIX_DEFAULT_SAVE_DIR redirects aria2's output away from the
-  //   user's real ~/Downloads (SettingsManager.seedSentinels falls
-  //   back to that when defaultSaveDir is empty), preventing test
-  //   files from leaking into the developer's home directory.
+  // - MOTRIX_DEFAULT_SAVE_DIR redirects aria2's output away from the user's
+  //   platform Downloads directory (SettingsManager.seedSentinels uses that
+  //   when defaultSaveDir is empty), preventing test files from leaking into
+  //   the developer's real download directory.
   //
   // Both are persisted into the (tmp) settings file under
   // MOTRIX_USER_DATA, which is itself per-test. They are merged into

--- a/src/main/platform/default-save-dir.test.ts
+++ b/src/main/platform/default-save-dir.test.ts
@@ -1,0 +1,41 @@
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { resolveDefaultSaveDirOptions } from './default-save-dir'
+
+describe('resolveDefaultSaveDirOptions', () => {
+  it.each([
+    ['Windows known folder', 'D:\\Downloads'],
+    ['macOS system folder', '/Volumes/Data/Downloads'],
+    ['Linux XDG folder', '/mnt/data/Downloads'],
+    ['Flatpak system folder', '/home/user/Downloads'],
+  ])('uses the %s outside Snap', (_label, systemDownloadsDir) => {
+    const getSystemDownloadsDir = vi.fn(() => systemDownloadsDir)
+
+    expect(
+      resolveDefaultSaveDirOptions({
+        snapEnvironment: null,
+        getSystemDownloadsDir,
+      })
+    ).toEqual({ defaultSaveDir: systemDownloadsDir })
+    expect(getSystemDownloadsDir).toHaveBeenCalledOnce()
+  })
+
+  it('preserves the real home fallback and migration check for Snap', () => {
+    const getSystemDownloadsDir = vi.fn(() => '/unused')
+    const options = resolveDefaultSaveDirOptions({
+      snapEnvironment: {
+        instanceName: 'motrix',
+        realHome: '/home/user',
+      },
+      getSystemDownloadsDir,
+    })
+
+    expect(options.defaultSaveDir).toBe(join('/home/user', 'Downloads'))
+    expect(
+      options.isLegacyDefaultSaveDir?.(
+        '/home/user/snap/motrix/current/Downloads'
+      )
+    ).toBe(true)
+    expect(getSystemDownloadsDir).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/platform/default-save-dir.ts
+++ b/src/main/platform/default-save-dir.ts
@@ -1,0 +1,36 @@
+import { join } from 'node:path'
+import type { PackagedLinuxSnapEnvironment } from '../bridge/snap-environment'
+import { isLegacySnapDefaultSaveDir } from '../bridge/snap-environment'
+
+export interface DefaultSaveDirOptionsInput {
+  snapEnvironment: Pick<
+    PackagedLinuxSnapEnvironment,
+    'instanceName' | 'realHome'
+  > | null
+  getSystemDownloadsDir: () => string
+}
+
+export interface DefaultSaveDirOptions {
+  defaultSaveDir: string
+  isLegacyDefaultSaveDir?: (value: string) => boolean
+}
+
+/** Resolve host-specific defaults without changing an already persisted path. */
+export function resolveDefaultSaveDirOptions({
+  snapEnvironment,
+  getSystemDownloadsDir,
+}: DefaultSaveDirOptionsInput): DefaultSaveDirOptions {
+  if (snapEnvironment === null) {
+    return { defaultSaveDir: getSystemDownloadsDir() }
+  }
+
+  // Electron resolves Downloads from Snap's revision-scoped HOME. Strict
+  // confinement cannot read the host's hidden XDG user-dir configuration
+  // without a privileged personal-files grant, so retain the stable real-home
+  // default and its narrowly scoped legacy migration.
+  return {
+    defaultSaveDir: join(snapEnvironment.realHome, 'Downloads'),
+    isLegacyDefaultSaveDir: (value: string) =>
+      isLegacySnapDefaultSaveDir(value, snapEnvironment),
+  }
+}

--- a/src/shared/schemas/app-settings.ts
+++ b/src/shared/schemas/app-settings.ts
@@ -11,8 +11,8 @@ export const appSettingsSchema = z.object({
   theme: z.enum(['system', 'light', 'dark']).catch('system'),
   language: supportedLocaleSchema.catch(DEFAULT_LOCALE),
   // Empty string is a sentinel: SettingsManager (main/server) seeds the
-  // absolute path (~/Downloads) on first load. The renderer never observes ''
-  // because settings are loaded before the UI mounts.
+  // absolute platform download directory on first load. The renderer never
+  // observes '' because settings are loaded before the UI mounts.
   defaultSaveDir: z.string().catch(''),
   notifyOnComplete: z.boolean().catch(true),
   notifyOnError: z.boolean().catch(true),


### PR DESCRIPTION
## Summary

- initialize the default save directory from the Electron platform Downloads path on Windows, macOS, native Linux, and Flatpak
- preserve the stable real-home fallback and narrowly scoped legacy migration for strict Snap confinement
- keep existing persisted user-selected download directories unchanged
- cover platform path selection with focused unit tests

## Verification

- pnpm run check:boundaries
- pnpm run lint
- pnpm exec tsc --noEmit
- pnpm run check:file-names
- pnpm exec vitest run src/main/platform/default-save-dir.test.ts src/core/settings/settings-manager.test.ts

Closes #1947