### PR TITLE
fix(windows): address picker, CJK, and association issues

### DIFF
--- a/src/main/ipc/commands.test.ts
+++ b/src/main/ipc/commands.test.ts
@@ -827,6 +827,10 @@ describe('buildCommandHandlers', () => {
 
   it('returns a picked save directory and handles cancellation', async () => {
     showOpenDialogMock.mockReset()
+    fromWebContentsMock.mockReset()
+    const sender = {} as never
+    const parent = { isDestroyed: () => false }
+    fromWebContentsMock.mockReturnValue(parent)
     showOpenDialogMock
       .mockResolvedValueOnce({ canceled: true, filePaths: [] })
       .mockResolvedValueOnce({ canceled: false, filePaths: ['/downloads'] })
@@ -834,15 +838,52 @@ describe('buildCommandHandlers', () => {
     const handlers = buildCommandHandlers(fakeCtx())
 
     await expect(
-      handlers[Commands.PickSaveDir]?.({ defaultPath: '/tmp' })
+      handlers[Commands.PickSaveDir]?.(sender, { defaultPath: '/tmp' })
     ).resolves.toBeNull()
     await expect(
-      handlers[Commands.PickSaveDir]?.({ defaultPath: '/tmp' })
+      handlers[Commands.PickSaveDir]?.(sender, { defaultPath: '/tmp' })
     ).resolves.toEqual({ path: '/downloads' })
-    expect(showOpenDialogMock).toHaveBeenCalledWith({
+    expect(showOpenDialogMock).toHaveBeenCalledWith(parent, {
       properties: ['openDirectory'],
       defaultPath: '/tmp',
     })
+  })
+
+  it('ignores concurrent save-directory picks from the same window', async () => {
+    showOpenDialogMock.mockReset()
+    fromWebContentsMock.mockReset()
+    const sender = {} as never
+    const parent = { isDestroyed: () => false }
+    fromWebContentsMock.mockReturnValue(parent)
+    let resolvePick!: (result: {
+      canceled: boolean
+      filePaths: string[]
+    }) => void
+    showOpenDialogMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolvePick = resolve
+        })
+    )
+    // @ts-expect-error partial ctx
+    const handlers = buildCommandHandlers(fakeCtx())
+
+    const first = handlers[Commands.PickSaveDir]?.(sender, {
+      defaultPath: '/first',
+    })
+    await expect(
+      handlers[Commands.PickSaveDir]?.(sender, { defaultPath: '/second' })
+    ).resolves.toBeNull()
+    expect(showOpenDialogMock).toHaveBeenCalledOnce()
+
+    resolvePick({ canceled: false, filePaths: ['/picked'] })
+    await expect(first).resolves.toEqual({ path: '/picked' })
+
+    showOpenDialogMock.mockResolvedValueOnce({ canceled: true, filePaths: [] })
+    await expect(
+      handlers[Commands.PickSaveDir]?.(sender, { defaultPath: '/third' })
+    ).resolves.toBeNull()
+    expect(showOpenDialogMock).toHaveBeenCalledTimes(2)
   })
 
   it('opens only allow-listed external URL schemes', async () => {
@@ -968,6 +1009,9 @@ describe('buildCommandHandlers', () => {
     const menuContextRegistration = ipcHandleMock.mock.calls.find(
       ([channel]) => channel === Commands.UpdateMenuContext
     )
+    const pickSaveDirRegistration = ipcHandleMock.mock.calls.find(
+      ([channel]) => channel === Commands.PickSaveDir
+    )
     const restartRegistration = ipcHandleMock.mock.calls.find(
       ([channel]) => channel === Commands.RestartEngine
     )
@@ -975,6 +1019,7 @@ describe('buildCommandHandlers', () => {
     expect(minimizeRegistration).toBeDefined()
     expect(toggleMaximizeRegistration).toBeDefined()
     expect(menuContextRegistration).toBeDefined()
+    expect(pickSaveDirRegistration).toBeDefined()
     expect(restartRegistration).toBeDefined()
 
     await closeRegistration?.[1]({ sender }, { showMain: true })
@@ -992,11 +1037,19 @@ describe('buildCommandHandlers', () => {
     })
     await toggleMaximizeRegistration?.[1]({ sender })
     await menuContextRegistration?.[1]({ sender }, { currentRoute: '/tasks' })
+    const pickerWindow = { isDestroyed: () => false }
+    fromWebContentsMock.mockReturnValueOnce(pickerWindow)
+    showOpenDialogMock.mockResolvedValueOnce({ canceled: true, filePaths: [] })
+    await pickSaveDirRegistration?.[1]({ sender }, { defaultPath: '/tmp' })
     await restartRegistration?.[1]({})
 
     expect(ctx.windowManager.getWindowIdBySender).toHaveBeenCalledWith(sender)
     expect(ctx.windowManager.closeAndRecycle).toHaveBeenCalledWith('main')
     expect(fromWebContentsMock).toHaveBeenCalledWith(sender)
+    expect(showOpenDialogMock).toHaveBeenCalledWith(pickerWindow, {
+      properties: ['openDirectory'],
+      defaultPath: '/tmp',
+    })
     expect(ctx.contextStore.merge).toHaveBeenCalledWith({
       currentRoute: '/tasks',
     })

--- a/src/main/ipc/commands.ts
+++ b/src/main/ipc/commands.ts
@@ -96,7 +96,13 @@ import { TaskStatus } from '@shared/types/task'
 import { canRetryMagnetMetadata } from '@shared/types/task-actions'
 import type { TaskActivityRecorder } from '@shared/types/task-activity'
 import type { TaskOccurrence } from '@shared/types/task-occurrence'
-import { BrowserWindow, dialog, ipcMain, shell } from 'electron'
+import {
+  BrowserWindow,
+  dialog,
+  ipcMain,
+  type OpenDialogOptions,
+  shell,
+} from 'electron'
 import { z } from 'zod'
 import type { BridgeManager } from '../bridge/bridge-manager'
 import type { CliToolService } from '../cli/cli-tool-service'
@@ -614,6 +620,7 @@ export function buildCommandHandlers(ctx: CommandContext): CommandHandlerMap {
       return res.response === 1
     },
   })
+  const saveDirPickersInFlight = new WeakSet<WebContents>()
 
   return {
     [Commands.InstallCliTool]: async (payload: unknown) =>
@@ -1113,15 +1120,30 @@ export function buildCommandHandlers(ctx: CommandContext): CommandHandlerMap {
       return { ok: true }
     },
 
-    [Commands.PickSaveDir]: async (params: { defaultPath?: string }) => {
-      const result = await dialog.showOpenDialog({
-        properties: ['openDirectory'],
-        defaultPath: params.defaultPath,
-      })
-      if (result.canceled || result.filePaths.length === 0) {
-        return null
+    [Commands.PickSaveDir]: async (
+      sender: WebContents,
+      params: { defaultPath?: string }
+    ) => {
+      if (saveDirPickersInFlight.has(sender)) return null
+
+      saveDirPickersInFlight.add(sender)
+      try {
+        const options: OpenDialogOptions = {
+          properties: ['openDirectory'],
+          defaultPath: params.defaultPath,
+        }
+        const parent = BrowserWindow.fromWebContents(sender)
+        const result =
+          parent && !parent.isDestroyed()
+            ? await dialog.showOpenDialog(parent, options)
+            : await dialog.showOpenDialog(options)
+        if (result.canceled || result.filePaths.length === 0) {
+          return null
+        }
+        return { path: result.filePaths[0] }
+      } finally {
+        saveDirPickersInFlight.delete(sender)
       }
-      return { path: result.filePaths[0] }
     },
 
     // ResizeWindow needs event.sender — the wrapper in registerCommandHandlers
@@ -1580,6 +1602,7 @@ export function registerCommandHandlers(ctx: CommandContext): () => void {
       channel === Commands.CloseCurrentWindow ||
       channel === Commands.MinimizeCurrentWindow ||
       channel === Commands.ToggleMaximizeCurrentWindow ||
+      channel === Commands.PickSaveDir ||
       channel === Commands.ResizeWindow ||
       channel === Commands.UpdateMenuContext
     ) {

--- a/src/main/platform/windows-default-apps.test.ts
+++ b/src/main/platform/windows-default-apps.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   buildWindowsDefaultAppsSettingsUrl,
   getWindowsDefaultAssociations,
+  readWindowsUserChoice,
   resolveWindowsDefaultAppsSettingsUrl,
   supportsRegisteredAppDefaultAppsQuery,
   WINDOWS_DEFAULT_APPS_SETTINGS_URL,
@@ -106,6 +107,35 @@ describe('Windows Default Apps settings', () => {
     })
     expect(hasRegistration).not.toHaveBeenCalled()
     expect(readUserChoice).not.toHaveBeenCalled()
+  })
+
+  it('uses Windows 11 UserChoiceLatest instead of a stale legacy value', async () => {
+    const queryProgId = vi.fn(async (key: string) => {
+      if (key.endsWith('UserChoiceLatest\\ProgId')) {
+        return key.includes('FileExts')
+          ? 'Motrix.File.Torrent'
+          : 'Motrix.Url.Magnet'
+      }
+      return 'Other.Stale.Handler'
+    })
+    const readUserChoice = (association: 'torrent' | 'magnet') =>
+      readWindowsUserChoice(association, { queryProgId })
+
+    await expect(
+      getWindowsDefaultAssociations({
+        platform: 'win32',
+        hasRegistration: vi.fn().mockResolvedValue(true),
+        readUserChoice,
+      })
+    ).resolves.toMatchObject({ torrent: true, magnet: true })
+    expect(queryProgId.mock.calls).toEqual([
+      [
+        'Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts\\.torrent\\UserChoiceLatest\\ProgId',
+      ],
+      [
+        'Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\magnet\\UserChoiceLatest\\ProgId',
+      ],
+    ])
   })
 
   it('reports current defaults for an all-users installation', async () => {

--- a/src/main/platform/windows-default-apps.ts
+++ b/src/main/platform/windows-default-apps.ts
@@ -11,12 +11,28 @@ export const WINDOWS_DEFAULT_APPS_SETTINGS_URL = 'ms-settings:defaultapps'
 const WINDOWS_CAPABILITIES_REGISTRY_PATH = 'Software\\Motrix\\Capabilities'
 const WINDOWS_TORRENT_PROGID = 'Motrix.File.Torrent'
 const WINDOWS_MAGNET_PROGID = 'Motrix.Url.Magnet'
-const WINDOWS_USER_CHOICE_KEYS = {
+const WINDOWS_ASSOCIATION_KEYS = {
   torrent:
-    'Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts\\.torrent\\UserChoice',
+    'Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts\\.torrent',
   magnet:
-    'Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\magnet\\UserChoice',
+    'Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\magnet',
 } as const
+const WINDOWS_USER_CHOICE_SUFFIXES = [
+  'UserChoiceLatest\\ProgId',
+  'UserChoiceLatest',
+  'UserChoice',
+] as const
+
+type WindowsAssociation = keyof typeof WINDOWS_ASSOCIATION_KEYS
+
+interface WindowsUserChoiceResult {
+  ok: boolean
+  progId: string | null
+}
+
+interface ReadWindowsUserChoiceDeps {
+  queryProgId?: (key: string) => Promise<string | null>
+}
 
 export type WindowsRegistrationScope = 'user' | 'machine'
 
@@ -29,8 +45,8 @@ interface GetWindowsDefaultAssociationsDeps {
   platform?: NodeJS.Platform
   hasRegistration?: (scope: WindowsRegistrationScope) => Promise<boolean | null>
   readUserChoice?: (
-    association: 'torrent' | 'magnet'
-  ) => Promise<{ ok: boolean; progId: string | null }>
+    association: WindowsAssociation
+  ) => Promise<WindowsUserChoiceResult>
 }
 
 /**
@@ -85,30 +101,44 @@ async function hasWindowsRegistration(
   }
 }
 
-async function readWindowsUserChoice(
-  association: 'torrent' | 'magnet'
-): Promise<{ ok: boolean; progId: string | null }> {
+async function queryWindowsRegistryProgId(key: string): Promise<string | null> {
   const systemRoot = process.env.SystemRoot ?? 'C:\\Windows'
   const regExe = path.win32.join(systemRoot, 'System32', 'reg.exe')
 
   try {
     const { stdout } = await execFileAsync(
       regExe,
-      [
-        'query',
-        `HKCU\\${WINDOWS_USER_CHOICE_KEYS[association]}`,
-        '/v',
-        'ProgId',
-        '/reg:64',
-      ],
+      ['query', `HKCU\\${key}`, '/v', 'ProgId', '/reg:64'],
       { timeout: 2_000, windowsHide: true }
     )
-    const progId =
+    return (
       /^\s*ProgId\s+REG_\w+\s+(.+?)\s*$/imu.exec(stdout.toString())?.[1] ?? null
-    return { ok: progId !== null, progId }
+    )
   } catch {
-    return { ok: false, progId: null }
+    return null
   }
+}
+
+/**
+ * Windows 11 24H2+ records the effective choice in UserChoiceLatest and may
+ * leave the legacy UserChoice stale. Current builds nest ProgId one level
+ * deeper, while earlier builds used a direct value. Probe both Latest layouts
+ * before falling back to the legacy key so the verdict follows the handler
+ * Windows actually resolves.
+ */
+export async function readWindowsUserChoice(
+  association: WindowsAssociation,
+  deps: ReadWindowsUserChoiceDeps = {}
+): Promise<WindowsUserChoiceResult> {
+  const queryProgId = deps.queryProgId ?? queryWindowsRegistryProgId
+  const baseKey = WINDOWS_ASSOCIATION_KEYS[association]
+
+  for (const suffix of WINDOWS_USER_CHOICE_SUFFIXES) {
+    const progId = await queryProgId(`${baseKey}\\${suffix}`)
+    if (progId !== null) return { ok: true, progId }
+  }
+
+  return { ok: false, progId: null }
 }
 
 export async function getWindowsDefaultAssociations(

--- a/src/renderer/components/desktop-kit/directory-picker.test.tsx
+++ b/src/renderer/components/desktop-kit/directory-picker.test.tsx
@@ -1,8 +1,8 @@
 import '@testing-library/jest-dom/vitest'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { FormProvider, useForm } from 'react-hook-form'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { DirectoryPicker } from './directory-picker'
 
 const pickSaveDirMock = vi.fn()
@@ -25,6 +25,10 @@ function Wrapper(props: { initial: string; variant: 'compact' | 'input' }) {
 }
 
 describe('<DirectoryPicker>', () => {
+  beforeEach(() => {
+    pickSaveDirMock.mockReset()
+  })
+
   it('input variant renders input + browse button', () => {
     render(<Wrapper initial="/x" variant="input" />)
     expect(screen.getByDisplayValue('/x')).toBeInTheDocument()
@@ -53,5 +57,31 @@ describe('<DirectoryPicker>', () => {
     const user = userEvent.setup()
     await user.click(screen.getByRole('button', { name: /browse/i }))
     expect(screen.getByTestId('value')).toHaveTextContent('/keep')
+  })
+
+  it('ignores repeated clicks while a picker request is pending', async () => {
+    let resolvePick!: (path: string | null) => void
+    pickSaveDirMock.mockImplementationOnce(
+      () =>
+        new Promise<string | null>((resolve) => {
+          resolvePick = resolve
+        })
+    )
+    render(<Wrapper initial="/current" variant="compact" />)
+    const button = screen.getByRole('button')
+
+    fireEvent.click(button)
+    fireEvent.click(button)
+
+    expect(pickSaveDirMock).toHaveBeenCalledTimes(1)
+    expect(button).toBeDisabled()
+
+    resolvePick('/picked')
+    await waitFor(() => expect(button).toBeEnabled())
+    expect(screen.getByTestId('value')).toHaveTextContent('/picked')
+
+    pickSaveDirMock.mockResolvedValueOnce(null)
+    fireEvent.click(button)
+    await waitFor(() => expect(pickSaveDirMock).toHaveBeenCalledTimes(2))
   })
 })

--- a/src/renderer/components/desktop-kit/directory-picker.tsx
+++ b/src/renderer/components/desktop-kit/directory-picker.tsx
@@ -2,6 +2,7 @@ import { Button } from '@renderer/components/ui/button'
 import { Input } from '@renderer/components/ui/input'
 import { usePlatformServices } from '@renderer/platform/services'
 import { Folder } from 'lucide-react'
+import { useRef, useState } from 'react'
 import {
   type FieldPath,
   type FieldValues,
@@ -29,14 +30,26 @@ export function DirectoryPicker<TFields extends FieldValues>({
   const { pickSaveDir } = usePlatformServices()
   const { setValue, control } = useFormContext<TFields>()
   const current = (useWatch({ control, name }) ?? '') as string
+  const pickInFlight = useRef(false)
+  const [isPicking, setIsPicking] = useState(false)
+  const pickerDisabled = disabled || isPicking
 
   const handlePick = async () => {
-    const picked = await pickSaveDir(current || undefined)
-    if (picked) {
-      setValue(name, picked as never, {
-        shouldValidate: true,
-        shouldDirty: true,
-      })
+    if (disabled || pickInFlight.current) return
+
+    pickInFlight.current = true
+    setIsPicking(true)
+    try {
+      const picked = await pickSaveDir(current || undefined)
+      if (picked) {
+        setValue(name, picked as never, {
+          shouldValidate: true,
+          shouldDirty: true,
+        })
+      }
+    } finally {
+      pickInFlight.current = false
+      setIsPicking(false)
     }
   }
 
@@ -47,7 +60,7 @@ export function DirectoryPicker<TFields extends FieldValues>({
         onClick={handlePick}
         aria-label={t('settings.common.changeDirectory')}
         title={current || undefined}
-        disabled={disabled}
+        disabled={pickerDisabled}
         className="group flex w-full items-center gap-2.5 rounded-md border border-border bg-background px-3 py-2 text-left text-sm transition-colors hover:border-ring hover:bg-accent/30 disabled:opacity-50"
       >
         {prefixLabel && (
@@ -78,7 +91,7 @@ export function DirectoryPicker<TFields extends FieldValues>({
         value={current}
         placeholder={placeholder}
         readOnly
-        disabled={disabled}
+        disabled={pickerDisabled}
         className="flex-1 text-xs [direction:rtl] [text-align:left] h-8"
       />
       <Button
@@ -86,7 +99,7 @@ export function DirectoryPicker<TFields extends FieldValues>({
         variant="outline"
         size="sm"
         onClick={handlePick}
-        disabled={disabled}
+        disabled={pickerDisabled}
       >
         <Folder className="mr-1 h-3 w-3" />
         {t('settings.common.browse')}

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -88,7 +88,7 @@
   --radius-xl: calc(var(--radius) + 4px);
   --color-tab-background: var(--tab-background);
   --font-heading: var(--font-sans);
-  --font-sans: "Inter Variable", sans-serif;
+  --font-sans: "Inter Variable", var(--font-cjk, sans-serif);
   --radius-2xl: calc(var(--radius) * 1.8);
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
@@ -139,6 +139,14 @@
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
   --tab-background: oklch(0.95 0 0);
+}
+
+.platform-win32:lang(zh-CN) {
+  --font-cjk: "Microsoft YaHei";
+}
+
+.platform-win32:lang(zh-TW) {
+  --font-cjk: "Microsoft JhengHei";
 }
 
 .platform-darwin.window-main .electron-window-chrome,
@@ -210,7 +218,7 @@
     @apply bg-background text-foreground;
     font-family:
       -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
-      sans-serif;
+      var(--font-cjk, sans-serif);
     margin: 0;
     padding: 0;
   }


### PR DESCRIPTION
## Summary

- prevent duplicate native directory dialogs by guarding concurrent requests in both the renderer and main process
- use Microsoft YaHei and Microsoft JhengHei as Windows fallbacks for Simplified and Traditional Chinese
- detect authoritative Windows 11 UserChoiceLatest associations before falling back to legacy UserChoice values

## Validation

- pnpm run check:boundaries
- pnpm run lint
- pnpm exec tsc --noEmit

## Manual validation

- on Windows, rapidly click the Save To path and confirm only one directory dialog opens
- switch between Simplified and Traditional Chinese and verify consistent CJK glyph rendering
- set torrent and magnet defaults in Windows Settings, return to Integration settings, and verify both statuses refresh correctly

Closes #1964
Closes #1965
Closes #1966