### PR TITLE
fix(cli): spawn windows executables directly

### DIFF
--- a/src/main/cli/command-runner.test.ts
+++ b/src/main/cli/command-runner.test.ts
@@ -62,6 +62,34 @@ describe('createCommandRunner', () => {
     expect(Buffer.byteLength(result.stdout)).toBeLessThanOrEqual(64)
   })
 
+  it('spawns Windows executables directly when their path contains spaces', async () => {
+    const child = Object.assign(new EventEmitter(), {
+      pid: 42,
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      kill: vi.fn(),
+    })
+    const spawnProcess = vi.fn().mockReturnValue(child)
+    const run = createCommandRunner({
+      platform: 'win32',
+      spawnProcess: spawnProcess as never,
+    })
+
+    const pending = run('C:\\Program Files\\nodejs\\node.EXE', ['--version'])
+    child.emit('close', 0)
+
+    await expect(pending).resolves.toMatchObject({ code: 0 })
+    expect(spawnProcess).toHaveBeenCalledWith(
+      'C:\\Program Files\\nodejs\\node.EXE',
+      ['--version'],
+      expect.objectContaining({
+        shell: false,
+        detached: false,
+        windowsHide: true,
+      })
+    )
+  })
+
   it('kills a timed-out POSIX process group', async () => {
     if (process.platform === 'win32') return
     const run = createCommandRunner()

--- a/src/main/cli/command-runner.ts
+++ b/src/main/cli/command-runner.ts
@@ -123,25 +123,26 @@ export function createCommandRunner(
     }
 
     return new Promise((resolve) => {
-      const useWindowsShell = platform === 'win32'
-      const batchShim = useWindowsShell && /\.(?:cmd|bat)$/i.test(command)
+      const isWindows = platform === 'win32'
+      const batchShim = isWindows && /\.(?:cmd|bat)$/i.test(command)
       const cap = Math.max(1, options?.maxBuffer ?? DEFAULT_MAX_BUFFER)
       let child: ReturnType<typeof spawn>
 
       try {
         child = spawnProcess(
-          useWindowsShell ? escapeCmdCommand(command) : command,
-          useWindowsShell
-            ? args.map((argument) => escapeCmdArgument(argument, batchShim))
+          batchShim ? escapeCmdCommand(command) : command,
+          batchShim
+            ? args.map((argument) => escapeCmdArgument(argument, true))
             : [...args],
           {
             cwd: options?.cwd,
             env: options?.env,
             stdio: ['ignore', 'pipe', 'pipe'],
-            shell: useWindowsShell
+            shell: batchShim
               ? windowsSystemBinary('cmd.exe', systemRoot)
               : false,
-            detached: !useWindowsShell,
+            detached: !isWindows,
+            windowsHide: isWindows,
           }
         )
       } catch (error) {
@@ -198,12 +199,12 @@ export function createCommandRunner(
       const killTree = () => {
         const pid = child.pid
         if (pid == null) return
-        if (useWindowsShell) {
+        if (isWindows) {
           try {
             const taskkill = spawnProcess(
               windowsSystemBinary('taskkill.exe', systemRoot),
               ['/pid', String(pid), '/t', '/f'],
-              { stdio: 'ignore', shell: false }
+              { stdio: 'ignore', shell: false, windowsHide: true }
             )
             // A failed spawn is normally reported asynchronously through the
             // child error event, outside the surrounding try/catch.


### PR DESCRIPTION
## Summary

- spawn native Windows executables directly instead of routing them through cmd.exe
- keep cmd.exe escaping only for .cmd and .bat package-manager shims
- preserve Windows taskkill-based process-tree termination for both native executables and batch shims
- hide child process windows for CLI probes and installs

## Root cause

The PATH refresh from #1973 correctly found the official Node.js installation. The remaining failure was in the command runner: it pre-escaped the absolute node.exe path and then passed it through the Node shell option. For a path containing Program Files, the nested shell processing caused Node.js to receive its own executable path as a script argument, matching the MODULE_NOT_FOUND diagnostic reported in #1998.

Native .exe and .com files do not require a command shell. Only Windows batch shims require cmd.exe.

## Verification

- focused command-runner regression test using C:\\Program Files\\nodejs\\node.EXE
- architecture boundary checks
- full Biome check
- TypeScript type check

Fixes #1998