### PR TITLE
chore(l10n): quote mark updates for simpchinese and english

### DIFF
--- a/src/renderer/routes/downloads/inspector/task-inspector-action-bar.test.tsx
+++ b/src/renderer/routes/downloads/inspector/task-inspector-action-bar.test.tsx
@@ -247,7 +247,7 @@ describe('TaskInspectorActionBar', () => {
       />
     )
     fireEvent.click(screen.getByRole('button', { name: /Remove/ }))
-    expect(screen.getByText(/Remove "sample"\?/)).toBeDefined()
+    expect(screen.getByText(/Remove “sample”\?/)).toBeDefined()
   })
 
   describe('Copy URL', () => {

--- a/src/renderer/routes/plugins/plugins-page.test.tsx
+++ b/src/renderer/routes/plugins/plugins-page.test.tsx
@@ -246,7 +246,7 @@ describe('PluginsPage', () => {
     fireEvent.change(screen.getByPlaceholderText('Find a plugin'), {
       target: { value: 'zzz' },
     })
-    expect(screen.getByText(/No plugins match "zzz"/)).toBeInTheDocument()
+    expect(screen.getByText(/No plugins match “zzz”/)).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Clear search' }))
     expect(screen.getByText('Test Plugin')).toBeInTheDocument()

--- a/src/shared/locales/en-US.json
+++ b/src/shared/locales/en-US.json
@@ -9,7 +9,7 @@
   "operatorAdmin": {
     "help": "Usage:\n  motrix-admin pairing pending [--json]\n  motrix-admin pairing approve <user-code> [--json]\n  motrix-admin pairing deny <user-code> [--json]\n\nThe command talks only to the running Motrix server over container loopback.",
     "errorPrefix": "motrix-admin: {{message}}",
-    "usageHint": "Run 'motrix-admin --help' for usage.",
+    "usageHint": "Run `motrix-admin --help` for usage.",
     "pending": {
       "none": "No pending pairing requests.",
       "row": "{{userCode}}  {{clientName}}  {{clientVersion}}  expires in {{ttl}}",
@@ -82,7 +82,7 @@
       "message_other": "{{count}} downloads are still active.",
       "detail": "Quitting now will pause it. Are you sure you want to quit?",
       "quitButton": "Quit",
-      "dontAskAgain": "Don't ask again"
+      "dontAskAgain": "Don’t ask again"
     }
   },
   "nav": {
@@ -133,7 +133,7 @@
         "listenPort": "Listen port",
         "diagnostics": {
           "title": "Engine diagnostics",
-          "description": "Check engine, identify the process using Motrix's RPC port, and recover safely.",
+          "description": "Check engine, identify the process using Motrix’s RPC port, and recover safely.",
           "open": "Diagnose",
           "checking": "Running engine checks…",
           "runAgain": "Run again",
@@ -164,7 +164,7 @@
             "none": "No process is blocking the RPC port.",
             "unidentified": "The process using this port could not be identified. Motrix will not terminate it.",
             "current_app": "PID {{pid}} ({{name}}) is managed by this Motrix session.",
-            "verified_orphan": "PID {{pid}} ({{name}}) matches Motrix's bundled binary and private launch parameters, so it is safe to terminate.",
+            "verified_orphan": "PID {{pid}} ({{name}}) matches Motrix’s bundled binary and private launch parameters, so it is safe to terminate.",
             "external_aria2": "PID {{pid}} ({{name}}) is aria2, but Motrix cannot verify ownership. It will not be terminated automatically.",
             "other": "PID {{pid}} ({{name}}) is not a verified Motrix aria2 process and is protected.",
             "unknown": "PID {{pid}} could not be identified and is protected."
@@ -173,7 +173,7 @@
             "ready": "Motrix can communicate with aria2."
           },
           "reason": {
-            "port_in_use": "Motrix's RPC port is occupied, so aria2 engine could not start.",
+            "port_in_use": "Motrix’s RPC port is occupied, so aria2 engine could not start.",
             "binary_unavailable": "The bundled aria2 executable is missing or unavailable.",
             "spawn_failed": "The aria2 process could not be created.",
             "rpc_unavailable": "aria2 engine started but did not accept Motrix RPC connections.",
@@ -196,13 +196,13 @@
           "recoveredOnPort": "The aria2 engine recovered on RPC port {{port}}.",
           "recoveryFailed": "Engine recovery failed. Run diagnostics again for the latest status.",
           "fallback": {
-            "available": "Motrix's default port {{port}} is available and can be restored now.",
+            "available": "Motrix’s default port {{port}} is available and can be restored now.",
             "verifiedOrphan": "A verified leftover Motrix aria2 process (PID {{pid}}) is using the default port {{port}}. Motrix can safely stop it before restoring the port.",
             "blocked": "The default port {{port}} is used by PID {{pid}} ({{name}}), but Motrix cannot verify ownership. The process will not be terminated.",
             "unidentified": "The process using default port {{port}} could not be identified. Motrix will keep using the current port.",
             "restore": "Restore Motrix default port {{port}}",
-            "restoring": "Restoring Motrix's default port {{port}}…",
-            "restoredDefault": "Motrix's default RPC port {{port}} has been restored.",
+            "restoring": "Restoring Motrix’s default port {{port}}…",
+            "restoredDefault": "Motrix’s default RPC port {{port}} has been restored.",
             "confirm": {
               "title": "Stop the leftover process and restore port {{port}}?",
               "description": "PID {{pid}} is verified as a leftover Motrix aria2 process. It will be stopped, the default port {{port}} will be saved, and aria2 will restart.",
@@ -211,7 +211,7 @@
           },
           "confirmForce": {
             "title": "Force stop the leftover aria2 process?",
-            "description": "PID {{pid}} matches Motrix's bundled binary, private RPC secret, and data paths. It will be terminated immediately, then aria2 will restart on the Motrix RPC port.",
+            "description": "PID {{pid}} matches Motrix’s bundled binary, private RPC secret, and data paths. It will be terminated immediately, then aria2 will restart on the Motrix RPC port.",
             "action": "Force stop & recover"
           }
         }
@@ -505,7 +505,7 @@
         "noTasks": "No downloads yet",
         "noTasksCta": "Press + to add one",
         "noMatchFilter": "No tasks match this filter",
-        "noMatchSearch": "No tasks match \"{{query}}\"",
+        "noMatchSearch": "No tasks match “{{query}}”",
         "clearSearch": "Clear search",
         "unavailable": "Tasks unavailable",
         "motion": {
@@ -694,7 +694,7 @@
           "invalidLines_one": "Skipped {{count}} invalid line",
           "invalidLines_other": "Skipped {{count}} invalid lines",
           "editPlaceholder": "One tracker URL per line. http(s)/udp/ws(s) only.",
-          "editHint": "These trackers replace the task's effective bt-tracker list. Announce-list entries from the .torrent are unaffected."
+          "editHint": "These trackers replace the task’s effective bt-tracker list. Announce-list entries from the .torrent are unaffected."
         },
         "multi": {
           "totals": "Totals",
@@ -727,7 +727,7 @@
         "retry": "Retry",
         "openFolder": "Open folder",
         "copyUrl": "Copy URL",
-        "copyUrlFailed": "Copy failed: could not load the task's link details. Try again.",
+        "copyUrlFailed": "Copy failed: could not load the task’s link details. Try again.",
         "selectFiles": "Select files",
         "remove": "Remove",
         "removeConfirmWithFiles": "Also delete the downloaded file(s) from disk",
@@ -746,7 +746,7 @@
         "removeTooltipBatch": "Remove {{n}} of {{total}} selected",
         "removeWithFilesShift": "Hold Shift to also delete files",
         "removeFilesEstimate": "Will delete {{bytes}} from disk",
-        "removeSingleTitle": "Remove \"{{name}}\"?",
+        "removeSingleTitle": "Remove “{{name}}”?",
         "removeAll_paused_Title": "Remove {{count}} paused tasks?",
         "removeAll_seeding_Title": "Remove {{count}} seeding tasks?",
         "removeAll_completed_Title": "Remove {{count}} completed tasks?",
@@ -850,7 +850,7 @@
     },
     "remove": {
       "title": "Remove task?",
-      "description": "'{{name}}' will be removed from the download list.",
+      "description": "“{{name}}” will be removed from the download list.",
       "deleteFilesLabel": "Delete downloaded files",
       "confirm": "Remove",
       "cancel": "Cancel",
@@ -859,7 +859,7 @@
     },
     "recovery": {
       "toast": "Recovered {{count}} interrupted task(s). Click to review.",
-      "finalizeRenameFailed": "Failed to rename file. The download file remains with '.motrix' suffix.",
+      "finalizeRenameFailed": "Failed to rename file. The download file remains with .motrix suffix.",
       "reseedFailed": "Download complete, but seeding failed to start.",
       "metaMissing": "Torrent metadata is missing. Cannot start seeding.",
       "startup": {
@@ -872,7 +872,7 @@
         "resumeSourceChanged": "The partial file was preserved because the remote file changed since the download started.",
         "resumeRangeUnsupported": "The partial file was preserved because the server does not support safe range resume.",
         "resumeValidationFailed": "The partial file was preserved because Motrix could not verify that the remote file is unchanged.",
-        "mediaInterrupted": "This media download was interrupted by an app restart and can't be resumed. Re-add it to retry."
+        "mediaInterrupted": "This media download was interrupted by an app restart and can’t be resumed. Re-add it to retry."
       }
     },
     "error": {
@@ -1181,7 +1181,7 @@
         "split": "Split connections per file",
         "splitDesc": "Number of segments to fetch a single file with.",
         "minSplitSize": "Minimum segment size (MB)",
-        "minSplitSizeDesc": "Don't split a file smaller than this."
+        "minSplitSizeDesc": "Don’t split a file smaller than this."
       },
       "reliability": {
         "title": "Network reliability",
@@ -1418,12 +1418,12 @@
         "associationSetupRequired": "Setup required",
         "associationDefault": "Default",
         "associationNotDefault": "Not default",
-        "associationUnavailable": "Couldn't verify",
+        "associationUnavailable": "Couldn’t verify",
         "associationNotRegistered": "Not registered",
         "openWindowsSettings": "Open Windows settings",
         "defaultAssociationsLinux": "Linux file and link associations",
         "defaultAssociationsLinuxCheckingDesc": "Checking this Linux package and its current desktop associations…",
-        "defaultAssociationsLinuxUnavailableDesc": "Desktop association status isn't available from this app environment.",
+        "defaultAssociationsLinuxUnavailableDesc": "Desktop association status isn’t available from this app environment.",
         "defaultAssociationsLinuxDesc": "Motrix can set itself as the .torrent default for an installed deb or rpm package. Magnet changes take effect when you apply this dialog.",
         "defaultAssociationsLinuxAppImageDesc": "Use Desktop integration below to register or remove this AppImage safely. Motrix restores verified previous handlers before deleting its desktop entry.",
         "defaultAssociationsLinuxSandboxDesc": "This package publishes Motrix as a handler, but your desktop environment chooses the default app. Removing the package may not restore the previous default automatically.",
@@ -1443,8 +1443,8 @@
         "repairLinuxAssociations": "Repair associations",
         "viewLinuxInstructions": "View setup steps",
         "linuxActionSet": "Motrix is now the default for .torrent files.",
-        "linuxActionFallback": "Automatic setup isn't available for this package. Setup instructions were opened instead.",
-        "linuxActionFailed": "Couldn't update the Linux default. Check your desktop environment settings."
+        "linuxActionFallback": "Automatic setup isn’t available for this package. Setup instructions were opened instead.",
+        "linuxActionFailed": "Couldn’t update the Linux default. Check your desktop environment settings."
       },
       "browser": {
         "title": "Browser extensions",
@@ -1468,12 +1468,12 @@
           "title": "{{name}} wants to connect to Motrix",
           "from": "From {{browser}}",
           "allow": "Allow",
-          "deny": "Don't allow"
+          "deny": "Don’t allow"
         },
         "pairUnavailable": "This pairing request is no longer pending — retry pairing from the browser extension.",
         "trustedExtensions": "Trusted extensions",
         "trustedSummary": "{{count}} total",
-        "trustedGuidance": "If you installed a download extension other than the official Motrix one, paste the extension ID it provided here. You usually don't need this.",
+        "trustedGuidance": "If you installed a download extension other than the official Motrix one, paste the extension ID it provided here. You usually don’t need this.",
         "trustedEmpty": "Nothing here yet.",
         "headerId": "Extension ID",
         "headerBrowser": "Browser",
@@ -1555,7 +1555,7 @@
           "title": "{{name}} wants to pair with Motrix",
           "code": "Verification code: {{code}}",
           "allow": "Allow",
-          "deny": "Don't allow"
+          "deny": "Don’t allow"
         },
         "inbox": {
           "title": "Pending approvals",
@@ -1613,7 +1613,7 @@
           "fileMissing": "File does not exist at this path."
         }
       },
-      "pairResolveFailed": "Couldn't submit your decision — try again.",
+      "pairResolveFailed": "Couldn’t submit your decision — try again.",
       "appimage": {
         "title": "Desktop integration",
         "desc": "Register this Motrix AppImage with your desktop so browsers and magnet links can hand downloads to it.",
@@ -1630,8 +1630,8 @@
           "healthy": "Integrated with this desktop.",
           "notIntegrated": "Not integrated with this desktop.",
           "failedTitle": "Desktop integration incomplete",
-          "failedDetail": "Motrix couldn't register itself as the handler for its links. Browser hand-off may not work until you re-enable desktop integration.",
-          "removeBlockedDetail": "Motrix couldn't safely restore a verified previous handler, so it kept its desktop entry to avoid leaving a broken default. Choose another default app in your desktop settings, then try removing the integration again.",
+          "failedDetail": "Motrix couldn’t register itself as the handler for its links. Browser hand-off may not work until you re-enable desktop integration.",
+          "removeBlockedDetail": "Motrix couldn’t safely restore a verified previous handler, so it kept its desktop entry to avoid leaving a broken default. Choose another default app in your desktop settings, then try removing the integration again.",
           "externalManaged": "Desktop integration is provided by another Motrix install."
         },
         "movedHint": "If you move the AppImage while Motrix is closed, links may fail to launch until you start Motrix once from its new location."
@@ -1891,7 +1891,7 @@
       "byAuthor": "by {{name}}",
       "requires": "Requires Motrix {{range}}",
       "notInstalled": "Not installed",
-      "notFound": "Plugin \"{{id}}\" was not found in the registry",
+      "notFound": "Plugin “{{id}}” was not found in the registry",
       "viewOnWebsite": "View on motrix.app",
       "installPending": "Installing straight from the registry is coming soon. Until then you can review the plugin here and on the website.",
       "updated": "updated {{date}}",
@@ -1910,7 +1910,7 @@
       "updateInstalled": "Update installed.",
       "actionFailed": "The action could not be completed."
     },
-    "searchNoMatch": "No plugins match \"{{query}}\"",
+    "searchNoMatch": "No plugins match “{{query}}”",
     "clearSearch": "Clear search",
     "tone": {
       "safe": "Looks safe",
@@ -2139,7 +2139,7 @@
         "notInstalled": "FFmpeg is not installed on this system.",
         "versionMismatch": "FFmpeg {{version}} is installed.",
         "requiredByPlugin": "This plugin requires ffmpeg. Install it and try again.",
-        "optionalDegraded": "This plugin's media features will be unavailable until ffmpeg is installed."
+        "optionalDegraded": "This plugin’s media features will be unavailable until ffmpeg is installed."
       }
     }
   },
@@ -2184,7 +2184,7 @@
       "agree": "Agree & Continue",
       "quit": "Quit",
       "retry": "Retry",
-      "saveFailed": "Couldn't save your consent. Check disk space and try again."
+      "saveFailed": "Couldn’t save your consent. Check disk space and try again."
     }
   },
   "notification": {
@@ -2208,7 +2208,7 @@
     },
     "dnsFallback": {
       "title": "{{name}} retried with system DNS",
-      "body": "Motrix couldn't reach a DNS server, so it switched to system DNS for this session."
+      "body": "Motrix couldn’t reach a DNS server, so it switched to system DNS for this session."
     },
     "center": {
       "title": "Notifications",

--- a/src/shared/locales/zh-CN.json
+++ b/src/shared/locales/zh-CN.json
@@ -9,7 +9,7 @@
   "operatorAdmin": {
     "help": "用法：\n  motrix-admin pairing pending [--json]\n  motrix-admin pairing approve <配对码> [--json]\n  motrix-admin pairing deny <配对码> [--json]\n\n此命令仅通过容器内的本机回环地址与正在运行的 Motrix 服务器通信。",
     "errorPrefix": "motrix-admin：{{message}}",
-    "usageHint": "运行“motrix-admin --help”查看用法。",
+    "usageHint": "运行 `motrix-admin --help` 查看用法。",
     "pending": {
       "none": "没有待处理的配对请求。",
       "row": "{{userCode}}  {{clientName}}  {{clientVersion}}  剩余 {{ttl}}",
@@ -503,7 +503,7 @@
         "noTasks": "暂无下载任务",
         "noTasksCta": "点击 + 添加一个",
         "noMatchFilter": "没有任务匹配此筛选",
-        "noMatchSearch": "没有任务匹配 \"{{query}}\"",
+        "noMatchSearch": "没有任务匹配「{{query}}」",
         "clearSearch": "清除搜索",
         "unavailable": "任务暂不可用",
         "motion": {
@@ -735,7 +735,7 @@
         "removeTooltipBatch": "移除所选中的 {{n}} / {{total}}",
         "removeWithFilesShift": "按住 Shift 同时删除文件",
         "removeFilesEstimate": "将从磁盘删除 {{bytes}}",
-        "removeSingleTitle": "移除任务 \"{{name}}\" ？",
+        "removeSingleTitle": "移除任务「{{name}}」？",
         "removeAll_paused_Title": "移除 {{count}} 个已暂停任务？",
         "removeAll_seeding_Title": "移除 {{count}} 个做种中任务？",
         "removeAll_completed_Title": "移除 {{count}} 个已完成任务？",
@@ -800,9 +800,9 @@
       "createdPartial": "已添加 {{ok}} 个，{{failed}} 个失败",
       "duplicate": {
         "title": "此种子已经存在",
-        "active-info-hash": "“{{name}}”正在运行。aria2 无法同时运行两个内容相同的种子任务。",
-        "selection-mismatch": "“{{name}}”使用了相同保存目录，但文件选择不同。Motrix 不会覆盖它，也不会静默创建重命名副本。",
-        "existing-files": "目标位置已经存在“{{name}}”，但对应任务记录不可用。Motrix 不会覆盖这些文件。",
+        "active-info-hash": "「{{name}}」正在运行。aria2 无法同时运行两个内容相同的种子任务。",
+        "selection-mismatch": "「{{name}}」使用了相同保存目录，但文件选择不同。Motrix 不会覆盖它，也不会静默创建重命名副本。",
+        "existing-files": "目标位置已经存在「{{name}}」，但对应任务记录不可用。Motrix 不会覆盖这些文件。",
         "filesOnDisk": "种子文件",
         "showExisting": "查看已有任务",
         "createCopy": "创建独立副本"
@@ -837,7 +837,7 @@
     },
     "remove": {
       "title": "移除任务？",
-      "description": "\"{{name}}\" 将从下载列表中移除。",
+      "description": "「{{name}}」将从下载列表中移除。",
       "deleteFilesLabel": "同时删除已下载的文件",
       "confirm": "移除",
       "cancel": "取消",
@@ -1873,7 +1873,7 @@
       "byAuthor": "作者：{{name}}",
       "requires": "需要 Motrix {{range}}",
       "notInstalled": "未安装",
-      "notFound": "插件 \"{{id}}\" 不在插件注册表中",
+      "notFound": "插件「{{id}}」不在插件注册表中",
       "viewOnWebsite": "在 motrix.app 查看",
       "installPending": "从注册表直接安装即将推出，目前可先在这里或官网查看该插件的完整信息。",
       "updated": "更新于 {{date}}",
@@ -1892,7 +1892,7 @@
       "updateInstalled": "更新已安装。",
       "actionFailed": "操作未能完成。"
     },
-    "searchNoMatch": "没有与\"{{query}}\"匹配的插件",
+    "searchNoMatch": "没有与「{{query}}」匹配的插件",
     "clearSearch": "清除搜索",
     "tone": {
       "safe": "运行正常",
@@ -2154,7 +2154,7 @@
         "chinese": "简体中文"
       },
       "summary": "继续前，请阅读以下内容。",
-      "body": "Motrix 仅提供下载管理功能，不提供、存储、托管或推荐任何下载内容。您应确保通过 Motrix 获取、使用或分享的内容已获得合法授权，并遵守适用的著作权及其他法律法规。因您下载、使用或分享内容产生的责任由您自行承担。点击“同意并继续”即表示您已阅读并理解本声明。",
+      "body": "Motrix 仅提供下载管理功能，不提供、存储、托管或推荐任何下载内容。您应确保通过 Motrix 获取、使用或分享的内容已获得合法授权，并遵守适用的著作权及其他法律法规。因您下载、使用或分享内容产生的责任由您自行承担。点击「同意并继续」即表示您已阅读并理解本声明。",
       "highlights": {
         "downloadManagement": "仅提供下载管理功能",
         "authorized": "已获得合法授权",


### PR DESCRIPTION
- Change SimpChinese quotes to 「」 to align with site and TradChinese
- Use curly quotes for non-command and non-path text in English
- Fix inconsistent quote usage across translation files

## Summary / 概述

This PR updates the quotation mark styles in the English and SimpChinese translations to ensure consistency with TradChinese and standard typographical conventions.

## Related issue / 相关 Issue

N/A

## Changes / 改动

- `src/renderer/routes/downloads/inspector/task-inspector-action-bar.test.tsx`
- `src/renderer/routes/plugins/plugins-page.test.tsx`
- `src/shared/locales/en-US.json`
- `src/shared/locales/zh-CN.json`

## Validation / 验证

<!-- Check every command you ran. Add focused tests and manual checks below. -->

- [x] `pnpm run check:boundaries`
- [x] `pnpm run lint`
- [x] `pnpm exec tsc --noEmit`
- [x] Relevant automated tests / 相关自动化测试
- [x] Manual verification, if applicable / 必要的手动验证

Validation details / 验证详情：

```
$ pnpm run check:boundaries
$ node scripts/check-boundaries.mjs
[PASS] core must not import electron
[PASS] core must not import fastify
[PASS] shared must not use Node-specific APIs or globals
[PASS] renderer must not import core or main
[PASS] server must not import electron
[PASS] server must not import src/main
[PASS] production source must not reference deployment staging contracts
[PASS] add-task UI must not import transport or protocol commands (except the IPC-aware hook/dialog/form)
[PASS] web-services must not reference Electron-only command symbols

$ pnpm run lint
$ biome check .
Checked 1617 files in 1692ms. No fixes applied.

$ pnpm exec tsc --noEmit

$ pnpm run check:i18n
$ node --import tsx scripts/check-i18n.mjs
check:i18n passed: 3 locales, 1634 logical translation keys.
```

## Checklist / 检查清单

- [x] This pull request targets `main` and contains one focused change.
- [x] User-visible text is localized, and paired English/Chinese documentation stays aligned.
- [x] No credentials, private URLs, personal paths, or other sensitive information are included.
- [x] I have read and followed the [contribution guidelines](https://github.com/agalwood/Motrix/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/agalwood/Motrix/blob/main/CODE_OF_CONDUCT.md).
