### PR TITLE
fix(settings): refresh user-agent presets

### DIFF
--- a/src/shared/constants/user-agents.ts
+++ b/src/shared/constants/user-agents.ts
@@ -11,17 +11,17 @@ export const BUILTIN_USER_AGENTS: readonly UserAgentPreset[] = [
   {
     label: 'Chrome',
     value:
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36',
   },
   {
     label: 'Firefox',
     value:
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 14.0; rv:120.0) Gecko/20100101 Firefox/120.0',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:154.0) Gecko/20100101 Firefox/154.0',
   },
   {
     label: 'Safari',
     value:
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Safari/605.1.15',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Safari/605.1.15',
   },
-  { label: 'Transmission', value: 'Transmission/4.0.6' },
+  { label: 'Transmission', value: 'Transmission/4.1.3' },
 ] as const


### PR DESCRIPTION
## Summary

- update the Chrome preset from 120 to 152
- update Firefox to 154 and use its frozen macOS 10.15 platform token
- update Safari to 26.6 and Transmission to 4.1.3

## Why

The bundled browser and client User-Agent presets have fallen significantly behind current stable releases and may be rejected by version-sensitive download sites.

This is the immediate static refresh for Issue #1943. A managed preset strategy can follow separately.

## Verification

- pnpm run check:boundaries
- pnpm run lint
- pnpm exec tsc --noEmit

Closes #1943