### PR TITLE
chore(release): prepare 2.0.0-beta.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. After its remaining release gates pass,
-download [v2.0.0-beta.25 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.25)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.25.md) before
+download [v2.0.0-beta.26 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.26)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.26.md) before
 installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -162,7 +162,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.25'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.26'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。剩余发布门禁通过后，请从 GitHub Releases
-下载 [v2.0.0-beta.25](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.25)，
-并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.25.zh-CN.md)。
+下载 [v2.0.0-beta.26](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.26)，
+并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.26.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -153,7 +153,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.25'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.26'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.26.md
+++ b/docs/release-notes/2.0.0-beta.26.md
@@ -1,0 +1,92 @@
+# Motrix 2.0.0-beta.26
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.26/docs/release-notes/2.0.0-beta.26.zh-CN.md)
+
+Motrix 2.0.0-beta.26 makes interrupted direct-download recovery safer, adds
+system default-app controls on Windows and Linux, uses each platform's
+Downloads directory for new installations, and refreshes several Settings
+details. It is intended for public distribution only after every protected
+release gate passes.
+
+## Highlights
+
+- Interrupted HTTP and FTP downloads now persist a non-sensitive replay
+  recipe and remote resource validators. On restart, Motrix inspects the
+  partial file, aria2 checkpoint, final-path conflicts, range support, and the
+  remote ETag or modification time before resuming. If identity or credentials
+  cannot be verified safely, the partial file is preserved and Motrix reports
+  why manual recovery is required
+  ([#1959](https://github.com/agalwood/Motrix/pull/1959)).
+- Integration settings now report whether Motrix owns `.torrent` files and
+  `magnet:` links on Windows and Linux. Windows opens the appropriate Default
+  Apps page without rewriting protected `UserChoice` values. Native Linux
+  packages can set the `.torrent` default through `xdg-mime`, while AppImage
+  integration preserves and restores verified previous handlers
+  ([#1957](https://github.com/agalwood/Motrix/pull/1957)).
+- New installations now default downloads to the operating system's Downloads
+  directory instead of assuming `<home>/Downloads`. Existing saved paths are
+  preserved, and confined Snap packages retain their stable real-home default
+  ([#1958](https://github.com/agalwood/Motrix/pull/1958)).
+- Compact selectors in Settings expand to fit localized labels instead of
+  clipping longer translations
+  ([#1955](https://github.com/agalwood/Motrix/pull/1955)).
+- Built-in Chrome, Firefox, Safari, and Transmission User-Agent presets have
+  been refreshed ([#1960](https://github.com/agalwood/Motrix/pull/1960)).
+
+## Before testing
+
+This is prerelease software. Back up existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Do not rely on this beta for your only copy of important
+downloads.
+
+To test recovery, interrupt an HTTP or FTP download after it has written both a
+partial file and an aria2 checkpoint, then restart Motrix and confirm that the
+task resumes without discarding progress. Also test a changed remote resource
+or missing checkpoint and confirm that Motrix preserves the partial file rather
+than combining incompatible bytes. On Windows and Linux, review the default-app
+status under Integration settings and verify `.torrent` and `magnet:` hand-off.
+
+## Planned downloads after release gates pass
+
+| Distribution | Architectures | Planned output |
+|--------------|---------------|----------------|
+| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | AppImage, DEB, and RPM |
+| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.26-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.26` tag in both registries |
+| Snap Store | — | Not published for this beta |
+
+After every container gate passes, the versioned image references will be
+`docker.io/motrixapp/motrix-server:2.0.0-beta.26` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.26`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.26/docs/docker-server.md)
+for storage, networking, and upgrade guidance.
+
+## Distribution notes
+
+- AppImage desktop integration is opt-in and confined to the current user's
+  XDG data directory. Browser-extension hand-off is not yet available from the
+  AppImage package because its Native Messaging host does not have a stable
+  path outside the mounted image.
+- Flatpak is validated separately and is not published by the release tag; the
+  GitHub prerelease includes its Native Host companion archives.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
+  Download them only from the official GitHub prerelease after it is published.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+- Snap is not published for this beta. Prerelease Snap runs stop after source
+  validation, so they do not build Snap artifacts, upload Store revisions, or
+  change `latest/edge`.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.26.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.26.zh-CN.md
@@ -1,0 +1,76 @@
+# Motrix 2.0.0-beta.26
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.26/docs/release-notes/2.0.0-beta.26.md) | 简体中文
+
+Motrix 2.0.0-beta.26 提升了中断直链下载的恢复安全性，增加 Windows 与 Linux
+系统默认应用控制，新安装会使用各平台的 Downloads 目录，并更新了多项设置细节。
+只有在全部受保护发布门禁通过后，本版本才适合公开分发。
+
+## 主要改进
+
+- 中断的 HTTP 与 FTP 下载现在会持久化不含敏感信息的重放配方和远端资源校验信息。
+  Motrix 重启后，会先检查部分文件、aria2 checkpoint、最终路径冲突、Range 支持，
+  以及远端 ETag 或修改时间，再决定是否恢复。无法安全验证资源身份或请求凭据时，
+  Motrix 会保留部分文件并说明需要手动恢复的原因
+  （[#1959](https://github.com/agalwood/Motrix/pull/1959)）。
+- 集成设置现在会显示 Windows 与 Linux 上 `.torrent` 文件和 `magnet:` 链接是否由
+  Motrix 接管。Windows 会打开对应的 Default Apps 页面，而不会改写受保护的
+  `UserChoice` 值；原生 Linux 安装包可通过 `xdg-mime` 设置 `.torrent` 默认应用；
+  AppImage 集成则会保存并恢复经过验证的旧 handler
+  （[#1957](https://github.com/agalwood/Motrix/pull/1957)）。
+- 新安装现在默认使用操作系统提供的 Downloads 目录，不再假设目录一定是
+  `<home>/Downloads`。已经保存的路径保持不变，受限 Snap 安装包继续使用稳定的
+  real-home 默认值（[#1958](https://github.com/agalwood/Motrix/pull/1958)）。
+- 设置中的紧凑 selector 会根据本地化标签自动扩展，避免较长译文被截断
+  （[#1955](https://github.com/agalwood/Motrix/pull/1955)）。
+- 内置 Chrome、Firefox、Safari 和 Transmission User-Agent preset 已更新
+  （[#1960](https://github.com/agalwood/Motrix/pull/1960)）。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1 数据的迁移路径
+尚未经过验证，请勿让本 beta 使用您唯一的一份 v1 数据。
+
+条件允许时，请使用独立的操作系统账号、设备或 Docker 数据目录并行测试 v2。不要依赖
+本 beta 保存唯一一份重要下载内容。
+
+测试恢复功能时，请在 HTTP 或 FTP 下载已经写入部分文件和 aria2 checkpoint 后中断
+任务，再重启 Motrix，确认任务能继续下载且不会丢失进度。也请测试远端资源已变化或
+checkpoint 缺失的情况，确认 Motrix 会保留部分文件，而不会拼接不兼容的数据。
+Windows 与 Linux 用户还应在集成设置中检查默认应用状态，并验证 `.torrent` 与
+`magnet:` 的转交行为。
+
+## 发布门禁通过后计划提供的下载
+
+| 分发方式 | 架构 | 计划产物 |
+|---------|------|---------|
+| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
+| Windows | `x64` | 未签名 NSIS 安装程序（`.exe`）和 ZIP |
+| Linux | `x64`、`arm64` | AppImage、DEB 和 RPM |
+| Flatpak Native Host companion | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.26-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个仓库中的不可变 `2.0.0-beta.26` 标签 |
+| Snap Store | — | 本 beta 不发布 |
+
+所有容器门禁通过后，可使用以下带版本镜像：
+`docker.io/motrixapp/motrix-server:2.0.0-beta.26` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.26`。存储、网络与升级说明请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.26/docs/docker-server.zh-CN.md)。
+
+## 分发说明
+
+- AppImage 桌面集成需要用户主动启用，且只会写入当前用户的 XDG 数据目录。由于 Native
+  Messaging host 在挂载镜像之外没有稳定路径，浏览器扩展暂时无法向 AppImage 安装包
+  转交下载任务。
+- Flatpak 单独验证，不由 release tag 发布；GitHub 预发布版会包含它的 Native Host
+  companion 压缩包。
+- 不提供 Windows `arm64` 和所有 32 位安装包。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅从官方 GitHub
+  预发布版下载。
+- Beta 容器标签不可变，也不会更新 `latest`、`stable` 或其他稳定通道浮动标签。
+- 本 beta 不发布 Snap。预发布 Snap 流程会在 source validation 后停止，不会构建或
+  上传 Snap 产物，也不会改动 `latest/edge`。
+
+## 反馈
+
+如遇到可复现的问题，请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues)
+反馈，并附上操作系统、架构、安装包类型和复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -76,6 +76,17 @@
   <releases>
     <!-- Update this list on every release; Flathub linter requires the most
          recent version listed here to match the manifest's source tag. -->
+    <release version="2.0.0-beta.26" date="2026-08-25">
+      <description>
+        <p>
+          Interrupted HTTP and FTP downloads now resume only after Motrix
+          verifies their checkpoints and remote resource identity. Windows and
+          Linux gain safer default-app controls, new installs use the platform
+          Downloads directory, localized Settings controls fit their content,
+          and built-in User-Agent presets are refreshed.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.25" date="2026-08-24">
       <description>
         <p>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.25",
+  "version": "2.0.0-beta.26",
   "packageManager": "pnpm@11.22.0+sha512.1ff870c4c6133dfd88fb2afc46dd13d47f09c9794b438c6fdb47ca98caf3bc16381ee0be93a091b8e3824cf01f889f46d7d9e20910fb0be1ab0fb5baa80dd621",
   "description": "A full-featured download manager",
   "keywords": [],


### PR DESCRIPTION
## Summary

- bump Motrix to 2.0.0-beta.26
- publish bilingual release notes for changes on main since beta.25
- refresh README beta links, Docker example, and Flatpak release metadata

## Verification

- pnpm run check:boundaries
- pnpm run lint
- pnpm exec tsc --noEmit
- pnpm exec vitest run tests/scripts/release-version-contract.test.ts tests/scripts/release-metadata.test.ts tests/scripts/release-signing-input.test.ts
- pnpm run check:flatpak
