### PR TITLE
fix(engine): talk to aria2 over http json-rpc

### DIFF
--- a/src/core/engine/aria2/aria2-config-builder.test.ts
+++ b/src/core/engine/aria2/aria2-config-builder.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // ─── Mock node:fs/promises ───────────────────────────────────
@@ -28,7 +29,13 @@ import type { EngineSettings } from '@shared/types/settings'
 import { Aria2ConfigBuilder } from './aria2-config-builder'
 
 const DEFAULT_SAVE_DIR = '/home/user/Downloads'
+const TEMPLATE_PATH = '/app/extra/aria2.conf'
+const USER_CONFIG_DIR = '/home/user/.config/motrix'
 const TEST_RPC_SECRET = 'test-rpc-secret'
+
+function userFile(...segments: string[]): string {
+  return path.join(USER_CONFIG_DIR, ...segments)
+}
 
 function makeEngineSettings(
   overrides?: Partial<EngineSettings>
@@ -68,10 +75,7 @@ describe('Aria2ConfigBuilder', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    builder = new Aria2ConfigBuilder(
-      '/app/extra/aria2.conf',
-      '/home/user/.config/motrix'
-    )
+    builder = new Aria2ConfigBuilder(TEMPLATE_PATH, USER_CONFIG_DIR)
   })
 
   afterEach(() => {
@@ -85,7 +89,7 @@ describe('Aria2ConfigBuilder', () => {
 
       const confPath = await builder.ensureUserConfig()
 
-      expect(confPath).toBe('/home/user/.config/motrix/aria2.conf')
+      expect(confPath).toBe(userFile('aria2.conf'))
       expect(mockCopyFile).not.toHaveBeenCalled()
     })
 
@@ -97,13 +101,13 @@ describe('Aria2ConfigBuilder', () => {
 
       const confPath = await builder.ensureUserConfig()
 
-      expect(confPath).toBe('/home/user/.config/motrix/aria2.conf')
-      expect(mockMkdir).toHaveBeenCalledWith('/home/user/.config/motrix', {
+      expect(confPath).toBe(userFile('aria2.conf'))
+      expect(mockMkdir).toHaveBeenCalledWith(USER_CONFIG_DIR, {
         recursive: true,
       })
       expect(mockCopyFile).toHaveBeenCalledWith(
-        '/app/extra/aria2.conf',
-        '/home/user/.config/motrix/aria2.conf'
+        TEMPLATE_PATH,
+        userFile('aria2.conf')
       )
     })
   })
@@ -113,9 +117,7 @@ describe('Aria2ConfigBuilder', () => {
       mockAccess.mockResolvedValue(undefined)
 
       await expect(builder.hasSavedSession()).resolves.toBe(true)
-      expect(mockAccess).toHaveBeenCalledWith(
-        '/home/user/.config/motrix/aria2.session'
-      )
+      expect(mockAccess).toHaveBeenCalledWith(userFile('aria2.session'))
     })
 
     it('returns false instead of throwing when the text session is unavailable', async () => {
@@ -128,7 +130,7 @@ describe('Aria2ConfigBuilder', () => {
   describe('SQLite recovery paths', () => {
     it('resolves the configured database path or the user-data default', () => {
       expect(builder.resolveSqliteDbPath({ sqlite3DbPath: '' })).toBe(
-        '/home/user/.config/motrix/aria2.db'
+        userFile('aria2.db')
       )
       expect(
         builder.resolveSqliteDbPath({ sqlite3DbPath: '/custom/tasks.db' })
@@ -146,26 +148,24 @@ describe('Aria2ConfigBuilder', () => {
           Object.assign(new Error('missing'), { code: 'ENOENT' })
         )
 
+      const databasePath = userFile('aria2.db')
+      const quarantineBasePath = `${databasePath}.corrupt-incident-1`
       await expect(
         builder.quarantineSqliteDatabase({ sqlite3DbPath: '' }, 'incident-1')
       ).resolves.toEqual({
-        databasePath: '/home/user/.config/motrix/aria2.db',
-        quarantineBasePath:
-          '/home/user/.config/motrix/aria2.db.corrupt-incident-1',
-        moved: [
-          '/home/user/.config/motrix/aria2.db.corrupt-incident-1',
-          '/home/user/.config/motrix/aria2.db.corrupt-incident-1-wal',
-        ],
+        databasePath,
+        quarantineBasePath,
+        moved: [quarantineBasePath, `${quarantineBasePath}-wal`],
       })
       expect(mockRename).toHaveBeenNthCalledWith(
         1,
-        '/home/user/.config/motrix/aria2.db',
-        '/home/user/.config/motrix/aria2.db.corrupt-incident-1'
+        databasePath,
+        quarantineBasePath
       )
       expect(mockRename).toHaveBeenNthCalledWith(
         2,
-        '/home/user/.config/motrix/aria2.db-wal',
-        '/home/user/.config/motrix/aria2.db.corrupt-incident-1-wal'
+        `${databasePath}-wal`,
+        `${quarantineBasePath}-wal`
       )
     })
   })
@@ -177,7 +177,7 @@ describe('Aria2ConfigBuilder', () => {
         upload: 0,
       })
 
-      expect(args).toContain('--conf-path=/home/user/.config/motrix/aria2.conf')
+      expect(args).toContain(`--conf-path=${userFile('aria2.conf')}`)
       expect(args).toContain('--enable-rpc=true')
       expect(args).toContain('--rpc-allow-origin-all=true')
       expect(args).toContain('--rpc-listen-all=false')
@@ -231,8 +231,8 @@ describe('Aria2ConfigBuilder', () => {
 
     it('allows an explicit all-interface RPC listener with authentication', () => {
       const externalBuilder = new Aria2ConfigBuilder(
-        '/app/extra/aria2.conf',
-        '/home/user/.config/motrix',
+        TEMPLATE_PATH,
+        USER_CONFIG_DIR,
         { rpcListenAll: true }
       )
 
@@ -252,8 +252,8 @@ describe('Aria2ConfigBuilder', () => {
       'refuses an all-interface RPC listener with a blank secret',
       (rpcSecret) => {
         const externalBuilder = new Aria2ConfigBuilder(
-          '/app/extra/aria2.conf',
-          '/home/user/.config/motrix',
+          TEMPLATE_PATH,
+          USER_CONFIG_DIR,
           { rpcListenAll: true }
         )
 
@@ -276,9 +276,7 @@ describe('Aria2ConfigBuilder', () => {
       })
 
       const saveSessionArg = args.find((a) => a.startsWith('--save-session='))
-      expect(saveSessionArg).toBe(
-        '--save-session=/home/user/.config/motrix/aria2.session'
-      )
+      expect(saveSessionArg).toBe(`--save-session=${userFile('aria2.session')}`)
     })
 
     it('loads the text session only when requested by the supervisor', () => {
@@ -295,11 +293,9 @@ describe('Aria2ConfigBuilder', () => {
       )
 
       expect(withoutInput).not.toContain(
-        '--input-file=/home/user/.config/motrix/aria2.session'
+        `--input-file=${userFile('aria2.session')}`
       )
-      expect(withInput).toContain(
-        '--input-file=/home/user/.config/motrix/aria2.session'
-      )
+      expect(withInput).toContain(`--input-file=${userFile('aria2.session')}`)
     })
 
     it('never combines text-session loading with active SQLite persistence', () => {
@@ -312,9 +308,7 @@ describe('Aria2ConfigBuilder', () => {
       )
 
       expect(args).toContain('--enable-sqlite3-persistence=true')
-      expect(args).not.toContain(
-        '--input-file=/home/user/.config/motrix/aria2.session'
-      )
+      expect(args).not.toContain(`--input-file=${userFile('aria2.session')}`)
       expect(args).not.toContain('--auto-save-interval=10')
     })
 
@@ -349,12 +343,8 @@ describe('Aria2ConfigBuilder', () => {
         download: 0,
         upload: 0,
       })
-      expect(args).toContain(
-        '--dht-file-path=/home/user/.config/motrix/dht.dat'
-      )
-      expect(args).toContain(
-        '--dht-file-path6=/home/user/.config/motrix/dht6.dat'
-      )
+      expect(args).toContain(`--dht-file-path=${userFile('dht.dat')}`)
+      expect(args).toContain(`--dht-file-path6=${userFile('dht6.dat')}`)
     })
 
     it('uses custom settings values', () => {
@@ -554,9 +544,7 @@ describe('Aria2ConfigBuilder', () => {
         download: 0,
         upload: 0,
       })
-      expect(args).toContain(
-        '--sqlite3-db-path=/home/user/.config/motrix/aria2.db'
-      )
+      expect(args).toContain(`--sqlite3-db-path=${userFile('aria2.db')}`)
     })
 
     it('uses explicit DB path when sqlite3DbPath is set', () => {
@@ -567,9 +555,7 @@ describe('Aria2ConfigBuilder', () => {
         { download: 0, upload: 0 }
       )
       expect(args).toContain('--sqlite3-db-path=/custom/path/db.sqlite')
-      expect(args).not.toContain(
-        '--sqlite3-db-path=/home/user/.config/motrix/aria2.db'
-      )
+      expect(args).not.toContain(`--sqlite3-db-path=${userFile('aria2.db')}`)
     })
 
     it('passes -1 history limit through verbatim', () => {

--- a/src/core/engine/aria2/aria2-rpc-client.test.ts
+++ b/src/core/engine/aria2/aria2-rpc-client.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Aria2RpcClient } from './aria2-rpc-client'
 import type { JsonRpcProtocol } from './json-rpc-protocol'
-import type { WebSocketTransport } from './web-socket-transport'
+import type { RpcTransport } from './rpc-transport'
 
 // ─── Fake JsonRpcProtocol ────────────────────────────────────
 // Records calls and lets tests control responses.
@@ -49,7 +49,7 @@ class FakeProtocol {
   }
 }
 
-// ─── Fake WebSocketTransport ─────────────────────────────────
+// ─── Fake RpcTransport ──────────────────────────────────────
 
 class FakeTransport {
   connect = vi.fn<(url: string) => Promise<void>>().mockResolvedValue(undefined)
@@ -70,18 +70,18 @@ describe('Aria2RpcClient', () => {
     fakeTransport = new FakeTransport()
     fakeProtocol = new FakeProtocol()
     client = new Aria2RpcClient(
-      fakeTransport as unknown as WebSocketTransport,
+      fakeTransport as unknown as RpcTransport,
       fakeProtocol as unknown as JsonRpcProtocol,
       'my-secret'
     )
   })
 
   describe('connect / disconnect', () => {
-    it('connects to ws://127.0.0.1:{port}/jsonrpc', async () => {
+    it('connects to http://127.0.0.1:{port}/jsonrpc', async () => {
       await client.connect(16800)
 
       expect(fakeTransport.connect).toHaveBeenCalledWith(
-        'ws://127.0.0.1:16800/jsonrpc'
+        'http://127.0.0.1:16800/jsonrpc'
       )
     })
 

--- a/src/core/engine/aria2/aria2-rpc-client.ts
+++ b/src/core/engine/aria2/aria2-rpc-client.ts
@@ -1,4 +1,5 @@
 import type { JsonRpcProtocol } from './json-rpc-protocol'
+import type { RpcTransport } from './rpc-transport'
 import type {
   Aria2HistoryCount,
   Aria2HistoryFilter,
@@ -12,7 +13,6 @@ import type {
   Aria2SearchQuery,
   Aria2Version,
 } from './types'
-import type { WebSocketTransport } from './web-socket-transport'
 
 interface Aria2Event {
   gid: string
@@ -31,7 +31,7 @@ export class Aria2RpcClient {
   private notificationHandlers = new Map<string, Set<EventHandler>>()
 
   constructor(
-    private transport: WebSocketTransport,
+    private transport: RpcTransport,
     private protocol: JsonRpcProtocol,
     private secret: string
   ) {
@@ -43,7 +43,7 @@ export class Aria2RpcClient {
   // ─── Connection ──────────────────────────────────────────────
 
   async connect(port: number, retries = 10, delayMs = 500): Promise<void> {
-    const url = `ws://127.0.0.1:${port}/jsonrpc`
+    const url = `http://127.0.0.1:${port}/jsonrpc`
     for (let attempt = 0; attempt < retries; attempt++) {
       try {
         await this.transport.connect(url)

--- a/src/core/engine/aria2/aria2-trust-store.test.ts
+++ b/src/core/engine/aria2/aria2-trust-store.test.ts
@@ -89,7 +89,10 @@ describe('Aria2TrustStore', () => {
       SSL_CERT_FILE: bundlePath,
     })
     expect(await readFile(bundlePath, 'utf8')).toBe(`${SYSTEM_CERTIFICATE}\n`)
-    expect((await stat(bundlePath)).mode & 0o777).toBe(0o600)
+    // Windows file modes are not POSIX; the 0o600 pin is for Unix OpenSSL.
+    if (process.platform !== 'win32') {
+      expect((await stat(bundlePath)).mode & 0o777).toBe(0o600)
+    }
   })
 
   it('falls back to bundled roots when the system store is empty', async () => {

--- a/src/core/engine/aria2/http-rpc-transport.test.ts
+++ b/src/core/engine/aria2/http-rpc-transport.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { HttpRpcTransport } from './http-rpc-transport'
+
+const { mockConnect, mockRequest } = vi.hoisted(() => ({
+  mockConnect: vi.fn(),
+  mockRequest: vi.fn(),
+}))
+
+vi.mock('node:net', () => ({
+  default: {
+    connect: mockConnect,
+  },
+}))
+
+vi.mock('undici', () => ({
+  Agent: class MockAgent {
+    close = vi.fn().mockResolvedValue(undefined)
+  },
+  request: (...args: unknown[]) => mockRequest(...args),
+}))
+
+interface FakeSocket {
+  handlers: Record<string, Array<(...args: unknown[]) => void>>
+  on: (event: string, handler: (...args: unknown[]) => void) => FakeSocket
+  setTimeout: (ms: number, handler?: () => void) => void
+  end: ReturnType<typeof vi.fn>
+  destroy: ReturnType<typeof vi.fn>
+  emit: (event: string, ...args: unknown[]) => void
+}
+
+function createFakeSocket(): FakeSocket {
+  const handlers: Record<string, Array<(...args: unknown[]) => void>> = {}
+  const socket: FakeSocket = {
+    handlers,
+    on(event, handler) {
+      if (!handlers[event]) handlers[event] = []
+      handlers[event].push(handler)
+      return socket
+    },
+    setTimeout: vi.fn(),
+    end: vi.fn(),
+    destroy: vi.fn(),
+    emit(event, ...args) {
+      for (const handler of handlers[event] ?? []) {
+        handler(...args)
+      }
+    },
+  }
+  return socket
+}
+
+describe('HttpRpcTransport', () => {
+  let transport: HttpRpcTransport
+  let socket: FakeSocket
+
+  beforeEach(() => {
+    socket = createFakeSocket()
+    mockConnect.mockReset()
+    mockRequest.mockReset()
+    mockConnect.mockImplementation(
+      (_port: number, _host: string, onConnect?: () => void): FakeSocket => {
+        if (onConnect) {
+          queueMicrotask(onConnect)
+        }
+        return socket
+      }
+    )
+    transport = new HttpRpcTransport()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('connect', () => {
+    it('probes TCP and resolves on a listening HTTP RPC port', async () => {
+      await transport.connect('http://127.0.0.1:16800/jsonrpc')
+      expect(mockConnect).toHaveBeenCalledWith(
+        16800,
+        '127.0.0.1',
+        expect.any(Function)
+      )
+      expect(socket.end).toHaveBeenCalled()
+      expect(transport.isConnected()).toBe(true)
+    })
+
+    it('rejects non-http URLs', async () => {
+      await expect(
+        transport.connect('ws://127.0.0.1:16800/jsonrpc')
+      ).rejects.toThrow('http(s)')
+      expect(transport.isConnected()).toBe(false)
+    })
+
+    it('rejects if already connected', async () => {
+      await transport.connect('http://127.0.0.1:16800/jsonrpc')
+      await expect(
+        transport.connect('http://127.0.0.1:16800/jsonrpc')
+      ).rejects.toThrow('already connected')
+    })
+  })
+
+  describe('send', () => {
+    it('POSTs JSON-RPC and delivers the response body as a message', async () => {
+      const handler = vi.fn()
+      transport.onMessage(handler)
+      await transport.connect('http://127.0.0.1:16800/jsonrpc')
+      mockRequest.mockResolvedValue({
+        body: {
+          text: async () => '{"jsonrpc":"2.0","id":"1","result":"OK"}',
+        },
+      })
+
+      transport.send('{"jsonrpc":"2.0","id":"1"}')
+      await vi.waitFor(() => {
+        expect(handler).toHaveBeenCalledWith(
+          '{"jsonrpc":"2.0","id":"1","result":"OK"}'
+        )
+      })
+      expect(mockRequest).toHaveBeenCalledWith(
+        'http://127.0.0.1:16800/jsonrpc',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'content-type': 'application/json',
+            connection: 'close',
+          }),
+          body: '{"jsonrpc":"2.0","id":"1"}',
+        })
+      )
+    })
+
+    it('throws when not connected', () => {
+      expect(() => transport.send('data')).toThrow('not connected')
+    })
+
+    it('forwards request errors to the error handler', async () => {
+      const handler = vi.fn()
+      transport.onError(handler)
+      await transport.connect('http://127.0.0.1:16800/jsonrpc')
+      mockRequest.mockRejectedValue(new Error('ECONNRESET'))
+
+      transport.send('{"jsonrpc":"2.0"}')
+      await vi.waitFor(() => {
+        expect(handler).toHaveBeenCalledWith(expect.any(Error))
+      })
+      expect(handler.mock.calls[0][0].message).toBe('ECONNRESET')
+    })
+  })
+
+  describe('disconnect', () => {
+    it('clears connected state', async () => {
+      await transport.connect('http://127.0.0.1:16800/jsonrpc')
+      transport.disconnect()
+      expect(transport.isConnected()).toBe(false)
+    })
+  })
+})

--- a/src/core/engine/aria2/http-rpc-transport.ts
+++ b/src/core/engine/aria2/http-rpc-transport.ts
@@ -1,0 +1,134 @@
+import net from 'node:net'
+import { Agent, request } from 'undici'
+import type {
+  RpcCloseHandler,
+  RpcErrorHandler,
+  RpcMessageHandler,
+  RpcTransport,
+} from './rpc-transport'
+
+const CONNECT_TIMEOUT_MS = 800
+
+/**
+ * JSON-RPC over HTTP POST.
+ *
+ * Some bundled aria2 Windows builds accept a WebSocket upgrade and execute
+ * the RPC method, but never write a response frame. HTTP on the same process
+ * answers immediately. Persistent keep-alive sockets against those builds
+ * also stall, so each call uses `Connection: close`.
+ */
+export class HttpRpcTransport implements RpcTransport {
+  private connected = false
+  private url: string | null = null
+  private dispatcher: Agent | null = null
+
+  private messageHandler: RpcMessageHandler | null = null
+  private errorHandler: RpcErrorHandler | null = null
+
+  connect(url: string): Promise<void> {
+    if (this.connected) {
+      return Promise.reject(new Error('HTTP RPC is already connected'))
+    }
+
+    let parsed: URL
+    try {
+      parsed = new URL(url)
+    } catch (err) {
+      return Promise.reject(err instanceof Error ? err : new Error(String(err)))
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return Promise.reject(
+        new Error('HttpRpcTransport requires an http(s) JSON-RPC URL')
+      )
+    }
+
+    const port =
+      Number(parsed.port) || (parsed.protocol === 'https:' ? 443 : 80)
+    const hostname = parsed.hostname
+
+    return new Promise<void>((resolve, reject) => {
+      const socket = net.connect(port, hostname, () => {
+        socket.setTimeout(0)
+        socket.end()
+        this.url = url
+        this.dispatcher = new Agent({
+          keepAliveTimeout: 1,
+          keepAliveMaxTimeout: 1,
+          pipelining: 0,
+        })
+        this.connected = true
+        resolve()
+      })
+
+      socket.on('error', (err: Error) => {
+        if (!this.connected) {
+          reject(err)
+        }
+      })
+
+      socket.setTimeout(CONNECT_TIMEOUT_MS, () => {
+        if (!this.connected) {
+          socket.destroy()
+          reject(new Error('connect timeout'))
+        }
+      })
+    })
+  }
+
+  disconnect(): void {
+    this.connected = false
+    this.url = null
+    const dispatcher = this.dispatcher
+    this.dispatcher = null
+    if (dispatcher) {
+      void dispatcher.close()
+    }
+  }
+
+  isConnected(): boolean {
+    return this.connected
+  }
+
+  send(data: string): void {
+    if (!this.connected || !this.url) {
+      throw new Error('HTTP RPC is not connected')
+    }
+    const url = this.url
+    const dispatcher = this.dispatcher
+    void this.post(url, data, dispatcher)
+  }
+
+  onMessage(handler: RpcMessageHandler): void {
+    this.messageHandler = handler
+  }
+
+  onClose(_handler: RpcCloseHandler): void {
+    // HTTP RPC has no persistent socket whose peer-close we can observe.
+  }
+
+  onError(handler: RpcErrorHandler): void {
+    this.errorHandler = handler
+  }
+
+  private async post(
+    url: string,
+    data: string,
+    dispatcher: Agent | null
+  ): Promise<void> {
+    try {
+      const { body } = await request(url, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          connection: 'close',
+        },
+        body: data,
+        dispatcher: dispatcher ?? undefined,
+      })
+      const text = await body.text()
+      this.messageHandler?.(text)
+    } catch (err) {
+      this.errorHandler?.(err instanceof Error ? err : new Error(String(err)))
+    }
+  }
+}

--- a/src/core/engine/aria2/json-rpc-protocol.test.ts
+++ b/src/core/engine/aria2/json-rpc-protocol.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { JsonRpcProtocol } from './json-rpc-protocol'
-import type { WebSocketTransport } from './web-socket-transport'
+import type { RpcTransport } from './rpc-transport'
 
 class FakeTransport {
   private messageHandler: ((data: string) => void) | null = null
@@ -51,7 +51,7 @@ describe('JsonRpcProtocol', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     transport = new FakeTransport()
-    protocol = new JsonRpcProtocol(transport as unknown as WebSocketTransport, {
+    protocol = new JsonRpcProtocol(transport as unknown as RpcTransport, {
       timeoutMs: 5000,
     })
   })

--- a/src/core/engine/aria2/json-rpc-protocol.ts
+++ b/src/core/engine/aria2/json-rpc-protocol.ts
@@ -1,4 +1,4 @@
-import type { WebSocketTransport } from './web-socket-transport'
+import type { RpcTransport } from './rpc-transport'
 
 interface PendingRequest {
   resolve: (value: unknown) => void
@@ -40,7 +40,7 @@ export class JsonRpcProtocol {
   private readonly timeoutMs: number
 
   constructor(
-    private transport: WebSocketTransport,
+    private transport: RpcTransport,
     options: JsonRpcProtocolOptions = {}
   ) {
     this.timeoutMs = options.timeoutMs ?? 10_000

--- a/src/core/engine/aria2/rpc-transport.ts
+++ b/src/core/engine/aria2/rpc-transport.ts
@@ -1,0 +1,21 @@
+export type RpcMessageHandler = (data: string) => void
+export type RpcCloseHandler = (code: number, reason: string) => void
+export type RpcErrorHandler = (err: Error) => void
+
+/**
+ * Bidirectional JSON-RPC carrier used by {@link JsonRpcProtocol}.
+ *
+ * `send` is fire-and-forget: matching responses arrive later through
+ * `onMessage`. HTTP implementations POST each payload and deliver the
+ * response body as a single message. WebSocket implementations forward
+ * frames in both directions, including server-initiated notifications.
+ */
+export interface RpcTransport {
+  connect(url: string): Promise<void>
+  disconnect(): void
+  isConnected(): boolean
+  send(data: string): void
+  onMessage(handler: RpcMessageHandler): void
+  onClose(handler: RpcCloseHandler): void
+  onError(handler: RpcErrorHandler): void
+}

--- a/src/core/engine/aria2/web-socket-transport.ts
+++ b/src/core/engine/aria2/web-socket-transport.ts
@@ -1,10 +1,11 @@
 import WebSocket from 'ws'
+import type { RpcTransport } from './rpc-transport'
 
 type MessageHandler = (data: string) => void
 type CloseHandler = (code: number, reason: string) => void
 type ErrorHandler = (err: Error) => void
 
-export class WebSocketTransport {
+export class WebSocketTransport implements RpcTransport {
   private ws: WebSocket | null = null
   private connected = false
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,6 +8,7 @@ import { Aria2RpcClient } from '@core/engine/aria2/aria2-rpc-client'
 import { Aria2TrustStore } from '@core/engine/aria2/aria2-trust-store'
 import type { DnsFallbackConsumer } from '@core/engine/aria2/dns-fallback'
 import { createDnsFallbackConsumer } from '@core/engine/aria2/dns-fallback'
+import { HttpRpcTransport } from '@core/engine/aria2/http-rpc-transport'
 import { JsonRpcProtocol } from '@core/engine/aria2/json-rpc-protocol'
 import {
   PollingScheduler,
@@ -15,7 +16,6 @@ import {
 } from '@core/engine/aria2/polling-scheduler'
 import { translateRawToTask } from '@core/engine/aria2/translate'
 import type { Aria2RawStatus } from '@core/engine/aria2/types'
-import { WebSocketTransport } from '@core/engine/aria2/web-socket-transport'
 import {
   ENGINE_READY_TIMEOUT_MS,
   EngineSupervisor,
@@ -339,7 +339,7 @@ const appliedDownloadProxyPolicy = new AppliedDownloadProxyPolicy()
 
 // ─── aria2 Infrastructure ───────────────────────────────
 
-const transport = new WebSocketTransport()
+const transport = new HttpRpcTransport()
 const protocol = new JsonRpcProtocol(transport)
 const processManager = new Aria2ProcessManager({
   ownershipFilePath: path.join(platform.userDataDir, 'aria2-owner.json'),

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -9,6 +9,7 @@ import { Aria2ProcessManager } from '@core/engine/aria2/aria2-process-manager'
 import { Aria2RpcClient } from '@core/engine/aria2/aria2-rpc-client'
 import { Aria2TrustStore } from '@core/engine/aria2/aria2-trust-store'
 import { createDnsFallbackConsumer } from '@core/engine/aria2/dns-fallback'
+import { HttpRpcTransport } from '@core/engine/aria2/http-rpc-transport'
 import { JsonRpcProtocol } from '@core/engine/aria2/json-rpc-protocol'
 import {
   PollingScheduler,
@@ -16,7 +17,6 @@ import {
 } from '@core/engine/aria2/polling-scheduler'
 import { translateRawToTask } from '@core/engine/aria2/translate'
 import type { Aria2RawStatus } from '@core/engine/aria2/types'
-import { WebSocketTransport } from '@core/engine/aria2/web-socket-transport'
 import {
   ENGINE_READY_TIMEOUT_MS,
   EngineSupervisor,
@@ -388,7 +388,7 @@ async function main() {
   })
 
   // ─── aria2 Infrastructure ─────────────────────────────────────
-  const transport = new WebSocketTransport()
+  const transport = new HttpRpcTransport()
   const protocol = new JsonRpcProtocol(transport)
   const processManager = new Aria2ProcessManager({
     ownershipFilePath: path.join(platform.userDataDir, 'aria2-owner.json'),

--- a/src/test-utils/aria2.ts
+++ b/src/test-utils/aria2.ts
@@ -12,8 +12,8 @@ import path from 'node:path'
 import { aria2BinaryName } from '@shared/platform/aria2'
 import { Aria2Adapter } from '../core/engine/aria2/aria2-adapter'
 import { Aria2RpcClient } from '../core/engine/aria2/aria2-rpc-client'
+import { HttpRpcTransport } from '../core/engine/aria2/http-rpc-transport'
 import { JsonRpcProtocol } from '../core/engine/aria2/json-rpc-protocol'
-import { WebSocketTransport } from '../core/engine/aria2/web-socket-transport'
 
 export interface Aria2Handle {
   proc: ChildProcess
@@ -181,14 +181,14 @@ export async function waitForRpc(
 /**
  * Build an `Aria2Adapter` connected to a running test aria2. The caller is
  * responsible for disconnecting the transport during cleanup via the returned
- * `disconnect` callback (which tears down the shared WebSocket).
+ * `disconnect` callback (which tears down the HTTP RPC session).
  */
 export async function connectAdapter(handle: Aria2Handle): Promise<{
   adapter: Aria2Adapter
   rpc: Aria2RpcClient
   disconnect: () => void
 }> {
-  const transport = new WebSocketTransport()
+  const transport = new HttpRpcTransport()
   const protocol = new JsonRpcProtocol(transport)
   const rpc = new Aria2RpcClient(transport, protocol, handle.secret)
   await rpc.connect(handle.port)


### PR DESCRIPTION
## Summary / 概述

On Windows, the bundled `aria2c.exe 1.37.0-motrix.10` accepts a WebSocket JSON-RPC upgrade and executes the method, but never writes a response frame. Motrix 2 speaks to the engine only over `ws://127.0.0.1:${port}/jsonrpc`, so the handshake (`aria2.changeGlobalOption`) times out after 10s, the engine is SIGTERM'd, and the dashboard stays Failed.

HTTP JSON-RPC on the same process answers in milliseconds. This PR switches the production engine transport (desktop + server) and the integration harness to HTTP POST with `Connection: close`. `PollingScheduler` already covers task updates, so losing engine WebSocket notifications is acceptable until the aria2 fork's writer is fixed.

Windows 上捆绑的 `aria2c.exe 1.37.0-motrix.10` 会接受 WebSocket JSON-RPC 升级并执行方法，但从不写回响应帧。Motrix 2 只通过 `ws://127.0.0.1:${port}/jsonrpc` 与引擎通信，因此握手超时、引擎被杀死、仪表盘保持 Failed。此 PR 将生产环境引擎传输改为 HTTP POST（`Connection: close`）。

## Related issue / 相关 Issue

Closes #2027

## Changes / 改动

- Add `RpcTransport` and `HttpRpcTransport` (undici POST, no keep-alive).
- Wire desktop `src/main`, server `src/server`, and `src/test-utils/aria2.ts` to HTTP RPC.
- Keep `WebSocketTransport` for existing unit tests.
- Point `Aria2RpcClient.connect` at `http://127.0.0.1:${port}/jsonrpc`.

## Validation / 验证

- [x] Relevant automated tests / 相关自动化测试
- [x] Manual verification, if applicable / 必要的手动验证
- [x] `pnpm run check:boundaries`
- [x] `pnpm run lint`
- [x] `pnpm exec tsc --noEmit`

Validation details / 验证详情：

```text
pnpm run check:boundaries
# 9/9 PASS

pnpm exec tsc --noEmit
# PASS

pnpm exec biome check \
  src/core/engine/aria2/aria2-rpc-client.ts \
  src/core/engine/aria2/aria2-rpc-client.test.ts \
  src/core/engine/aria2/http-rpc-transport.ts \
  src/core/engine/aria2/http-rpc-transport.test.ts \
  src/core/engine/aria2/json-rpc-protocol.ts \
  src/core/engine/aria2/json-rpc-protocol.test.ts \
  src/core/engine/aria2/rpc-transport.ts \
  src/core/engine/aria2/web-socket-transport.ts \
  src/core/engine/aria2/aria2-config-builder.test.ts \
  src/core/engine/aria2/aria2-trust-store.test.ts \
  src/test-utils/aria2.ts
# PASS

pnpm exec biome check . --formatter-enabled=false
# 1683 files, 0 lint errors
# Full `pnpm run lint` on this Windows checkout also reports CRLF vs
# biome `lineEnding: lf` for the rest of the tree (`* text=auto` native
# EOL). CI Linux checkouts are LF.

pnpm run check:file-names
# PASS (1934 files)

pnpm exec vitest run src/core/engine/aria2
# 470 passed, 4 skipped (real-aria2 integration: no extra/win32 binary)

node ./node_modules/vitest/vitest.mjs run \
  src/core/engine/aria2/http-rpc-transport.test.ts \
  src/core/engine/aria2/aria2-rpc-client.test.ts \
  src/core/engine/aria2/json-rpc-protocol.test.ts \
  src/core/engine/aria2/web-socket-transport.test.ts
# 4 files, 84 tests passed
```

Manual: on Windows 11 x64 with Motrix 2.0.0-beta.28, HTTP JSON-RPC against the bundled aria2 recovered the engine (handshake, polling, and a test download). Raw WebSocket frames to the same binary returned 0 bytes after a successful 101 upgrade.

## Checklist / 检查清单

- [x] This pull request targets `main` and contains one focused change.
- [x] User-visible text is localized, and paired English/Chinese documentation stays aligned.
- [x] No credentials, private URLs, personal paths, or other sensitive information are included.
- [x] I have read and followed the contribution guidelines and Code of Conduct.
