### PR TITLE
fix(add-task): refresh default save directory on open

### DIFF
--- a/src/renderer/components/add-task/add-task-form.test.tsx
+++ b/src/renderer/components/add-task/add-task-form.test.tsx
@@ -132,6 +132,83 @@ describe('AddTaskForm', () => {
     expect(mockServices.readClipboard).toHaveBeenCalledOnce()
   })
 
+  it('refreshes the default save directory when a precreated window is shown', async () => {
+    const { transport } = await import('@renderer/lib/transport')
+    vi.mocked(transport.invoke).mockImplementation(async (channel: string) => {
+      if (channel === 'query:getSettings') {
+        return {
+          app: {
+            autofillClipboardLinks: false,
+            defaultSaveDir: '/downloads/new',
+          },
+        }
+      }
+      return { gid: 'test-gid' }
+    })
+    renderForm({
+      subscribeEvents: true,
+      defaultValues: {
+        tab: 'links',
+        urls: '',
+        saveDir: '/downloads/old',
+      },
+    })
+    expect(screen.getAllByTitle('/downloads/old').length).toBeGreaterThan(0)
+
+    const setModeListener = vi
+      .mocked(transport.on)
+      .mock.calls.find(([channel]) => channel === Events.SetAddTaskMode)?.[1]
+    act(() => {
+      setModeListener?.({ mode: 'links' })
+    })
+
+    await waitFor(() =>
+      expect(screen.getAllByTitle('/downloads/new').length).toBeGreaterThan(0)
+    )
+    expect(screen.queryAllByTitle('/downloads/old')).toHaveLength(0)
+  })
+
+  it('preserves a dirty per-task save directory when the mode is refreshed', async () => {
+    const user = userEvent.setup()
+    const { transport } = await import('@renderer/lib/transport')
+    vi.mocked(transport.invoke).mockImplementation(async (channel: string) => {
+      if (channel === 'query:getSettings') {
+        return {
+          app: {
+            autofillClipboardLinks: false,
+            defaultSaveDir: '/downloads/default',
+          },
+        }
+      }
+      return { gid: 'test-gid' }
+    })
+    vi.mocked(mockServices.pickSaveDir).mockResolvedValueOnce(
+      '/downloads/per-task'
+    )
+    renderForm({ subscribeEvents: true })
+
+    await user.click(screen.getByRole('button', { name: /change directory/i }))
+    await waitFor(() =>
+      expect(
+        screen.getAllByTitle('/downloads/per-task').length
+      ).toBeGreaterThan(0)
+    )
+
+    const setModeListener = vi
+      .mocked(transport.on)
+      .mock.calls.find(([channel]) => channel === Events.SetAddTaskMode)?.[1]
+    await act(async () => {
+      setModeListener?.({ mode: 'links' })
+      await Promise.resolve()
+    })
+
+    expect(transport.invoke).toHaveBeenCalledTimes(2)
+    expect(screen.getAllByTitle('/downloads/per-task').length).toBeGreaterThan(
+      0
+    )
+    expect(screen.queryAllByTitle('/downloads/default')).toHaveLength(0)
+  })
+
   it('does not prefill when the setting is turned off', async () => {
     const { transport } = await import('@renderer/lib/transport')
     vi.mocked(transport.invoke).mockImplementation(async (channel: string) => {

--- a/src/renderer/components/add-task/add-task-form.tsx
+++ b/src/renderer/components/add-task/add-task-form.tsx
@@ -42,7 +42,10 @@ import { FooterActions } from './footer-actions'
 import { LinksTabPanel } from './links-tab-panel'
 import { TorrentTabPanel } from './torrent-tab-panel'
 import { parseUrlLines } from './url-interpreters/multiline-url'
-import { useExternalHydration } from './use-external-hydration'
+import {
+  type AddTaskModeHydrationContext,
+  useExternalHydration,
+} from './use-external-hydration'
 
 interface AddTaskFormProps {
   defaultValues?: DeepPartial<AddTaskFormValues>
@@ -90,44 +93,62 @@ export function AddTaskForm({
     defaultValues: { ...BASE_DEFAULTS, ...defaultValues } as AddTaskFormValues,
   })
 
-  const clipboardAutofillRequest = useRef(0)
+  const openHydrationRequest = useRef(0)
 
-  // Read once for each actual open. The desktop add-task window is precreated
-  // while hidden, so only its user-triggered SetAddTaskMode event starts a
-  // read; an in-page dialog is already visible when this form mounts.
-  const autofillClipboardLinks = useCallback(async () => {
-    const request = ++clipboardAutofillRequest.current
-    if (form.getValues('tab') !== 'links') return
-    if (form.getValues('urls')) return
-    try {
-      const settings = (await transport.invoke(Queries.GetSettings)) as {
-        app?: { autofillClipboardLinks?: boolean }
+  // Refresh open-scoped settings for each actual open. The desktop add-task
+  // window is precreated while hidden, so its mount-time default directory can
+  // be stale by the time the user opens it. In-page dialogs are already visible
+  // when this form mounts and only need clipboard hydration here.
+  const hydrateOpenState = useCallback(
+    async (context?: AddTaskModeHydrationContext) => {
+      const request = ++openHydrationRequest.current
+      try {
+        const settings = (await transport.invoke(Queries.GetSettings)) as {
+          app?: {
+            autofillClipboardLinks?: boolean
+            defaultSaveDir?: string
+          }
+        }
+        if (request !== openHydrationRequest.current) return
+
+        if (
+          context?.refreshDefaultSaveDir &&
+          !form.getFieldState('saveDir').isDirty &&
+          typeof settings?.app?.defaultSaveDir === 'string'
+        ) {
+          form.setValue(
+            'saveDir' as never,
+            settings.app.defaultSaveDir as never,
+            { shouldDirty: false, shouldValidate: false }
+          )
+        }
+
+        if (form.getValues('tab') !== 'links') return
+        if (form.getValues('urls')) return
+        if (settings?.app?.autofillClipboardLinks === false) return
+
+        const content = (await platform.readClipboard()).trim()
+        if (request !== openHydrationRequest.current || !content) return
+        const lines = parseUrlLines(content)
+        if (lines.length === 0 || !lines.every((line) => line.valid)) return
+        if (form.getValues('urls')) return
+        form.setValue(
+          'urls' as never,
+          lines.map((line) => line.url).join('\n') as never,
+          { shouldValidate: true }
+        )
+      } catch {
+        // Best effort — local defaults keep the form usable and the clipboard
+        // may be unreadable under web permissions.
       }
-      if (
-        request !== clipboardAutofillRequest.current ||
-        settings?.app?.autofillClipboardLinks === false
-      ) {
-        return
-      }
-      const content = (await platform.readClipboard()).trim()
-      if (request !== clipboardAutofillRequest.current || !content) return
-      const lines = parseUrlLines(content)
-      if (lines.length === 0 || !lines.every((line) => line.valid)) return
-      if (form.getValues('urls')) return
-      form.setValue(
-        'urls' as never,
-        lines.map((line) => line.url).join('\n') as never,
-        { shouldValidate: true }
-      )
-    } catch {
-      // Best effort — the clipboard may be unreadable (web permissions).
-    }
-  }, [form, platform])
+    },
+    [form, platform]
+  )
 
-  useExternalHydration(form, subscribeEvents, autofillClipboardLinks)
+  useExternalHydration(form, subscribeEvents, hydrateOpenState)
 
-  // Backfill the default save directory for each new task. Per-task advanced
-  // overrides stay empty unless the caller or user supplies them explicitly.
+  // Backfill the default save directory for the initially mounted form.
+  // Desktop opens refresh it again through hydrateOpenState above.
   useEffect(() => {
     let cancelled = false
     ;(async () => {
@@ -150,16 +171,15 @@ export function AddTaskForm({
     }
   }, [form])
 
-  // Only immediately visible in-page dialogs read on mount. Desktop opens are
-  // triggered by useExternalHydration after SetAddTaskMode resets the
-  // precreated form, so precreation never accesses the clipboard and external
-  // prefill always wins.
+  // Only immediately visible in-page dialogs read the clipboard on mount.
+  // Desktop opens are triggered after SetAddTaskMode resets the precreated
+  // form, so precreation never accesses the clipboard and external prefill wins.
   useEffect(() => {
-    if (!subscribeEvents) void autofillClipboardLinks()
+    if (!subscribeEvents) void hydrateOpenState()
     return () => {
-      clipboardAutofillRequest.current += 1
+      openHydrationRequest.current += 1
     }
-  }, [autofillClipboardLinks, subscribeEvents])
+  }, [hydrateOpenState, subscribeEvents])
 
   const onSubmit = useCallback(
     async (values: AddTaskFormValues) => {

--- a/src/renderer/components/add-task/use-external-hydration.ts
+++ b/src/renderer/components/add-task/use-external-hydration.ts
@@ -10,10 +10,14 @@ import {
 import { useEffect } from 'react'
 import type { UseFormReturn } from 'react-hook-form'
 
+export interface AddTaskModeHydrationContext {
+  refreshDefaultSaveDir: boolean
+}
+
 export function useExternalHydration(
   form: UseFormReturn<AddTaskFormValues>,
   enabled: boolean,
-  onModeHydrated?: () => void
+  onModeHydrated?: (context: AddTaskModeHydrationContext) => void
 ) {
   useEffect(() => {
     if (!enabled) return
@@ -59,16 +63,18 @@ export function useExternalHydration(
       const parsed = setAddTaskModeEventPayloadSchema.safeParse(args[0])
       if (!parsed.success) return
       const defaults = urlParamsToFormDefaults(parsed.data)
+      const refreshDefaultSaveDir =
+        defaults.saveDir === undefined && !form.getFieldState('saveDir').isDirty
       // A mode switch without an explicit saveDir must not wipe whatever
-      // is already in the field (e.g. the user's defaultSaveDir that the
-      // form backfilled at mount). Symmetric to onProtocol below.
+      // is already in the field before the current default is refreshed.
+      // A dirty value is a per-task user override and remains authoritative.
       if (defaults.saveDir === undefined) {
         defaults.saveDir = form.getValues('saveDir')
       }
       form.reset(defaults as Partial<AddTaskFormValues>, {
         keepErrors: false,
       })
-      onModeHydrated?.()
+      onModeHydrated?.({ refreshDefaultSaveDir })
     }
 
     transport.on(Events.MagnetFileSelection, onMagnet)


### PR DESCRIPTION
## Summary / 概述

Refresh the default save directory whenever a precreated Add Task window is actually shown, so Settings changes apply on the first open instead of the second. Explicit and dirty per-task directory overrides remain authoritative.

## Related issue / 相关 Issue

Closes #2026

## Changes / 改动

- refresh open-scoped Add Task settings after `SetAddTaskMode`
- preserve explicit and user-selected per-task save directories
- cover stale prewarm state and dirty override behavior with regression tests

## Validation / 验证

- [x] `pnpm run check:boundaries`
- [x] `pnpm run lint`
- [x] `pnpm exec tsc --noEmit`
- [x] Relevant automated tests / 相关自动化测试
- [ ] Manual verification, if applicable / 必要的手动验证

Validation details / 验证详情：

- `pnpm exec vitest run src/renderer/components/add-task/add-task-form.test.tsx src/renderer/components/add-task/use-external-hydration.test.ts` — 2 files, 30 tests passed
- macOS arm64 local worktree

## Checklist / 检查清单

- [x] This pull request targets `main` and contains one focused change.
- [x] User-visible text is localized, and paired English/Chinese documentation stays aligned.
- [x] No credentials, private URLs, personal paths, or other sensitive information are included.
- [x] I have read and followed the [contribution guidelines](https://github.com/agalwood/Motrix/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/agalwood/Motrix/blob/main/CODE_OF_CONDUCT.md).