### PR TITLE
fix: isolate dev data and repair tracker proxy sync

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,8 @@ pnpm install
 pnpm start
 ```
 
+By default, `pnpm start` uses a separate user-data profile next to the regular Motrix profile (normally `Motrix-dev`), so development does not modify the installed application's data. To select another directory, set `MOTRIX_USER_DATA` to its absolute path before running `pnpm start`.
+
 Create your development branch from the latest `main` and target `main` with your pull request. The legacy `master` branch only preserves the v1 codebase and is frozen; do not submit new changes to it.
 
 Branch names use `<type>/<snake_case_topic>_<YYYYMMDD>`. You may place an issue number before the topic when one is available, for example `fix/1970_conduct_links_20260826`.

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -27,6 +27,8 @@ pnpm install
 pnpm start
 ```
 
+默认情况下，`pnpm start` 会使用常规 Motrix 配置目录旁独立的用户数据目录（通常为 `Motrix-dev`），避免开发过程修改已安装应用的数据。如需使用其他目录，请在运行 `pnpm start` 前将 `MOTRIX_USER_DATA` 设为该目录的绝对路径。
+
 请从最新的 `main` 创建开发分支，并将 Pull Request 提交到 `main`。`master` 仅保留旧版 v1 代码，已经冻结；请勿向该分支提交新改动。
 
 分支名称使用 `<type>/<snake_case_topic>_<YYYYMMDD>` 格式。如果存在对应 Issue，可以在主题前加入 Issue 编号，例如 `fix/1970_conduct_links_20260826`。

--- a/src/core/tracker/tracker-http-client.ts
+++ b/src/core/tracker/tracker-http-client.ts
@@ -1,0 +1,44 @@
+import type { ProxyConfig } from '@shared/types/tracker'
+
+interface TrackerRequestInit {
+  method?: string
+  signal?: AbortSignal
+}
+
+interface TrackerResponse {
+  text(): Promise<string>
+}
+
+export interface TrackerHttpClient {
+  fetch(url: string, init: TrackerRequestInit): Promise<TrackerResponse>
+  close(): Promise<void>
+}
+
+export async function createTrackerHttpClient(
+  proxy?: ProxyConfig
+): Promise<TrackerHttpClient> {
+  if (!proxy) {
+    return {
+      fetch: (url, init) => globalThis.fetch(url, init),
+      close: async () => undefined,
+    }
+  }
+
+  // The dispatcher and fetch implementation must come from the same Undici
+  // package. Node's global fetch can bundle a different Undici major whose
+  // dispatcher handler contract is incompatible with this ProxyAgent.
+  const { fetch, ProxyAgent } = await import('undici')
+  let uri = proxy.server
+  if (proxy.username) {
+    const url = new URL(uri)
+    url.username = proxy.username
+    url.password = proxy.password ?? ''
+    uri = url.toString()
+  }
+  const dispatcher = new ProxyAgent(uri)
+
+  return {
+    fetch: (url, init) => fetch(url, { ...init, dispatcher }),
+    close: () => dispatcher.close(),
+  }
+}

