### PR TITLE
fix(window): restore maximized state on relaunch

### DIFF
--- a/src/core/settings/validators.test.ts
+++ b/src/core/settings/validators.test.ts
@@ -10,7 +10,26 @@ import {
   natSettingsSchema,
   validateAppSettings,
   validateEngineSettings,
+  windowStateSchema,
 } from './validators'
+
+describe('windowStateSchema', () => {
+  it('migrates legacy bounds to a non-maximized saved state', () => {
+    expect(
+      windowStateSchema.parse({
+        main: { x: 100, y: 100, width: 1024, height: 768 },
+      })
+    ).toEqual({
+      main: {
+        x: 100,
+        y: 100,
+        width: 1024,
+        height: 768,
+        maximized: false,
+      },
+    })
+  })
+})
 
 describe('validateEngineSettings', () => {
   it('returns defaults for empty object', () => {

--- a/src/main/window/window-manager.test.ts
+++ b/src/main/window/window-manager.test.ts
@@ -54,6 +54,8 @@ vi.mock('electron', () => {
     isFocused = vi.fn(() => true)
     isMaximized = vi.fn(() => false)
     getBounds = vi.fn(() => ({ ...this._bounds }))
+    getNormalBounds = vi.fn(() => ({ ...this._bounds }))
+    maximize = vi.fn()
     setBounds = vi.fn(
       (b: { x: number; y: number; width: number; height: number }) => {
         this._bounds = b
@@ -703,6 +705,51 @@ describe('WindowManager', () => {
 
     const win = wm.open('main')
     expect(win.setBounds).toHaveBeenCalledWith(savedBounds)
+  })
+
+  it('saves normal bounds and maximized state for a maximized window', () => {
+    const sm = createMockSettingsManager()
+    const wm = new WindowManager({
+      settingsManager: sm,
+      preloadPath: '/fake/preload.cjs',
+      loadUrl: vi.fn(),
+    })
+    const win = wm.open('main')
+    const normalBounds = { x: 120, y: 80, width: 1100, height: 760 }
+    vi.mocked(win.getNormalBounds).mockReturnValue(normalBounds)
+    vi.mocked(win.isMaximized).mockReturnValue(true)
+
+    wm.saveBounds('main')
+
+    expect(sm.update).toHaveBeenCalledWith({
+      windowState: { main: { ...normalBounds, maximized: true } },
+    })
+    expect(win.getBounds).not.toHaveBeenCalled()
+  })
+
+  it('restores normal bounds before re-maximizing a window', () => {
+    const savedState = {
+      x: 100,
+      y: 100,
+      width: 1024,
+      height: 768,
+      maximized: true,
+    }
+    const wm = new WindowManager({
+      settingsManager: createMockSettingsManager({ main: savedState }),
+      preloadPath: '/fake/preload.cjs',
+      loadUrl: vi.fn(),
+    })
+
+    const win = wm.open('main')
+
+    expect(win.setBounds).toHaveBeenCalledWith({
+      x: 100,
+      y: 100,
+      width: 1024,
+      height: 768,
+    })
+    expect(win.maximize).toHaveBeenCalledOnce()
   })
 
   it('ignores saved bounds if outside all screens', () => {

--- a/src/main/window/window-manager.ts
+++ b/src/main/window/window-manager.ts
@@ -5,7 +5,7 @@ import {
   type WindowMaximizedChangedPayload,
 } from '@shared/protocol/events'
 import type { AddTaskUrlParams } from '@shared/schemas/add-task'
-import type { WindowBounds } from '@shared/types/settings'
+import type { WindowBounds, WindowState } from '@shared/types/settings'
 import { BrowserWindow, screen, shell } from 'electron'
 import type { LiquidGlassController } from './liquid-glass'
 import { buildPlatformOptions } from './platform-options'
@@ -291,9 +291,12 @@ export class WindowManager {
     const win = this.windows.get(id)
     if (!win || win.isDestroyed()) return
 
-    const bounds = win.getBounds()
+    const state: WindowState = {
+      ...win.getNormalBounds(),
+      maximized: win.isMaximized(),
+    }
     this.deps.settingsManager
-      .update({ windowState: { [id]: bounds } })
+      .update({ windowState: { [id]: state } })
       .catch(() => {})
   }
 
@@ -546,16 +549,21 @@ export class WindowManager {
     if (!config.persistBounds) return
 
     const settings = this.deps.settingsManager.get()
-    const saved = settings.windowState[id] as WindowBounds | undefined
+    const saved = settings.windowState[id] as WindowState | undefined
     if (!saved) {
       win.center()
       return
     }
 
-    if (this.isBoundsVisible(saved)) {
-      win.setBounds(saved)
+    const { maximized = false, ...bounds } = saved
+    if (this.isBoundsVisible(bounds)) {
+      win.setBounds(bounds)
     } else {
       win.center()
+    }
+
+    if (maximized && config.maximizable) {
+      win.maximize()
     }
   }
 

--- a/src/shared/schemas/window-bounds.ts
+++ b/src/shared/schemas/window-bounds.ts
@@ -7,6 +7,10 @@ export const windowBoundsSchema = z.object({
   height: z.number().min(200),
 })
 
+export const savedWindowStateSchema = windowBoundsSchema.extend({
+  maximized: z.boolean().catch(false),
+})
+
 export const windowStateSchema = z
-  .record(z.string(), windowBoundsSchema)
+  .record(z.string(), savedWindowStateSchema)
   .catch({})

--- a/src/shared/types/settings.ts
+++ b/src/shared/types/settings.ts
@@ -13,6 +13,10 @@ export interface WindowBounds {
   height: number
 }
 
+export interface WindowState extends WindowBounds {
+  maximized: boolean
+}
+
 export interface TrackerSettings {
   autoSync: boolean
   syncIntervalHours: number
@@ -144,7 +148,7 @@ export interface AppSettings {
   media: MediaSettings
   dashboard: DashboardLayoutSettings
   speedLimit: SpeedLimitSettings
-  windowState: Record<string, WindowBounds>
+  windowState: Record<string, WindowState>
 }
 
 export interface OnboardingState {


### PR DESCRIPTION
## Summary
- persist normal window bounds separately from the maximized state
- restore normal bounds before re-maximizing the main window
- migrate legacy bounds-only settings to a non-maximized state

Fixes #2020

## Verification
- 160 focused window and settings tests
- pnpm run check:boundaries
- pnpm run lint
- pnpm exec tsc --noEmit