### PR TITLE
fix(snap): honor scoped edge channel credentials

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -2,9 +2,11 @@
 #
 # Snap is deliberately independent from the GitHub Release workflow:
 #   - amd64 and arm64 are built on matching native Ubuntu runners;
-#   - pull requests and manual runs never receive Store credentials;
+#   - pull requests and ordinary manual builds never receive Store credentials;
 #   - protected stable and beta release tags publish a complete
 #     two-architecture build set to latest/edge only;
+#   - an explicit protected-main manual run can recover edge publication
+#     without moving or replacing an immutable release tag;
 #   - candidate and stable receive that exact build set through snap-promote.yml.
 
 name: Snap
@@ -38,6 +40,12 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      publish_edge:
+        description: Publish the protected main build to latest/edge
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -47,11 +55,21 @@ permissions:
 concurrency:
   group: >-
     ${{
-      github.event_name == 'push'
+      (
+        github.event_name == 'push'
+        || (
+          github.event_name == 'workflow_dispatch'
+          && inputs.publish_edge == true
+        )
+      )
       && 'snap-store-publication'
       || format('snap-{0}-{1}', github.event_name, github.ref)
     }}
-  cancel-in-progress: ${{ github.event_name != 'push' }}
+  cancel-in-progress: >-
+    ${{
+      github.event_name != 'push'
+      && inputs.publish_edge != true
+    }}
 
 jobs:
   preflight:
@@ -69,8 +87,8 @@ jobs:
       - name: Validate release metadata
         id: metadata
         env:
-          # Pull requests and manual runs validate package SemVer but cannot
-          # satisfy the tag-only publication branch below.
+          # Pull requests and manual runs validate package SemVer without
+          # pretending to be a protected release-tag event.
           RELEASE_EVENT_NAME: >-
             ${{
               github.event_name == 'push'
@@ -239,9 +257,16 @@ jobs:
   publish-edge:
     name: Publish complete build set to edge
     if: >-
-      github.event_name == 'push' &&
-      startsWith(github.ref, 'refs/tags/v') &&
-      github.ref_protected == true
+      (
+        github.event_name == 'push' &&
+        startsWith(github.ref, 'refs/tags/v') &&
+        github.ref_protected == true
+      ) || (
+        github.event_name == 'workflow_dispatch' &&
+        inputs.publish_edge == true &&
+        github.ref == 'refs/heads/main' &&
+        github.ref_protected == true
+      )
     needs: [preflight, build]
     runs-on: ubuntu-24.04
     # Bounded pre-mutation steps plus a 45-minute release/rollback window.

--- a/scripts/release-snap-build-set.mjs
+++ b/scripts/release-snap-build-set.mjs
@@ -52,6 +52,11 @@ function snapshotsMatch(left, right) {
   )
 }
 
+function snapcraftChannel(channel) {
+  const [track, risk, extra] = channel.split('/')
+  return track === 'latest' && risk && extra === undefined ? risk : channel
+}
+
 function wait(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds))
 }
@@ -174,6 +179,10 @@ export async function releaseSnapBuildSet({
     )
   }
   const approved = normalizeRevisions(revisions)