--- a/src/core/tracker/tracker-prober.test.ts
+++ b/src/core/tracker/tracker-prober.test.ts
@@ -1,12 +1,41 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const undiciMock = vi.hoisted(() => {
+  const agents: Array<{
+    uri: string
+    close: ReturnType<typeof vi.fn>
+  }> = []
+
+  class ProxyAgent {
+    readonly close = vi.fn(async () => undefined)
+
+    constructor(readonly uri: string) {
+      agents.push(this)
+    }
+  }
+
+  return {
+    agents,
+    fetch: vi.fn(),
+    ProxyAgent,
+  }
+})
+
+vi.mock('undici', () => ({
+  fetch: undiciMock.fetch,
+  ProxyAgent: undiciMock.ProxyAgent,
+}))
+
 import { TrackerProber } from './tracker-prober'
 
 describe('TrackerProber', () => {
   let prober: TrackerProber
 
   beforeEach(() => {
-    prober = new TrackerProber()
     vi.restoreAllMocks()
+    undiciMock.fetch.mockReset()
+    undiciMock.agents.length = 0
+    prober = new TrackerProber()
   })
 
   it('returns empty array for empty input', async () => {
@@ -38,6 +67,43 @@ describe('TrackerProber', () => {
     expect(result).toHaveLength(1)
     expect(result[0].status).toBe('unreachable')
     expect(result[0].failCount).toBe(1)
+  })
+
+  it('uses undici fetch with an HTTP ProxyAgent and closes the agent', async () => {
+    const globalFetch = vi
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(
+        new Error('global fetch must not be used with a proxy')
+      )
+    undiciMock.fetch
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockRejectedValueOnce(new Error('tracker unavailable'))
+
+    const result = await prober.probe(
+      ['http://healthy.test/announce', 'https://unavailable.test/announce'],
+      {
+        timeoutMs: 5000,
+        proxy: { server: 'http://127.0.0.1:7890' },
+      }
+    )
+
+    expect(globalFetch).not.toHaveBeenCalled()
+    expect(undiciMock.agents).toHaveLength(1)
+    expect(undiciMock.agents[0].uri).toBe('http://127.0.0.1:7890')
+    expect(undiciMock.fetch).toHaveBeenCalledTimes(2)
+    for (const [, init] of undiciMock.fetch.mock.calls) {
+      expect(init).toEqual(
+        expect.objectContaining({
+          method: 'HEAD',
+          dispatcher: undiciMock.agents[0],
+        })
+      )
+    }
+    expect(undiciMock.agents[0].close).toHaveBeenCalledOnce()
+    expect(result.map(({ status }) => status)).toEqual([
+      'healthy',
+      'unreachable',
+    ])
   })
 
   it('detects protocol from URL scheme', async () => {

--- a/src/core/tracker/tracker-prober.ts
+++ b/src/core/tracker/tracker-prober.ts
@@ -4,6 +4,10 @@ import type {
   TrackerProtocol,
 } from '@shared/types/tracker'
 import { trackerLogger } from './logger'
+import {
+  createTrackerHttpClient,
+  type TrackerHttpClient,
+} from './tracker-http-client'
 
 const log = trackerLogger('prober')
 
@@ -28,9 +32,15 @@ export class TrackerProber {
       },
       'probe start'
     )
-    const results = await Promise.allSettled(
-      urls.map((url) => this.probeOne(url, opts))
-    )
+    const httpClient = await createTrackerHttpClient(opts.proxy)
+    let results: PromiseSettledResult<number>[]
+    try {
+      results = await Promise.allSettled(
+        urls.map((url) => this.probeOne(url, opts, httpClient))
+      )
+    } finally {
+      await httpClient.close()
+    }
 
     const mapped = results.map((r, i) => {
       const url = urls[i]
@@ -76,7 +86,11 @@ export class TrackerProber {
     return mapped
   }
 
-  private async probeOne(url: string, opts: ProbeOptions): Promise<number> {
+  private async probeOne(
+    url: string,
+    opts: ProbeOptions,
+    httpClient: TrackerHttpClient
+  ): Promise<number> {
     const protocol = this.detectProtocol(url)
     const start = Date.now()
 
@@ -84,13 +98,9 @@ export class TrackerProber {
       return this.probeUdp(url, opts.timeoutMs)
     }
 
-    const dispatcher = opts.proxy
-      ? await this.buildProxyAgent(opts.proxy)
-      : undefined
-    await fetch(url, {
+    await httpClient.fetch(url, {
       method: 'HEAD',
       signal: AbortSignal.timeout(opts.timeoutMs),
-      ...(dispatcher ? { dispatcher } : {}),
     })
     return Date.now() - start
   }
@@ -134,23 +144,5 @@ export class TrackerProber {
     if (url.startsWith('ws://')) return 'ws'
     if (url.startsWith('https://')) return 'https'
     return 'http'
-  }
-
-  private async buildProxyAgent(
-    proxy: ProxyConfig
-  ): Promise<import('undici').ProxyAgent | undefined> {
-    try {
-      const { ProxyAgent } = await import('undici')
-      let uri = proxy.server
-      if (proxy.username) {
-        const u = new URL(uri)
-        u.username = proxy.username
-        u.password = proxy.password ?? ''
-        uri = u.toString()
-      }
-      return new ProxyAgent(uri)
-    } catch {
-      return undefined
-    }
   }
 }

--- a/src/core/tracker/tracker-syncer.test.ts
+++ b/src/core/tracker/tracker-syncer.test.ts
@@ -1,5 +1,32 @@
 import type { TrackerSource } from '@shared/types/tracker'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const undiciMock = vi.hoisted(() => {
+  const agents: Array<{
+    uri: string
+    close: ReturnType<typeof vi.fn>
+  }> = []
+
+  class ProxyAgent {
+    readonly close = vi.fn(async () => undefined)
+
+    constructor(readonly uri: string) {
+      agents.push(this)
+    }
+  }
+
+  return {
+    agents,
+    fetch: vi.fn(),
+    ProxyAgent,
+  }
+})
+
+vi.mock('undici', () => ({
+  fetch: undiciMock.fetch,
+  ProxyAgent: undiciMock.ProxyAgent,
+}))
+
 import { TrackerSyncer } from './tracker-syncer'
 
 const source = (id: string, url: string): TrackerSource => ({
@@ -15,8 +42,10 @@ describe('TrackerSyncer', () => {
   let syncer: TrackerSyncer
 
   beforeEach(() => {
-    syncer = new TrackerSyncer()
     vi.restoreAllMocks()
+    undiciMock.fetch.mockReset()
+    undiciMock.agents.length = 0
+    syncer = new TrackerSyncer()
   })
 
   it('returns empty result for empty sources', async () => {
@@ -61,6 +90,39 @@ describe('TrackerSyncer', () => {
     expect(result.sourceStatus.good.ok).toBe(true)
     expect(result.sourceStatus.bad.ok).toBe(false)
     expect(result.sourceStatus.bad.error).toBe('network error')
+  })
+
+  it('uses undici fetch with an HTTP ProxyAgent and closes the agent', async () => {
+    const globalFetch = vi
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(
+        new Error('global fetch must not be used with a proxy')
+      )
+    undiciMock.fetch
+      .mockResolvedValueOnce(new Response('udp://proxied.test:80/announce\n'))
+      .mockRejectedValueOnce(new Error('source unavailable'))
+
+    const result = await syncer.fetch(
+      [
+        source('proxied', 'http://lists.test/trackers.txt'),
+        source('failed', 'http://lists.test/unavailable.txt'),
+      ],
+      { server: 'http://127.0.0.1:7890' }
+    )
+
+    expect(globalFetch).not.toHaveBeenCalled()
+    expect(undiciMock.agents).toHaveLength(1)
+    expect(undiciMock.agents[0].uri).toBe('http://127.0.0.1:7890')
+    expect(undiciMock.fetch).toHaveBeenCalledTimes(2)
+    for (const [, init] of undiciMock.fetch.mock.calls) {
+      expect(init).toEqual(
+        expect.objectContaining({ dispatcher: undiciMock.agents[0] })
+      )
+    }
+    expect(undiciMock.agents[0].close).toHaveBeenCalledOnce()
+    expect(result.trackers).toEqual(['udp://proxied.test:80/announce'])
+    expect(result.sourceStatus.proxied.ok).toBe(true)
+    expect(result.sourceStatus.failed.ok).toBe(false)
   })
 
   it('populates SourceFetchStatus.urls with per-source URLs on success', async () => {

--- a/src/core/tracker/tracker-syncer.ts
+++ b/src/core/tracker/tracker-syncer.ts
@@ -5,6 +5,7 @@ import type {
   TrackerSource,
 } from '@shared/types/tracker'
 import { trackerLogger } from './logger'
+import { createTrackerHttpClient } from './tracker-http-client'
 
 const log = trackerLogger('syncer')
 
@@ -40,32 +41,40 @@ export class TrackerSyncer {
       { enabledSources: enabled.length, proxy: Boolean(proxy) },
       'fetch start'
     )
-    const dispatcher = proxy ? await this.buildProxyAgent(proxy) : undefined
+    const httpClient = await createTrackerHttpClient(proxy)
     const now = Date.now()
 
-    const entries = await Promise.allSettled(
-      enabled.map(async (src) => {
-        const start = Date.now()
-        const res = await fetch(`${src.url}?t=${now}`, {
-          signal: AbortSignal.timeout(30_000),
-          ...(dispatcher ? { dispatcher } : {}),
+    let entries: PromiseSettledResult<{
+      id: string
+      urls: string[]
+      elapsedMs: number
+    }>[]
+    try {
+      entries = await Promise.allSettled(
+        enabled.map(async (src) => {
+          const start = Date.now()
+          const res = await httpClient.fetch(`${src.url}?t=${now}`, {
+            signal: AbortSignal.timeout(30_000),
+          })
+          const text = await res.text()
+          const urls = [
+            ...new Set(
+              text
+                .split(/\r?\n/)
+                .map((line) => line.trim())
+                .filter(isValidTrackerLine)
+            ),
+          ]
+          return {
+            id: src.id,
+            urls,
+            elapsedMs: Date.now() - start,
+          }
         })
-        const text = await res.text()
-        const urls = [
-          ...new Set(
-            text
-              .split(/\r?\n/)
-              .map((line) => line.trim())
-              .filter(isValidTrackerLine)
-          ),
-        ]
-        return {
-          id: src.id,
-          urls,
-          elapsedMs: Date.now() - start,
-        }
-      })
-    )
+      )
+    } finally {
+      await httpClient.close()
+    }
 
     const seen = new Set<string>()
     const sourceStatus: Record<string, SourceFetchStatus> = {}
@@ -99,7 +108,10 @@ export class TrackerSyncer {
           elapsedMs: 0,
           error,
         }
-        log.warn({ id: src.id, url: src.url, error }, 'source fetch failed')
+        log.warn(
+          { id: src.id, url: src.url, error, err: entry.reason },
+          'source fetch failed'
+        )
       }
     }
 
@@ -115,23 +127,5 @@ export class TrackerSyncer {
     )
 
     return { trackers: [...seen], sourceStatus }
-  }
-
-  private async buildProxyAgent(
-    proxy: ProxyConfig
-  ): Promise<import('undici').ProxyAgent | undefined> {
-    try {
-      const { ProxyAgent } = await import('undici')
-      let uri = proxy.server
-      if (proxy.username) {
-        const url = new URL(uri)
-        url.username = proxy.username
-        url.password = proxy.password ?? ''
-        uri = url.toString()
-      }
-      return new ProxyAgent(uri)
-    } catch {
-      return undefined
-    }
   }
 }

--- a/src/main/platform/services.test.ts
+++ b/src/main/platform/services.test.ts
@@ -1,43 +1,159 @@
 import { RunHost } from '@shared/platform/services'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const paths: Record<string, string> = { userData: '/fake/userData' }
+const originalResourcesPath = Object.getOwnPropertyDescriptor(
+  process,
+  'resourcesPath'
+)
+
+const mocks = vi.hoisted(() => {
+  const state = {
+    isPackaged: false,
+    paths: { userData: '/fake/Motrix' } as Record<string, string>,
+    operations: [] as string[],
+  }
+
+  return {
+    state,
+    mkdirSync: vi.fn((directory: string) => {
+      state.operations.push(`mkdir:${directory}`)
+    }),
+    getPath: vi.fn((name: string) => state.paths[name] ?? `/fake/${name}`),
+    setPath: vi.fn((name: string, value: string) => {
+      state.operations.push(`setPath:${name}:${value}`)
+      state.paths[name] = value
+    }),
+  }
+})
+
+vi.mock('node:fs', () => ({
+  default: { mkdirSync: mocks.mkdirSync },
+  mkdirSync: mocks.mkdirSync,
+}))
 
 vi.mock('electron', () => ({
   app: {
-    getPath: (name: string) => paths[name] ?? `/fake/${name}`,
-    setPath: (name: string, value: string) => {
-      paths[name] = value
+    get isPackaged() {
+      return mocks.state.isPackaged
     },
-    isPackaged: false,
+    getPath: mocks.getPath,
+    setPath: mocks.setPath,
   },
 }))
 
+import { createElectronPlatformServices } from './services'
+
 describe('createElectronPlatformServices', () => {
   beforeEach(() => {
-    vi.resetModules()
-    paths.userData = '/fake/userData'
+    vi.clearAllMocks()
+    mocks.state.isPackaged = false
+    mocks.state.paths = { userData: '/fake/Motrix' }
+    mocks.state.operations = []
+    Object.defineProperty(process, 'resourcesPath', {
+      configurable: true,
+      value: '/fake/resources',
+    })
     delete process.env.MOTRIX_USER_DATA
   })
 
   afterEach(() => {
     delete process.env.MOTRIX_USER_DATA
+    if (originalResourcesPath) {
+      Object.defineProperty(process, 'resourcesPath', originalResourcesPath)
+    } else {
+      Reflect.deleteProperty(process, 'resourcesPath')
+    }
   })
 
-  it('resolves paths from Electron app API in dev', async () => {
-    const { createElectronPlatformServices } = await import('./services')
+  it('uses a sibling development profile by default', () => {
     const svc = createElectronPlatformServices()
+
     expect(svc.host).toBe(RunHost.Electron)
-    expect(svc.userDataDir).toBe('/fake/userData')
+    expect(svc.userDataDir).toBe('/fake/Motrix-dev')
     expect(svc.isDev).toBe(true)
     expect(svc.aria2BinaryPath.endsWith('aria2c')).toBe(true)
     expect(svc.extraResourceDir).toMatch(/extra$/)
   })
 
-  it('honors MOTRIX_USER_DATA env override', async () => {
-    process.env.MOTRIX_USER_DATA = '/tmp/motrix-e2e-xyz'
-    const { createElectronPlatformServices } = await import('./services')
+  it('gives MOTRIX_USER_DATA priority in development', () => {
+    process.env.MOTRIX_USER_DATA = '/tmp/motrix-custom'
+
     const svc = createElectronPlatformServices()
-    expect(svc.userDataDir).toBe('/tmp/motrix-e2e-xyz')
+
+    expect(svc.userDataDir).toBe('/tmp/motrix-custom')
+  })
+
+  it('ignores an empty MOTRIX_USER_DATA value', () => {
+    process.env.MOTRIX_USER_DATA = ''
+
+    const svc = createElectronPlatformServices()
+
+    expect(svc.userDataDir).toBe('/fake/Motrix-dev')
+  })
+
+  it('keeps the Electron user data directory unchanged when packaged', () => {
+    mocks.state.isPackaged = true
+
+    const svc = createElectronPlatformServices()
+
+    expect(svc.userDataDir).toBe('/fake/Motrix')
+    expect(svc.isDev).toBe(false)
+    expect(mocks.mkdirSync).not.toHaveBeenCalled()
+    expect(mocks.setPath).not.toHaveBeenCalled()
+  })
+
+  it('honors MOTRIX_USER_DATA when packaged', () => {
+    mocks.state.isPackaged = true
+    process.env.MOTRIX_USER_DATA = '/tmp/motrix-packaged'
+
+    const svc = createElectronPlatformServices()
+
+    expect(svc.userDataDir).toBe('/tmp/motrix-packaged')
+    expect(mocks.mkdirSync).toHaveBeenCalledWith('/tmp/motrix-packaged', {
+      recursive: true,
+    })
+    expect(mocks.setPath).toHaveBeenNthCalledWith(
+      1,
+      'userData',
+      '/tmp/motrix-packaged'
+    )
+    expect(mocks.setPath).toHaveBeenNthCalledWith(
+      2,
+      'sessionData',
+      '/tmp/motrix-packaged'
+    )
+  })
+
+  it('rejects a relative MOTRIX_USER_DATA before creating it', () => {
+    process.env.MOTRIX_USER_DATA = 'relative/profile'
+
+    expect(() => createElectronPlatformServices()).toThrow(
+      'MOTRIX_USER_DATA must be an absolute path'
+    )
+    expect(mocks.mkdirSync).not.toHaveBeenCalled()
+    expect(mocks.setPath).not.toHaveBeenCalled()
+  })
+
+  it('creates the selected directory before setting both Electron paths', () => {
+    createElectronPlatformServices()
+
+    expect(mocks.mkdirSync).toHaveBeenCalledWith('/fake/Motrix-dev', {
+      recursive: true,
+    })
+    expect(mocks.setPath).toHaveBeenNthCalledWith(
+      1,
+      'userData',
+      '/fake/Motrix-dev'
+    )
+    expect(mocks.setPath).toHaveBeenNthCalledWith(
+      2,
+      'sessionData',
+      '/fake/Motrix-dev'
+    )
+    expect(mocks.state.operations).toEqual([
+      'mkdir:/fake/Motrix-dev',
+      'setPath:userData:/fake/Motrix-dev',
+      'setPath:sessionData:/fake/Motrix-dev',
+    ])
   })
 })

--- a/src/main/platform/services.ts
+++ b/src/main/platform/services.ts
@@ -1,3 +1,4 @@
+import { mkdirSync } from 'node:fs'
 import path from 'node:path'
 import { aria2BinaryName } from '@shared/platform/aria2'
 import { type PlatformServices, RunHost } from '@shared/platform/services'
@@ -5,14 +6,21 @@ import { app } from 'electron'
 
 export function createElectronPlatformServices(): PlatformServices {
   const isDev = !app.isPackaged
-
-  // Honor MOTRIX_USER_DATA so e2e harnesses (and any tooling that needs
-  // hermetic state) can redirect settings/db/logs to a tmp dir without
-  // polluting the developer's real userData. Must run before reading
-  // userData so the override path is what's returned below.
   const userDataOverride = process.env.MOTRIX_USER_DATA
-  if (userDataOverride) {
-    app.setPath('userData', userDataOverride)
+  const defaultUserDataDir = app.getPath('userData')
+  const userDataDir =
+    userDataOverride ||
+    (isDev ? `${defaultUserDataDir}-dev` : defaultUserDataDir)
+
+  // Resolve this before any persistent service or the single-instance lock.
+  // Electron requires an existing absolute directory for app.setPath().
+  if (userDataOverride || isDev) {
+    if (!path.isAbsolute(userDataDir)) {
+      throw new Error('MOTRIX_USER_DATA must be an absolute path')
+    }
+    mkdirSync(userDataDir, { recursive: true })
+    app.setPath('userData', userDataDir)
+    app.setPath('sessionData', userDataDir)
   }
 
   const projectRoot = isDev ? path.resolve(__dirname, '..', '..') : ''
@@ -22,7 +30,7 @@ export function createElectronPlatformServices(): PlatformServices {
 
   return {
     host: RunHost.Electron,
-    userDataDir: app.getPath('userData'),
+    userDataDir,
     extraResourceDir: extraDir,
     aria2BinaryPath: path.join(
       extraDir,


### PR DESCRIPTION
## Summary

- isolate unpackaged Electron user data and session data in a sibling development profile
- allow an absolute `MOTRIX_USER_DATA` override and document the development behavior
- use the same Undici implementation for tracker proxy fetches and proxy agents
- cover both tracker source synchronization and health probes, reusing and closing each batch agent
- preserve the underlying fetch error in tracker logs for future diagnosis

## Why

Development launches currently share persistent state with an installed Motrix application. Tracker synchronization also fails immediately through an HTTP proxy because Electron's global fetch and the project's Undici ProxyAgent use incompatible dispatcher contracts.

## Verification

- `pnpm exec vitest run src/main/platform/services.test.ts`
- `pnpm exec vitest run src/core/tracker/tracker-syncer.test.ts src/core/tracker/tracker-prober.test.ts`
- `pnpm run check:file-names`
- `pnpm run check:boundaries`
- `pnpm run lint`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `pnpm build:server`
- verified tracker synchronization through a local recording HTTP proxy

Closes #1977
Closes #1979
