### PR TITLE
fix(build): include the Motrix license in Server artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,7 @@ COPY --from=build --chown=node:node /app/dist/server-app/bin/aria2c ./bin/aria2c
 COPY --from=full-root-production-deps --chown=node:node /app/node_modules ./node_modules
 COPY --from=build --chown=node:node /app/extra/aria2.conf ./extra/aria2.conf
 COPY --from=build --chown=node:node /app/dist/builtin-plugins ./builtin-plugins
+COPY --from=build --chown=node:node /app/LICENSE ./LICENSE
 COPY --from=build --chown=node:node /app/THIRD_PARTY_NOTICES.md ./THIRD_PARTY_NOTICES.md
 COPY --from=build --chown=node:node /app/THIRD_PARTY_NOTICES.zh-CN.md ./THIRD_PARTY_NOTICES.zh-CN.md
 COPY --from=build --chown=node:node /app/THIRD_PARTY_LICENSES ./THIRD_PARTY_LICENSES

--- a/scripts/server-runtime-dependencies.json
+++ b/scripts/server-runtime-dependencies.json
@@ -57,6 +57,11 @@
   ],
   "resourceInputs": [
     {
+      "source": "LICENSE",
+      "destination": "LICENSE",
+      "type": "file"
+    },
+    {
       "source": "THIRD_PARTY_LICENSES",
       "destination": "THIRD_PARTY_LICENSES",
       "type": "directory"

--- a/scripts/smoke-server-image.mjs
+++ b/scripts/smoke-server-image.mjs
@@ -593,6 +593,8 @@ async function assertRuntimeContract(name, url, token, identity, timeoutMs) {
       'test -w /downloads',
       'test -w /data/tmp',
       'test ! -w /app',
+      'test -s /app/LICENSE',
+      'test -s /app/THIRD_PARTY_NOTICES.md',
       'test -s /data/motrix.db',
       'test "$MOTRIX_ARIA2_BIN" = "/app/bin/aria2c"',
       'test "$SSL_CERT_FILE" = "/etc/ssl/certs/ca-certificates.crt"',

--- a/scripts/verify-server-package.mjs
+++ b/scripts/verify-server-package.mjs
@@ -323,6 +323,24 @@ export async function verifyServerPackage(options) {
     }
     return `${tree.files.length} regular files and no symlinks`
   })
+  await check('project-license', async () => {
+    if (
+      typeof appManifest?.license !== 'string' ||
+      appManifest.license === ''
+    ) {
+      throw new Error('generated package.json has no project license')
+    }
+    const licensePath = path.join(stageRoot, 'LICENSE')
+    const info = await lstat(licensePath)
+    if (!info.isFile()) {
+      throw new Error('LICENSE is not a regular file')
+    }
+    const text = await readFile(licensePath, 'utf8')
+    if (text.trim() === '') {
+      throw new Error('LICENSE is empty')
+    }
+    return `Motrix ${appManifest.license} license is included`
+  })
   await check('bundled-engine', async () => {
     if (!engineInput) return 'runtime contract does not bundle an engine'
     const assetKey = `${target.platform}-${target.arch}`

--- a/tests/check-third-party-notices.test.ts
+++ b/tests/check-third-party-notices.test.ts
@@ -362,6 +362,7 @@ describe('third-party graph dependency notices', () => {
       ).toContain(`legal/${artifact}`)
     }
     for (const destination of [
+      'LICENSE',
       'THIRD_PARTY_NOTICES.md',
       'THIRD_PARTY_NOTICES.zh-CN.md',
       'THIRD_PARTY_LICENSES',

--- a/tests/scripts/audit-server-runtime.test.ts
+++ b/tests/scripts/audit-server-runtime.test.ts
@@ -255,6 +255,7 @@ describe('Server package contracts', () => {
       'motrix-admin.mjs',
     ])
     expect(contract.resourceInputs.map((entry) => entry.source)).toEqual([
+      'LICENSE',
       'THIRD_PARTY_LICENSES',
       'THIRD_PARTY_NOTICES.md',
       'THIRD_PARTY_NOTICES.zh-CN.md',

--- a/tests/scripts/docker-server-runtime.test.ts
+++ b/tests/scripts/docker-server-runtime.test.ts
@@ -194,6 +194,7 @@ describe('Docker Server runtime staging contract', () => {
     expect(imageSmoke).toContain('Save directory is not writable: /downloads')
     expect(imageSmoke).toContain('did not survive container restart')
     expect(imageSmoke).toContain("'SQLite3-Persistence'")
+    expect(imageSmoke).toContain("'test -s /app/LICENSE'")
     expect(imageSmoke).toContain("'test ! -e /usr/bin/aria2c'")
     expect(imageSmoke).toContain(
       '\'test "$(readlink /proc/$aria2_pid/exe)" = "/app/bin/aria2c"\''

--- a/tests/scripts/verify-server-package.test.ts
+++ b/tests/scripts/verify-server-package.test.ts
@@ -99,6 +99,11 @@ function fixtureContract() {
     ],
     resourceInputs: [
       {
+        source: 'LICENSE',
+        destination: 'LICENSE',
+        type: 'file',
+      },
+      {
         source: 'legal/notice.txt',
         destination: 'legal/notice.txt',
         type: 'file',
@@ -146,6 +151,7 @@ async function createStagedFixture(
       2
     )}\n`
   )
+  await writeFixtureFile(root, 'LICENSE', 'MIT License\n')
   await writeFixtureFile(
     root,
     'dist/server/index.mjs',
@@ -207,7 +213,7 @@ async function createStagedFixture(
     const engineBytes = nativeHeader('darwin', 'arm64')
     await writeFixtureFile(root, 'extra/darwin/arm64/aria2c', engineBytes)
     await chmod(path.join(root, 'extra/darwin/arm64/aria2c'), 0o755)
-    contract.resourceInputs.unshift({
+    contract.resourceInputs.splice(1, 0, {
       source: 'extra/{platform}/{arch}/{aria2Binary}',
       destination: 'bin/{aria2Binary}',
       type: 'file',
@@ -309,6 +315,17 @@ describe('verifyServerPackage', () => {
     await rm(path.join(fixture.stageRoot, 'dist/server/motrix-admin.mjs'))
 
     await expect(verifyFixture(fixture)).rejects.toThrow()
+  })
+
+  it('rejects a staged Server artifact without the Motrix license', async () => {
+    const fixture = await createStagedFixture()
+    await rm(path.join(fixture.stageRoot, 'LICENSE'))
+
+    await expect(verifyFixture(fixture)).rejects.toThrow('project-license')
+    const report = JSON.parse(await readFile(fixture.reportPath, 'utf8'))
+    expect(report.checks).toContainEqual(
+      expect.objectContaining({ id: 'project-license', passed: false })
+    )
   })
 
   it('rejects target drift and foreign native binaries', async () => {


### PR DESCRIPTION
## Summary

- stage the Motrix project LICENSE with Server legal resources
- copy the license into the final Server container image
- verify staged packages and container smoke tests include a non-empty project license
- keep the Server runtime and third-party notice contracts covered by regression tests

## Why

Server artifacts already ship third-party notices and licenses, but omitted the Motrix project license itself. This aligns staged Server packages and the runtime container with the declared project license.

## Validation

- 43 focused Server packaging and license-contract tests passed
- third-party notice audit validated 547 runtime packages; 21 generator tests passed
- architecture boundary check passed
- Biome checked 1,610 files
- TypeScript type-check passed
- Server, worker, and web renderer production builds passed
- darwin-arm64 Server staging and package verification passed (123 packages)