+  // Snap Store API responses use the canonical latest/<risk> spelling, while
+  // channel-restricted macaroons issued for the default track authorize the
+  // short risk name used by Snapcraft's mutation commands.
+  const mutationChannel = snapcraftChannel(channel)
   const snapshotOptions = {
     snapName,
     channel,
@@ -186,9 +195,14 @@ export async function releaseSnapBuildSet({
   try {
     // Treat even a rejected initial close as an uncertain mutation. The Store
     // may have committed the close before the CLI lost its response.
-    await runSnapcraft(['close', snapName, channel])
+    await runSnapcraft(['close', snapName, mutationChannel])
     for (const architecture of ARCHITECTURES) {
-      await runSnapcraft(['release', snapName, approved[architecture], channel])
+      await runSnapcraft([
+        'release',
+        snapName,
+        approved[architecture],
+        mutationChannel,
+      ])
     }
     await verifySnapStoreChannel({
       snapName,
@@ -202,14 +216,14 @@ export async function releaseSnapBuildSet({
     })
   } catch (releaseError) {
     try {
-      await runSnapcraft(['close', snapName, channel])
+      await runSnapcraft(['close', snapName, mutationChannel])
       for (const architecture of ARCHITECTURES) {
         if (previous[architecture]) {
           await runSnapcraft([
             'release',
             snapName,
             previous[architecture],
-            channel,
+            mutationChannel,
           ])
         }
       }
@@ -220,7 +234,7 @@ export async function releaseSnapBuildSet({
         // A rollback can fail after restoring only one architecture. Close the
         // target again so a partially restored public channel is not left
         // available. A closed channel is safer than a mixed build set.
-        await runSnapcraft(['close', snapName, channel])
+        await runSnapcraft(['close', snapName, mutationChannel])
       } catch (error) {
         containmentError = error
       }

--- a/tests/scripts/snap-build-set-release.test.ts
+++ b/tests/scripts/snap-build-set-release.test.ts
@@ -106,9 +106,9 @@ describe('release-snap-build-set', () => {
       version: '2.0.0',
     })
     expect(runSnapcraft.mock.calls).toEqual([
-      [['close', 'motrix', 'latest/candidate']],
-      [['release', 'motrix', '20', 'latest/candidate']],
-      [['release', 'motrix', '21', 'latest/candidate']],
+      [['close', 'motrix', 'candidate']],
+      [['release', 'motrix', '20', 'candidate']],
+      [['release', 'motrix', '21', 'candidate']],
     ])
   })
 
@@ -150,12 +150,12 @@ describe('release-snap-build-set', () => {
       })
     ).rejects.toThrow(/previous revisions were restored/)
     expect(runSnapcraft.mock.calls).toEqual([
-      [['close', 'motrix', 'latest/candidate']],
-      [['release', 'motrix', '20', 'latest/candidate']],
-      [['release', 'motrix', '21', 'latest/candidate']],
-      [['close', 'motrix', 'latest/candidate']],
-      [['release', 'motrix', '10', 'latest/candidate']],
-      [['release', 'motrix', '11', 'latest/candidate']],
+      [['close', 'motrix', 'candidate']],
+      [['release', 'motrix', '20', 'candidate']],
+      [['release', 'motrix', '21', 'candidate']],
+      [['close', 'motrix', 'candidate']],
+      [['release', 'motrix', '10', 'candidate']],
+      [['release', 'motrix', '11', 'candidate']],
     ])
   })
 
@@ -201,10 +201,10 @@ describe('release-snap-build-set', () => {
       })
     ).rejects.toThrow(/previous revisions were restored/)
     expect(runSnapcraft.mock.calls).toEqual([
-      [['close', 'motrix', 'latest/candidate']],
-      [['close', 'motrix', 'latest/candidate']],
-      [['release', 'motrix', '10', 'latest/candidate']],
-      [['release', 'motrix', '11', 'latest/candidate']],
+      [['close', 'motrix', 'candidate']],
+      [['close', 'motrix', 'candidate']],
+      [['release', 'motrix', '10', 'candidate']],
+      [['release', 'motrix', '11', 'candidate']],
     ])
   })
 
@@ -232,7 +232,7 @@ describe('release-snap-build-set', () => {
       })
     ).rejects.toThrow(/previous revisions were restored/)
     expect(runSnapcraft.mock.calls.at(-1)).toEqual([
-      ['release', 'motrix', '10', 'latest/candidate'],
+      ['release', 'motrix', '10', 'candidate'],
     ])
   })
 
@@ -260,10 +260,10 @@ describe('release-snap-build-set', () => {
       })
     ).rejects.toThrow(/previous revisions were restored/)
     expect(runSnapcraft.mock.calls).toEqual([
-      [['close', 'motrix', 'latest/candidate']],
-      [['release', 'motrix', '20', 'latest/candidate']],
-      [['release', 'motrix', '21', 'latest/candidate']],
-      [['close', 'motrix', 'latest/candidate']],
+      [['close', 'motrix', 'candidate']],
+      [['release', 'motrix', '20', 'candidate']],
+      [['release', 'motrix', '21', 'candidate']],
+      [['close', 'motrix', 'candidate']],
     ])
   })
 
