### PR TITLE
chore(release): prepare 2.0.0-beta.28

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. After its remaining release gates pass,
-download [v2.0.0-beta.27 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.27)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.27.md) before
+download [v2.0.0-beta.28 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.28)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.28.md) before
 installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -165,7 +165,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.27'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.28'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。剩余发布门禁通过后，请从 GitHub Releases
-下载 [v2.0.0-beta.27](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.27)，
-并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.27.zh-CN.md)。
+下载 [v2.0.0-beta.28](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.28)，
+并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.28.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -156,7 +156,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.27'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.28'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.28.md
+++ b/docs/release-notes/2.0.0-beta.28.md
@@ -9,16 +9,16 @@ after every protected release gate passes.
 
 ## Highlights
 
-- HTTP and FTP downloads now derive safe final filenames after redirects,
-  request rewriting, plugin hooks, and proxy-aware remote metadata probes.
-  Explicit user filenames remain authoritative, while failed probes retain a
-  safe URL-based fallback
+- HTTP(S) downloads now derive safe final filenames after redirects, request
+  rewriting, plugin hooks, and proxy-aware remote metadata probes. Explicit
+  user filenames remain authoritative, while failed probes retain a safe
+  URL-based fallback
   ([#1976](https://github.com/agalwood/Motrix/issues/1976),
   [#1988](https://github.com/agalwood/Motrix/issues/1988)).
-- The Files inspector keeps the logical destination name instead of exposing
-  aria2's temporary `.motrix` suffix. Finalization rebases persisted file
-  records after a successful rename without changing BitTorrent, Magnet, or
-  multiplexed-download paths
+- The Files inspector keeps the logical HTTP/FTP destination name instead of
+  exposing aria2's temporary `.motrix` suffix. Finalization rebases persisted
+  file records after a successful rename without changing BitTorrent, Magnet,
+  or multiplexed-download paths
   ([#1987](https://github.com/agalwood/Motrix/issues/1987)).
 - An explicitly empty RPC password now enables intentional no-token mode.
   Motrix still binds aria2 RPC to loopback, disables permissive cross-origin

--- a/docs/release-notes/2.0.0-beta.28.md
+++ b/docs/release-notes/2.0.0-beta.28.md
@@ -13,29 +13,29 @@ after every protected release gate passes.
   rewriting, plugin hooks, and proxy-aware remote metadata probes. Explicit
   user filenames remain authoritative, while failed probes retain a safe
   URL-based fallback
-  ([#1976](https://github.com/agalwood/Motrix/issues/1976),
-  [#1988](https://github.com/agalwood/Motrix/issues/1988)).
+  ([#1976](https://github.com/agalwood/Motrix/issues/1976)).
 - The Files inspector keeps the logical HTTP/FTP destination name instead of
   exposing aria2's temporary `.motrix` suffix. Finalization rebases persisted
   file records after a successful rename without changing BitTorrent, Magnet,
   or multiplexed-download paths
-  ([#1987](https://github.com/agalwood/Motrix/issues/1987)).
+  ([#2001](https://github.com/agalwood/Motrix/issues/2001)).
 - An explicitly empty RPC password now enables intentional no-token mode.
   Motrix still binds aria2 RPC to loopback, disables permissive cross-origin
   access, refreshes the RPC client before the first call to a restarted engine,
   and coalesces concurrent restart requests
-  ([#1997](https://github.com/agalwood/Motrix/issues/1997),
-  [#1999](https://github.com/agalwood/Motrix/issues/1999)).
-- HTTP, HTTPS, and SOCKS5 proxies share the same BitTorrent boundary: they
-  cover HTTP(S) trackers and Web Seeds, but not peer connections, DHT, or UDP
-  trackers. This release adds an authenticated loopback HTTP bridge so SOCKS5
-  can also serve regular HTTP(S)/FTP downloads, tracker-list refreshes, and
-  that BitTorrent HTTP(S) traffic. Per-listener authentication is generated in
-  memory and removed when the bridge stops
+  ([#1987](https://github.com/agalwood/Motrix/issues/1987),
+  [#1988](https://github.com/agalwood/Motrix/issues/1988)).
+- Native BitTorrent traffic has the same boundary regardless of the selected
+  proxy: peer connections, DHT, and UDP trackers remain direct. Only HTTP(S)
+  requests associated with a torrent, such as HTTP(S) trackers and Web Seeds,
+  can use the download proxy. This release adds an authenticated loopback HTTP
+  bridge so SOCKS5 also works for regular HTTP(S) downloads, tracker-list
+  refreshes, and that BitTorrent HTTP(S) traffic. Per-listener authentication
+  is generated in memory and removed when the bridge stops
   ([#1977](https://github.com/agalwood/Motrix/issues/1977)).
 - Motrix now uses `@motrix/nat@0.1.1`, improving Windows default-route
   selection and NAT mapping in multi-adapter environments such as Tailscale
-  ([#2001](https://github.com/agalwood/Motrix/issues/2001)).
+  ([#1999](https://github.com/agalwood/Motrix/issues/1999)).
 - Windows CLI discovery now starts native executables directly and reserves
   `cmd.exe` for batch shims, fixing Node.js paths under `Program Files`
   ([#1998](https://github.com/agalwood/Motrix/issues/1998)).
@@ -45,7 +45,8 @@ after every protected release gate passes.
 - The Downloads page restores its empty state when only removed records remain.
   Protected beta tags also use the Store's scoped edge channel correctly when
   publishing the verified two-architecture Snap set to `latest/edge`
-  ([#1996](https://github.com/agalwood/Motrix/pull/1996),
+  ([#1997](https://github.com/agalwood/Motrix/issues/1997),
+  [#1996](https://github.com/agalwood/Motrix/pull/1996),
   [#2002](https://github.com/agalwood/Motrix/pull/2002)).
 
 ## Before testing

--- a/docs/release-notes/2.0.0-beta.28.md
+++ b/docs/release-notes/2.0.0-beta.28.md
@@ -1,0 +1,107 @@
+# Motrix 2.0.0-beta.28
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.28/docs/release-notes/2.0.0-beta.28.zh-CN.md)
+
+Motrix 2.0.0-beta.28 resolves beta blockers in direct-download naming and
+finalization, RPC lifecycle, proxy handling, Windows networking and
+integration, and Snap publication. It is intended for public distribution only
+after every protected release gate passes.
+
+## Highlights
+
+- HTTP and FTP downloads now derive safe final filenames after redirects,
+  request rewriting, plugin hooks, and proxy-aware remote metadata probes.
+  Explicit user filenames remain authoritative, while failed probes retain a
+  safe URL-based fallback
+  ([#1976](https://github.com/agalwood/Motrix/issues/1976),
+  [#1988](https://github.com/agalwood/Motrix/issues/1988)).
+- The Files inspector keeps the logical destination name instead of exposing
+  aria2's temporary `.motrix` suffix. Finalization rebases persisted file
+  records after a successful rename without changing BitTorrent, Magnet, or
+  multiplexed-download paths
+  ([#1987](https://github.com/agalwood/Motrix/issues/1987)).
+- An explicitly empty RPC password now enables intentional no-token mode.
+  Motrix still binds aria2 RPC to loopback, disables permissive cross-origin
+  access, refreshes the RPC client before the first call to a restarted engine,
+  and coalesces concurrent restart requests
+  ([#1997](https://github.com/agalwood/Motrix/issues/1997),
+  [#1999](https://github.com/agalwood/Motrix/issues/1999)).
+- HTTP, HTTPS, and SOCKS5 proxies share the same BitTorrent boundary: they
+  cover HTTP(S) trackers and Web Seeds, but not peer connections, DHT, or UDP
+  trackers. This release adds an authenticated loopback HTTP bridge so SOCKS5
+  can also serve regular HTTP(S)/FTP downloads, tracker-list refreshes, and
+  that BitTorrent HTTP(S) traffic. Per-listener authentication is generated in
+  memory and removed when the bridge stops
+  ([#1977](https://github.com/agalwood/Motrix/issues/1977)).
+- Motrix now uses `@motrix/nat@0.1.1`, improving Windows default-route
+  selection and NAT mapping in multi-adapter environments such as Tailscale
+  ([#2001](https://github.com/agalwood/Motrix/issues/2001)).
+- Windows CLI discovery now starts native executables directly and reserves
+  `cmd.exe` for batch shims, fixing Node.js paths under `Program Files`
+  ([#1998](https://github.com/agalwood/Motrix/issues/1998)).
+- The Windows installer restores the dedicated `.torrent` association icon
+  while preserving the installer-owned Default Apps design
+  ([#2003](https://github.com/agalwood/Motrix/issues/2003)).
+- The Downloads page restores its empty state when only removed records remain.
+  Protected beta tags also use the Store's scoped edge channel correctly when
+  publishing the verified two-architecture Snap set to `latest/edge`
+  ([#1996](https://github.com/agalwood/Motrix/pull/1996),
+  [#2002](https://github.com/agalwood/Motrix/pull/2002)).
+
+## Before testing
+
+This is prerelease software. Back up existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Pay particular attention to redirected HTTP downloads,
+downloads using each proxy protocol, the documented BitTorrent proxy boundary,
+RPC no-token mode, engine restarts, and Windows networking or file
+associations relevant to your environment.
+
+After the protected release completes, Snap testers can install the strictly
+confined build with `sudo snap install motrix --edge`. Existing installations
+tracking `latest/edge` should upgrade to the same beta.28 revision set.
+
+## Planned downloads after release gates pass
+
+| Distribution | Architectures | Planned output |
+|--------------|---------------|----------------|
+| macOS 12 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | AppImage, DEB, and RPM |
+| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.28-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.28` tag in both registries |
+| Snap Store | `amd64`, `arm64` | Verified build set on `latest/edge` |
+
+After every container gate passes, the versioned image references will be
+`docker.io/motrixapp/motrix-server:2.0.0-beta.28` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.28`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.28/docs/docker-server.md)
+for storage, networking, and upgrade guidance.
+
+## Distribution notes
+
+- AppImage desktop integration is opt-in and confined to the current user's
+  XDG data directory. Browser-extension hand-off is not yet available from the
+  AppImage package because its Native Messaging host does not have a stable
+  path outside the mounted image.
+- Flatpak is validated separately and is not published by the release tag; the
+  GitHub prerelease includes its Native Host companion archives.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
+  Download them only from the official GitHub prerelease after it is published.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+- The Snap package is strictly confined. Its approved `personal-files`
+  interface is limited to registering Native Messaging host manifests for
+  supported browsers. Beta publication updates `latest/edge` only; it does not
+  promote the build to `candidate` or `stable`.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.28.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.28.zh-CN.md
@@ -11,26 +11,26 @@ Windows 网络与系统集成，以及 Snap 发布中的 beta 阻塞问题。只
 - HTTP(S) 下载现在会在重定向、请求改写、插件 hook 和支持代理的远端元数据
   探测完成后生成安全的最终文件名。用户明确指定的文件名仍拥有最高优先级；
   探测失败时则保留安全的 URL fallback
-  （[#1976](https://github.com/agalwood/Motrix/issues/1976)、
-  [#1988](https://github.com/agalwood/Motrix/issues/1988)）。
+  （[#1976](https://github.com/agalwood/Motrix/issues/1976)）。
 - 文件检查器会显示 HTTP/FTP 的逻辑目标名称，不再暴露 aria2 临时使用的
   `.motrix` 后缀。成功重命名后，收尾流程会同步持久化文件记录，同时不改变
   BitTorrent、Magnet 或多路下载路径
-  （[#1987](https://github.com/agalwood/Motrix/issues/1987)）。
+  （[#2001](https://github.com/agalwood/Motrix/issues/2001)）。
 - 明确保存为空的 RPC 密码现在表示主动启用无 token 模式。Motrix 仍会把 aria2
   RPC 限制在 loopback、关闭宽松的跨域访问，在重启后的首次调用前同步 RPC
   client，并把并发重启请求合并为一次停止与启动
-  （[#1997](https://github.com/agalwood/Motrix/issues/1997)、
-  [#1999](https://github.com/agalwood/Motrix/issues/1999)）。
-- HTTP、HTTPS 与 SOCKS5 代理具有相同的 BitTorrent 边界：它们会代理
-  HTTP(S) Tracker 与 Web Seed，但不会代理 peer 连接、DHT 或 UDP Tracker。
-  本版本新增带认证的 loopback HTTP bridge，使 SOCKS5 也能用于普通
-  HTTP(S)/FTP 下载、Tracker 列表更新与这部分 BitTorrent HTTP(S) 流量。
-  每个 bridge listener 都会在内存中生成独立认证信息，并在停止时清除
+  （[#1987](https://github.com/agalwood/Motrix/issues/1987)、
+  [#1988](https://github.com/agalwood/Motrix/issues/1988)）。
+- 无论选择哪种代理，原生 BitTorrent 流量的边界都相同：peer 连接、DHT 和
+  UDP Tracker 保持直连。只有与种子相关的 HTTP(S) 请求（例如 HTTP(S)
+  Tracker 与 Web Seed）可以使用下载代理。本版本新增带认证的 loopback HTTP
+  bridge，使 SOCKS5 也能用于普通 HTTP(S) 下载、Tracker 列表更新与这部分
+  BitTorrent HTTP(S) 流量。每个 bridge listener 都会在内存中生成独立认证信息，
+  并在停止时清除
   （[#1977](https://github.com/agalwood/Motrix/issues/1977)）。
 - Motrix 已升级到 `@motrix/nat@0.1.1`，改善 Tailscale 等多网卡 Windows
   环境中的默认路由选择与 NAT 映射
-  （[#2001](https://github.com/agalwood/Motrix/issues/2001)）。
+  （[#1999](https://github.com/agalwood/Motrix/issues/1999)）。
 - Windows CLI 现在会直接启动原生可执行文件，只为批处理 shim 使用
   `cmd.exe`，从而修复 `Program Files` 下的 Node.js 路径问题
   （[#1998](https://github.com/agalwood/Motrix/issues/1998)）。
@@ -40,7 +40,8 @@ Windows 网络与系统集成，以及 Snap 发布中的 beta 阻塞问题。只
 - 当任务记录只剩已删除项时，下载页面会重新显示空状态。受保护 beta tag
   发布双架构 Snap 构建集时，也会正确使用 Store 限定的 edge 通道并更新
   `latest/edge`
-  （[#1996](https://github.com/agalwood/Motrix/pull/1996)、
+  （[#1997](https://github.com/agalwood/Motrix/issues/1997)、
+  [#1996](https://github.com/agalwood/Motrix/pull/1996)、
   [#2002](https://github.com/agalwood/Motrix/pull/2002)）。
 
 ## 测试前须知

--- a/docs/release-notes/2.0.0-beta.28.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.28.zh-CN.md
@@ -1,0 +1,95 @@
+# Motrix 2.0.0-beta.28
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.28/docs/release-notes/2.0.0-beta.28.md) | 简体中文
+
+Motrix 2.0.0-beta.28 修复了直接下载命名与收尾、RPC 生命周期、代理处理、
+Windows 网络与系统集成，以及 Snap 发布中的 beta 阻塞问题。只有在所有受保护
+发布门禁通过后，本版本才适合公开分发。
+
+## 主要改进
+
+- HTTP 与 FTP 下载现在会在重定向、请求改写、插件 hook 和支持代理的远端元数据
+  探测完成后生成安全的最终文件名。用户明确指定的文件名仍拥有最高优先级；
+  探测失败时则保留安全的 URL fallback
+  （[#1976](https://github.com/agalwood/Motrix/issues/1976)、
+  [#1988](https://github.com/agalwood/Motrix/issues/1988)）。
+- 文件检查器会显示逻辑目标名称，不再暴露 aria2 临时使用的 `.motrix` 后缀。
+  成功重命名后，收尾流程会同步持久化文件记录，同时不改变 BitTorrent、Magnet
+  或多路下载路径
+  （[#1987](https://github.com/agalwood/Motrix/issues/1987)）。
+- 明确保存为空的 RPC 密码现在表示主动启用无 token 模式。Motrix 仍会把 aria2
+  RPC 限制在 loopback、关闭宽松的跨域访问，在重启后的首次调用前同步 RPC
+  client，并把并发重启请求合并为一次停止与启动
+  （[#1997](https://github.com/agalwood/Motrix/issues/1997)、
+  [#1999](https://github.com/agalwood/Motrix/issues/1999)）。
+- HTTP、HTTPS 与 SOCKS5 代理具有相同的 BitTorrent 边界：它们会代理
+  HTTP(S) Tracker 与 Web Seed，但不会代理 peer 连接、DHT 或 UDP Tracker。
+  本版本新增带认证的 loopback HTTP bridge，使 SOCKS5 也能用于普通
+  HTTP(S)/FTP 下载、Tracker 列表更新与这部分 BitTorrent HTTP(S) 流量。
+  每个 bridge listener 都会在内存中生成独立认证信息，并在停止时清除
+  （[#1977](https://github.com/agalwood/Motrix/issues/1977)）。
+- Motrix 已升级到 `@motrix/nat@0.1.1`，改善 Tailscale 等多网卡 Windows
+  环境中的默认路由选择与 NAT 映射
+  （[#2001](https://github.com/agalwood/Motrix/issues/2001)）。
+- Windows CLI 现在会直接启动原生可执行文件，只为批处理 shim 使用
+  `cmd.exe`，从而修复 `Program Files` 下的 Node.js 路径问题
+  （[#1998](https://github.com/agalwood/Motrix/issues/1998)）。
+- Windows 安装程序恢复了专用的 `.torrent` 关联图标，同时保留由安装程序
+  管理的 Default Apps 设计
+  （[#2003](https://github.com/agalwood/Motrix/issues/2003)）。
+- 当任务记录只剩已删除项时，下载页面会重新显示空状态。受保护 beta tag
+  发布双架构 Snap 构建集时，也会正确使用 Store 限定的 edge 通道并更新
+  `latest/edge`
+  （[#1996](https://github.com/agalwood/Motrix/pull/1996)、
+  [#2002](https://github.com/agalwood/Motrix/pull/2002)）。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1 数据的
+迁移路径尚未经过验证，请勿让本 beta 使用您唯一的一份 v1 数据。
+
+条件允许时，请使用独立的操作系统账号、设备或 Docker 数据目录并行测试 v2。
+请重点检查重定向 HTTP 下载、使用各类代理的下载、发布说明中的 BitTorrent
+代理边界、RPC 无 token 模式、下载引擎重启，以及与自身环境相关的 Windows
+网络或文件关联行为。
+
+受保护发布完成后，Snap 测试者可使用
+`sudo snap install motrix --edge` 安装严格限制的构建。已跟踪
+`latest/edge` 的安装应升级到同一组 beta.28 revision。
+
+## 发布门禁通过后计划提供的下载
+
+| 分发方式 | 架构 | 计划产物 |
+|---------|------|---------|
+| macOS 12 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
+| Windows | `x64` | 未签名 NSIS 安装程序（`.exe`）和 ZIP |
+| Linux | `x64`、`arm64` | AppImage、DEB 和 RPM |
+| Flatpak Native Host companion | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.28-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个仓库中的不可变 `2.0.0-beta.28` 标签 |
+| Snap Store | `amd64`、`arm64` | `latest/edge` 上的已验证构建集 |
+
+所有容器门禁通过后，可使用以下带版本镜像：
+`docker.io/motrixapp/motrix-server:2.0.0-beta.28` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.28`。存储、网络与升级说明请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.28/docs/docker-server.zh-CN.md)。
+
+## 分发说明
+
+- AppImage 桌面集成需要用户主动启用，且只会写入当前用户的 XDG 数据目录。由于
+  Native Messaging host 在挂载镜像之外没有稳定路径，浏览器扩展暂时无法向
+  AppImage 安装包转交下载任务。
+- Flatpak 单独验证，不由 release tag 发布；GitHub 预发布版会包含它的
+  Native Host companion 压缩包。
+- 不提供 Windows `arm64` 和所有 32 位安装包。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅从已发布的
+  官方 GitHub 预发布版下载。
+- Beta 容器标签不可变，也不会更新 `latest`、`stable` 或其他稳定通道
+  浮动标签。
+- Snap 安装包使用严格限制。已批准的 `personal-files` interface 仅用于为支持的
+  浏览器注册 Native Messaging host manifest。Beta 发布只会更新
+  `latest/edge`，不会把构建晋级到 `candidate` 或 `stable`。
+
+## 反馈
+
+如遇到可复现的问题，请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues)
+反馈，并附上操作系统、架构、安装包类型和复现步骤。

--- a/docs/release-notes/2.0.0-beta.28.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.28.zh-CN.md
@@ -8,14 +8,14 @@ Windows 网络与系统集成，以及 Snap 发布中的 beta 阻塞问题。只
 
 ## 主要改进
 
-- HTTP 与 FTP 下载现在会在重定向、请求改写、插件 hook 和支持代理的远端元数据
+- HTTP(S) 下载现在会在重定向、请求改写、插件 hook 和支持代理的远端元数据
   探测完成后生成安全的最终文件名。用户明确指定的文件名仍拥有最高优先级；
   探测失败时则保留安全的 URL fallback
   （[#1976](https://github.com/agalwood/Motrix/issues/1976)、
   [#1988](https://github.com/agalwood/Motrix/issues/1988)）。
-- 文件检查器会显示逻辑目标名称，不再暴露 aria2 临时使用的 `.motrix` 后缀。
-  成功重命名后，收尾流程会同步持久化文件记录，同时不改变 BitTorrent、Magnet
-  或多路下载路径
+- 文件检查器会显示 HTTP/FTP 的逻辑目标名称，不再暴露 aria2 临时使用的
+  `.motrix` 后缀。成功重命名后，收尾流程会同步持久化文件记录，同时不改变
+  BitTorrent、Magnet 或多路下载路径
   （[#1987](https://github.com/agalwood/Motrix/issues/1987)）。
 - 明确保存为空的 RPC 密码现在表示主动启用无 token 模式。Motrix 仍会把 aria2
   RPC 限制在 loopback、关闭宽松的跨域访问，在重启后的首次调用前同步 RPC

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -80,10 +80,11 @@
       <description>
         <p>
           Direct-download naming and finalization are more reliable, empty RPC
-          passwords are supported, and SOCKS5 joins HTTP and HTTPS proxies in
-          covering BT HTTP traffic while peers, DHT, and UDP trackers stay
-          direct. This release also improves Windows CLI, NAT, torrent
-          associations, and Snap edge publication.
+          passwords are supported, and SOCKS5 can carry ordinary and
+          BitTorrent-associated HTTP traffic through an authenticated local
+          bridge while peers, DHT, and UDP trackers stay direct. This release
+          also improves Windows CLI, NAT, torrent associations, and Snap edge
+          publication.
         </p>
       </description>
     </release>

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -76,6 +76,17 @@
   <releases>
     <!-- Update this list on every release; Flathub linter requires the most
          recent version listed here to match the manifest's source tag. -->
+    <release version="2.0.0-beta.28" date="2026-08-28">
+      <description>
+        <p>
+          Direct-download naming and finalization are more reliable, empty RPC
+          passwords are supported, and SOCKS5 joins HTTP and HTTPS proxies in
+          covering BT HTTP traffic while peers, DHT, and UDP trackers stay
+          direct. This release also improves Windows CLI, NAT, torrent
+          associations, and Snap edge publication.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.27" date="2026-08-27">
       <description>
         <p>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.27",
+  "version": "2.0.0-beta.28",
   "packageManager": "pnpm@11.22.0+sha512.1ff870c4c6133dfd88fb2afc46dd13d47f09c9794b438c6fdb47ca98caf3bc16381ee0be93a091b8e3824cf01f889f46d7d9e20910fb0be1ab0fb5baa80dd621",
   "description": "A full-featured download manager",
   "keywords": [],


### PR DESCRIPTION
## Summary

- bump Motrix from 2.0.0-beta.27 to 2.0.0-beta.28
- add paired English and Simplified Chinese release notes
- align the README download, notes, Docker image, and Flatpak metainfo version surfaces
- document the protocol-independent BitTorrent proxy boundary

## Included changes

- recover scoped Snap edge publication from #1996
- fix native Windows CLI executable spawning from #2000
- ship the direct-download naming, RPC lifecycle, proxy bridge, NAT, empty-state, and Windows torrent-association fixes from #2002

## Validation

- 134 focused release, workflow, Flatpak, and container metadata tests
- release version contract
- Flatpak packaging contract
- file naming check
- architecture boundary check
- full Biome check
- TypeScript no-emit check
- staged diff check

After this PR passes CI and is merged to main, the protected lightweight tag v2.0.0-beta.28 will trigger the complete Build/Release and Snap publication workflows.
