### PR TITLE
fix(proxy): import system settings through isolated session

### DIFF
--- a/src/main/ipc/queries.test.ts
+++ b/src/main/ipc/queries.test.ts
@@ -23,12 +23,25 @@ import { buildQueryHandlers, registerQueryHandlers } from './queries'
 const ipcMocks = vi.hoisted(() => ({
   handle: vi.fn(),
   removeHandler: vi.fn(),
+  defaultResolveProxy: vi.fn(),
+  systemProxySession: {
+    setProxy: vi.fn(),
+    forceReloadProxyConfig: vi.fn(),
+    resolveProxy: vi.fn(),
+  },
+  fromPartition: vi.fn(),
 }))
 
 vi.mock('electron', () => ({
   ipcMain: {
     handle: ipcMocks.handle,
     removeHandler: ipcMocks.removeHandler,
+  },
+  session: {
+    defaultSession: { resolveProxy: ipcMocks.defaultResolveProxy },
+    fromPartition: ipcMocks.fromPartition.mockReturnValue(
+      ipcMocks.systemProxySession
+    ),
   },
 }))
 
@@ -132,6 +145,37 @@ function serializeCommandGraphRecords(): string {
 }
 
 describe('buildQueryHandlers', () => {
+  it('reads the OS proxy through an isolated system-mode session', async () => {
+    ipcMocks.systemProxySession.setProxy.mockResolvedValue(undefined)
+    ipcMocks.systemProxySession.forceReloadProxyConfig.mockResolvedValue(
+      undefined
+    )
+    ipcMocks.systemProxySession.resolveProxy.mockResolvedValue(
+      'PROXY 10.0.0.1:8080'
+    )
+    const handlers = buildQueryHandlers({} as QueryContext)
+
+    await expect(handlers[Queries.GetSystemProxy]?.()).resolves.toEqual({
+      protocol: 'http',
+      host: '10.0.0.1',
+      port: 8080,
+    })
+    expect(ipcMocks.fromPartition).toHaveBeenCalledWith(
+      'motrix-system-proxy-probe',
+      { cache: false }
+    )
+    expect(ipcMocks.systemProxySession.setProxy).toHaveBeenCalledWith({
+      mode: 'system',
+    })
+    expect(
+      ipcMocks.systemProxySession.forceReloadProxyConfig
+    ).toHaveBeenCalledOnce()
+    expect(ipcMocks.systemProxySession.resolveProxy).toHaveBeenCalledWith(
+      'https://example.com'
+    )
+    expect(ipcMocks.defaultResolveProxy).not.toHaveBeenCalled()
+  })
+
   it('delegates CLI status to the shared singleton service', async () => {
     const status = { phase: 'ready', installCommand: 'npm install -g x' }
     const cliToolService = {

--- a/src/main/ipc/queries.ts
+++ b/src/main/ipc/queries.ts
@@ -56,6 +56,9 @@ import { createGetTaskBtTrackerHandler } from './queries/get-task-bt-tracker'
 import { createGetTaskFilesHandler } from './queries/get-task-files'
 import { registerTrustedIpcHandler } from './trusted-ipc'
 
+const SYSTEM_PROXY_PROBE_PARTITION = 'motrix-system-proxy-probe'
+const SYSTEM_PROXY_PROBE_URL = 'https://example.com'
+
 export interface QueryContext {
   cliToolService: Pick<CliToolService, 'getStatus'>
   taskManager: TaskManager
@@ -166,8 +169,18 @@ export function buildQueryHandlers(ctx: QueryContext): QueryHandlerMap {
     [Queries.GetUpdateState]: async () => updateManager.getState(),
 
     [Queries.GetSystemProxy]: async () => {
-      const chain = await session.defaultSession.resolveProxy(
-        'https://example.com'
+      // The default session carries Motrix's explicit app-update route, which
+      // can be `direct` even while the OS has a proxy configured. Probe with a
+      // separate in-memory session so importing system settings neither reads
+      // nor mutates the app's active route.
+      const systemProxySession = session.fromPartition(
+        SYSTEM_PROXY_PROBE_PARTITION,
+        { cache: false }
+      )
+      await systemProxySession.setProxy({ mode: 'system' })
+      await systemProxySession.forceReloadProxyConfig()
+      const chain = await systemProxySession.resolveProxy(
+        SYSTEM_PROXY_PROBE_URL
       )
       return parseElectronProxyChain(chain)
     },


### PR DESCRIPTION
## Summary
- resolve the operating-system proxy through a dedicated in-memory Electron session
- force the probe session into system mode and refresh its proxy configuration before resolving
- leave the default application session and its active proxy route untouched

Fixes #2017

## Verification
- 33 focused IPC and proxy tests
- pnpm run check:boundaries
- pnpm run lint
- pnpm exec tsc --noEmit