### PR TITLE
fix(renderer): stabilize marquee selection rendering

### DIFF
--- a/src/renderer/components/desktop-kit/marquee-selection/marquee-overlay.test.tsx
+++ b/src/renderer/components/desktop-kit/marquee-selection/marquee-overlay.test.tsx
@@ -88,14 +88,18 @@ afterEach(() => {
 })
 
 describe('MarqueeOverlay', () => {
-  it('keeps one box node mounted and updates its transform imperatively', () => {
+  it('keeps one box node mounted and updates its geometry imperatively', () => {
     const { container } = createMockContainer()
     renderOverlay(container)
     const initialBox = screen.getByTestId('marquee-box')
 
     expect(initialBox.style.opacity).toBe('0')
-    expect(initialBox.style.transform).toContain('scale(0.001, 0.001)')
-    expect(initialBox.style.willChange).toBe('')
+    expect(initialBox.getAttribute('x')).toBe('0')
+    expect(initialBox.getAttribute('y')).toBe('0')
+    expect(initialBox.getAttribute('width')).toBe('0')
+    expect(initialBox.getAttribute('height')).toBe('0')
+    expect(initialBox.style.transform).toBe('')
+    expect(initialBox.hasAttribute('vector-effect')).toBe(false)
     const overlay = initialBox.closest('svg')
     expect(overlay?.classList.contains('inset-0')).toBe(true)
     expect(overlay?.classList.contains('size-full')).toBe(true)
@@ -104,17 +108,82 @@ describe('MarqueeOverlay', () => {
     fireEvent.mouseMove(window, { clientX: 140, clientY: 220 })
     flushAnimationFrames()
 
-    const firstTransform = initialBox.style.transform
     expect(screen.getByTestId('marquee-box')).toBe(initialBox)
-    expect(firstTransform).toContain('translate3d(100px, 120px, 0)')
+    expect(initialBox.getAttribute('x')).toBe('100')
+    expect(initialBox.getAttribute('y')).toBe('120')
+    expect(initialBox.getAttribute('width')).toBe('40')
+    expect(initialBox.getAttribute('height')).toBe('100')
     expect(initialBox.style.opacity).toBe('1')
-    expect(initialBox.style.willChange).toBe('transform')
 
     fireEvent.mouseMove(window, { clientX: 180, clientY: 260 })
     flushAnimationFrames()
 
     expect(screen.getByTestId('marquee-box')).toBe(initialBox)
-    expect(initialBox.style.transform).not.toBe(firstTransform)
+    expect(initialBox.getAttribute('width')).toBe('80')
+    expect(initialBox.getAttribute('height')).toBe('140')
+  })
+
+  it('renders a horizontal drag without a degenerate scale transform', () => {
+    const { container } = createMockContainer()
+    const { onSelectionChange } = renderOverlay(container)
+
+    fireEvent.mouseDown(container, { clientX: 100, clientY: 120 })
+    fireEvent.mouseMove(window, { clientX: 180, clientY: 120 })
+    flushAnimationFrames()
+
+    const box = screen.getByTestId('marquee-box')
+    expect(box.getAttribute('x')).toBe('100')
+    expect(box.getAttribute('y')).toBe('120')
+    expect(box.getAttribute('width')).toBe('80')
+    expect(box.getAttribute('height')).toBe('0.001')
+    expect(box.style.transform).toBe('')
+    expect(onSelectionChange).toHaveBeenCalledWith(3, 3)
+  })
+
+  it('renders a vertical drag without a degenerate scale transform', () => {
+    const { container } = createMockContainer()
+    const { onSelectionChange } = renderOverlay(container)
+
+    fireEvent.mouseDown(container, { clientX: 100, clientY: 120 })
+    fireEvent.mouseMove(window, { clientX: 100, clientY: 220 })
+    flushAnimationFrames()
+
+    const box = screen.getByTestId('marquee-box')
+    expect(box.getAttribute('x')).toBe('100')
+    expect(box.getAttribute('y')).toBe('120')
+    expect(box.getAttribute('width')).toBe('0.001')
+    expect(box.getAttribute('height')).toBe('100')
+    expect(box.style.transform).toBe('')
+    expect(onSelectionChange).toHaveBeenCalledWith(3, 5)
+  })
+
+  it('preserves a subpixel axis without scaling the box', () => {
+    const { container } = createMockContainer()
+    renderOverlay(container)
+
+    fireEvent.mouseDown(container, { clientX: 100.25, clientY: 120.25 })
+    fireEvent.mouseMove(window, { clientX: 180.75, clientY: 120.5 })
+    flushAnimationFrames()
+
+    const box = screen.getByTestId('marquee-box')
+    expect(box.getAttribute('x')).toBe('100.25')
+    expect(box.getAttribute('y')).toBe('120.25')
+    expect(box.getAttribute('width')).toBe('80.5')
+    expect(box.getAttribute('height')).toBe('0.25')
+    expect(box.style.transform).toBe('')
+  })
+
+  it('uses theme-aware neutral colors for the selection box', () => {
+    const { container } = createMockContainer()
+    renderOverlay(container)
+
+    const box = screen.getByTestId('marquee-box')
+    expect(box.style.fill).toContain('var(--color-ring')
+    expect(box.style.fill).toContain('12%')
+    expect(box.style.stroke).toContain('var(--color-ring')
+    expect(box.style.stroke).toContain('78%')
+    expect(box.style.stroke).toContain('var(--color-foreground')
+    expect(box.style.strokeWidth).toBe('1')
   })
 
   it('updates drag geometry without a React update commit', () => {
@@ -193,11 +262,13 @@ describe('MarqueeOverlay', () => {
 
     expect(onSelectionChange).toHaveBeenCalledWith(3, 5)
     expect(onSelectionEnd).toHaveBeenCalledOnce()
-    expect(screen.getByTestId('marquee-box').style.opacity).toBe('0')
-    expect(screen.getByTestId('marquee-box').style.transform).toContain(
-      'scale(0.001, 0.001)'
-    )
-    expect(screen.getByTestId('marquee-box').style.willChange).toBe('')
+    const box = screen.getByTestId('marquee-box')
+    expect(box.style.opacity).toBe('0')
+    expect(box.getAttribute('x')).toBe('0')
+    expect(box.getAttribute('y')).toBe('0')
+    expect(box.getAttribute('width')).toBe('0')
+    expect(box.getAttribute('height')).toBe('0')
+    expect(box.style.transform).toBe('')
   })
 
   it('cancels a queued frame on mouseup', () => {

--- a/src/renderer/components/desktop-kit/marquee-selection/marquee-overlay.tsx
+++ b/src/renderer/components/desktop-kit/marquee-selection/marquee-overlay.tsx
@@ -3,10 +3,19 @@ import type { DragState, MarqueeOverlayProps } from './types'
 import { useAutoScroll } from './use-auto-scroll'
 
 const Z_MARQUEE = 10
-const MIN_RECT_SIZE = 0.001
+const MIN_VISIBLE_RECT_SIZE = 0.001
 
-function rectTransform(x: number, y: number, width: number, height: number) {
-  return `translate3d(${x}px, ${y}px, 0) scale(${width}, ${height})`
+function setRectGeometry(
+  box: SVGRectElement,
+  x: number,
+  y: number,
+  width: number,
+  height: number
+) {
+  box.setAttribute('x', String(x))
+  box.setAttribute('y', String(y))
+  box.setAttribute('width', String(width))
+  box.setAttribute('height', String(height))
 }
 
 export function MarqueeOverlay(props: MarqueeOverlayProps) {
@@ -57,8 +66,7 @@ export function MarqueeOverlay(props: MarqueeOverlayProps) {
     if (!box) return
 
     box.style.opacity = '0'
-    box.style.transform = rectTransform(0, 0, MIN_RECT_SIZE, MIN_RECT_SIZE)
-    box.style.willChange = ''
+    setRectGeometry(box, 0, 0, 0, 0)
   }, [])
 
   const paintDragFrame = useCallback(() => {
@@ -73,10 +81,10 @@ export function MarqueeOverlay(props: MarqueeOverlayProps) {
     const maxY = Math.max(adjustedOriginY, drag.currentY)
     const minX = Math.min(drag.originX, drag.currentX)
     const maxX = Math.max(drag.originX, drag.currentX)
-    const width = Math.max(maxX - minX, MIN_RECT_SIZE)
-    const height = Math.max(maxY - minY, MIN_RECT_SIZE)
+    const width = Math.max(maxX - minX, MIN_VISIBLE_RECT_SIZE)
+    const height = Math.max(maxY - minY, MIN_VISIBLE_RECT_SIZE)
 
-    box.style.transform = rectTransform(minX, minY, width, height)
+    setRectGeometry(box, minX, minY, width, height)
     box.style.opacity = '1'
 
     const range = computeIndices(
@@ -148,9 +156,6 @@ export function MarqueeOverlay(props: MarqueeOverlayProps) {
         const dy = drag.currentY - drag.originY
         if (Math.sqrt(dx * dx + dy * dy) < minDragDistance) return
         drag.active = true
-        if (boxRef.current) {
-          boxRef.current.style.willChange = 'transform'
-        }
       }
 
       updateAutoScrollPointer(event.clientY, drag.containerRect)
@@ -257,17 +262,14 @@ export function MarqueeOverlay(props: MarqueeOverlayProps) {
         data-testid="marquee-box"
         x={0}
         y={0}
-        width={1}
-        height={1}
-        vectorEffect="non-scaling-stroke"
+        width={0}
+        height={0}
         style={{
-          fill: 'color-mix(in srgb, var(--color-primary, #2563eb) 22%, transparent)',
-          stroke: 'var(--color-primary, #2563eb)',
-          strokeWidth: 1.5,
+          fill: 'color-mix(in oklab, var(--color-ring, currentColor) 12%, transparent)',
+          stroke:
+            'color-mix(in oklab, var(--color-ring, currentColor) 78%, var(--color-foreground, currentColor))',
+          strokeWidth: 1,
           opacity: 0,
-          transform: rectTransform(0, 0, MIN_RECT_SIZE, MIN_RECT_SIZE),
-          transformBox: 'fill-box',
-          transformOrigin: '0 0',
         }}
       />
     </svg>


### PR DESCRIPTION
## Summary

- replace the scaled 1x1 SVG marquee rectangle with direct SVG geometry updates
- remove the degenerate non-scaling stroke/compositor combination that produced horizontal and vertical rendering artifacts
- soften the marquee fill and outline with theme-aware ring/foreground colors in light and dark themes
- cover horizontal, vertical, subpixel, cleanup, color, and no-React-commit behavior

## Root cause

The marquee overlay stretched a 1x1 SVG rectangle with a highly non-uniform CSS scale while using a non-scaling stroke. When either drag axis approached zero, Chromium could rasterize the stroke far beyond the intended bounds. Updating the rectangle's x, y, width, and height directly avoids that unstable transform path while preserving the existing single-node RAF update loop.

## Validation

- `pnpm exec vitest run src/renderer/components/desktop-kit/marquee-selection` (19 passed)
- `pnpm run check:boundaries`
- `pnpm run lint`
- `pnpm exec tsc --noEmit`
- `git diff --check`
- manually compared horizontal, vertical, and subpixel rendering plus light/dark palette output in Electron

Closes #1985
