### PR TITLE
fix(windows): avoid shortcut creation on startup

### DIFF
--- a/src/main/plugin/capability-host.test.ts
+++ b/src/main/plugin/capability-host.test.ts
@@ -87,6 +87,7 @@ describe('createElectronCapabilityHost', () => {
 
   beforeEach(() => {
     db = makeDb()
+    MockNotification.isSupported.mockClear()
   })
 
   afterEach(() => {
@@ -107,6 +108,22 @@ describe('createElectronCapabilityHost', () => {
     })
 
     expect(host.http).toBeInstanceOf(HttpCapabilityHost)
+  })
+
+  it('does not initialize native notification support while wiring capabilities', async () => {
+    await createElectronCapabilityHost({
+      appVersion: '2.0.0',
+      hostLanguage: 'en-US',
+      db,
+      userDataDir: tmpdir(),
+      pluginsDir: path.join(tmpdir(), 'plugins'),
+      settingsManager: makeSettingsManager(),
+      configReader: () => ({}),
+      secretFieldsFor: () => new Set(),
+      manifestCommandIdsFor: () => new Set(),
+    })
+
+    expect(MockNotification.isSupported).not.toHaveBeenCalled()
   })
 
   it('returns a CapabilityHost with a functional storage host', async () => {

--- a/src/main/plugin/notify-electron.test.ts
+++ b/src/main/plugin/notify-electron.test.ts
@@ -85,13 +85,27 @@ function clearInstances(): void {
 describe('ElectronNotifyHost', () => {
   beforeEach(() => {
     clearInstances()
+    FakeNotification.isSupported.mockClear()
     FakeNotification.isSupported.mockReturnValue(true)
   })
 
-  // Test 1: available === true when isSupported returns true.
-  it('available === true when Notification.isSupported() is true', () => {
+  // Constructing the host must not initialize Electron's native notification
+  // presenter. Electron 43 performs Windows shortcut registration as a side
+  // effect of Notification.isSupported().
+  it('does not query notification support during construction', () => {
+    new ElectronNotifyHost()
+
+    expect(FakeNotification.isSupported).not.toHaveBeenCalled()
+  })
+
+  // Test 1: support detection remains available on demand and is evaluated
+  // only once, matching the previous snapshot semantics.
+  it('resolves and caches availability lazily', () => {
     const host = new ElectronNotifyHost()
+
     expect(host.available).toBe(true)
+    expect(host.available).toBe(true)
+    expect(FakeNotification.isSupported).toHaveBeenCalledOnce()
   })
 
   // Test 2: show() constructs a Notification with the provided title/body.
@@ -153,14 +167,16 @@ describe('ElectronNotifyHost', () => {
     expect(first.closed).toBe(true)
   })
 
-  // Test 7: available === false — show() throws NotifyCapabilityError.
-  it('throws when available is false', async () => {
+  // Test 7: unsupported runtimes still fail when a notification is requested.
+  it('checks support on first use and throws when unavailable', async () => {
+    FakeNotification.isSupported.mockReturnValue(false)
     const host = new ElectronNotifyHost()
-    // Manually override available to simulate unsupported platform.
-    ;(host as unknown as { available: boolean }).available = false
 
     await expect(
       host.show('plugin-a', { title: 'Hi', body: 'x' })
     ).rejects.toMatchObject({ code: 'plugin.capability.unavailable' })
+    expect(host.available).toBe(false)
+    expect(FakeNotification.isSupported).toHaveBeenCalledOnce()
+    expect(instances).toHaveLength(0)
   })
 })

--- a/src/main/plugin/notify-electron.ts
+++ b/src/main/plugin/notify-electron.ts
@@ -12,9 +12,18 @@ import {
 import { Notification } from 'electron'
 
 export class ElectronNotifyHost implements NotifyCapabilityHost {
-  readonly available: boolean = Notification.isSupported()
+  private notificationSupported: boolean | undefined
 
   private readonly active = new Map<string, Notification>()
+
+  get available(): boolean {
+    // Keep this check lazy. On Windows, Electron 43 initializes its toast
+    // activator from Notification.isSupported(), which creates or rewrites a
+    // per-user Start Menu shortcut. Constructing the capability host happens
+    // on every app launch, even when no plugin requests a notification.
+    this.notificationSupported ??= Notification.isSupported()
+    return this.notificationSupported
+  }
 
   async show(pluginId: string, opts: NotifyShowOpts): Promise<void> {
     if (!this.available) {


### PR DESCRIPTION
## Summary / 概述

Prevent routine desktop startup from initializing Electron native notification support. Electron 43 registers or repairs a per-user Start Menu shortcut when `Notification.isSupported()` initializes the Windows toast presenter, so probing notification capability while wiring the plugin host recreated `Motrix.lnk` on every launch.

## Related issue / 相关 Issue

Closes #2011

## Changes / 改动

- Resolve and cache plugin notification availability only when the capability is first used.
- Verify constructing `ElectronNotifyHost` does not query native notification support.
- Verify the complete Electron capability host startup path does not initialize notifications.
- Preserve unavailable-runtime errors and notification deduplication behavior.

## Validation / 验证

- [x] `pnpm run check:boundaries`
- [x] `pnpm run lint`
- [x] `pnpm exec tsc --noEmit`
- [x] Relevant automated tests / 相关自动化测试
- [ ] Manual verification, if applicable / 必要的手动验证

Validation details / 验证详情：

- `pnpm exec vitest run src/main/plugin/notify-electron.test.ts src/main/plugin/capability-host.test.ts src/main/notifications/os-bridge.test.ts` — 3 files, 56 tests passed.
- `pnpm run check:boundaries` — passed.
- `pnpm run lint` — 1,627 files checked, no fixes required.
- `pnpm exec tsc --noEmit` — passed.
- Windows 11 runtime verification was not available on the development host.

## Checklist / 检查清单

- [x] This pull request targets `main` and contains one focused change.
- [x] User-visible text is localized, and paired English/Chinese documentation stays aligned. (Not applicable: no user-visible text or documentation changed.)
- [x] No credentials, private URLs, personal paths, or other sensitive information are included.
- [x] I have read and followed the [contribution guidelines](https://github.com/agalwood/Motrix/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/agalwood/Motrix/blob/main/CODE_OF_CONDUCT.md).