@@ -309,12 +309,12 @@ describe('release-snap-build-set', () => {
       })
     ).rejects.toThrow(/previous revisions were restored/)
     expect(runSnapcraft.mock.calls).toEqual([
-      [['close', 'motrix', 'latest/candidate']],
-      [['release', 'motrix', '20', 'latest/candidate']],
-      [['release', 'motrix', '21', 'latest/candidate']],
-      [['close', 'motrix', 'latest/candidate']],
-      [['release', 'motrix', '10', 'latest/candidate']],
-      [['release', 'motrix', '11', 'latest/candidate']],
+      [['close', 'motrix', 'candidate']],
+      [['release', 'motrix', '20', 'candidate']],
+      [['release', 'motrix', '21', 'candidate']],
+      [['close', 'motrix', 'candidate']],
+      [['release', 'motrix', '10', 'candidate']],
+      [['release', 'motrix', '11', 'candidate']],
     ])
   })
 
@@ -392,7 +392,7 @@ describe('release-snap-build-set', () => {
       })
     ).rejects.toThrow(/rollback failed and the target channel was closed/)
     expect(runSnapcraft.mock.calls.at(-1)).toEqual([
-      ['close', 'motrix', 'latest/candidate'],
+      ['close', 'motrix', 'candidate'],
     ])
   })
 

--- a/tests/scripts/workflow-snap.test.ts
+++ b/tests/scripts/workflow-snap.test.ts
@@ -166,7 +166,7 @@ describe('Snap build workflow contract', () => {
     }
   })
 
-  it('publishes protected stable and beta tags through the edge environment', () => {
+  it('publishes protected tags and explicit protected-main recovery runs through the edge environment', () => {
     const preflight = workflowJob(snapWorkflow, 'preflight')
     const preflightOutputs = asRecord(preflight.outputs, 'preflight outputs')
     const build = workflowJob(snapWorkflow, 'build')
@@ -180,6 +180,9 @@ describe('Snap build workflow contract', () => {
     expect(build).not.toHaveProperty('if')
     expect(condition).toContain("github.event_name == 'push'")
     expect(condition).toContain("startsWith(github.ref, 'refs/tags/v')")
+    expect(condition).toContain("github.event_name == 'workflow_dispatch'")
+    expect(condition).toContain('inputs.publish_edge == true')
+    expect(condition).toContain("github.ref == 'refs/heads/main'")
     expect(condition).toContain('github.ref_protected == true')
     expect(snapSource).not.toContain(
       "needs.preflight.outputs.prerelease == 'false'"
@@ -197,7 +200,24 @@ describe('Snap build workflow contract', () => {
       tags: ['v*'],
     })
     expect(triggers).toHaveProperty('pull_request')
-    expect(triggers).toHaveProperty('workflow_dispatch')
+    const manual = asRecord(
+      triggers.workflow_dispatch,
+      'workflow dispatch trigger'
+    )
+    const manualInputs = asRecord(manual.inputs, 'workflow dispatch inputs')
+    expect(asRecord(manualInputs.publish_edge, 'publish edge input')).toEqual({
+      description: 'Publish the protected main build to latest/edge',
+      required: true,
+      default: false,
+      type: 'boolean',
+    })
+    const concurrency = asRecord(snapWorkflow.concurrency, 'Snap concurrency')
+    expect(stringField(concurrency, 'group')).toContain(
+      'inputs.publish_edge == true'
+    )
+    expect(stringField(concurrency, 'cancel-in-progress')).toContain(
+      'inputs.publish_edge != true'
+    )
   })
 
   it('installs pinned verifier dependencies before verification and Store mutation', () => {


### PR DESCRIPTION
## Summary

- use the short risk name for Snapcraft mutations on the default latest track, matching channel-scoped Store credentials
- retain canonical latest/risk names for public Store verification
- add an explicit protected-main manual edge publication path so beta.27 can be recovered without moving its immutable tag

## Failure addressed

The beta.27 Snap run uploaded amd64 revision 53 and arm64 revision 49, then failed because a credential restricted to edge rejected the mutation argument latest/edge. The workflow containment logic closed the channel, so no mixed build set remains public.

## Verification

- 28 focused Snap workflow/release tests
- lint
- TypeScript no-emit check
- boundary and filename checks
- git diff check