### PR TITLE
fix(aria2): harden WebSocket RPC and upgrade engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -520,6 +520,15 @@ jobs:
             }
           }
 
+      - name: Verify staged Windows aria2 WebSocket contract
+        if: matrix.platform == 'win32'
+        env:
+          MOTRIX_ARIA2_TEST_BIN: ${{ matrix.resources_dir }}/extra/win32/${{ matrix.arch }}/aria2c.exe
+        run: >-
+          pnpm exec vitest run
+          src/core/engine/aria2/engine-websocket-contract.integration.test.ts
+          --reporter=verbose
+
       - name: Upload Electron size report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -299,7 +299,7 @@ jobs:
                 -path "*/native-messaging-hosts/*" \
               \) -print -quit)"
               output="$("$aria2c" --version)"
-              printf "%s\n" "$output" | grep -qF "aria2 version 1.37.0-motrix.10"
+              printf "%s\n" "$output" | grep -qF "aria2 version 1.37.0-motrix.11"
               printf "%s\n" "$output" | grep -qF "Async DNS"
               printf "%s\n" "$output" | grep -qF "BitTorrent"
               printf "%s\n" "$output" | grep -qF "HTTPS"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,6 +330,15 @@ jobs:
             }
           }
 
+      - name: Verify staged Windows aria2 WebSocket contract
+        if: matrix.platform == 'win32'
+        env:
+          MOTRIX_ARIA2_TEST_BIN: ${{ matrix.resources_dir }}/extra/win32/${{ matrix.arch }}/aria2c.exe
+        run: >-
+          pnpm exec vitest run
+          src/core/engine/aria2/engine-websocket-contract.integration.test.ts
+          --reporter=verbose
+
       - name: Create isolated signing input
         if: >-
           github.event_name == 'push' &&

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -83,8 +83,8 @@ must obtain permission or replace the font before distributing the build.
 Desktop builds bundle an `aria2c` executable pinned by
 `scripts/engine.lock.json`:
 
-- **Version:** 1.37.0-motrix.10
-- **Source:** <https://github.com/motrixapp/aria2/tree/v1.37.0-motrix.10>
+- **Version:** 1.37.0-motrix.11
+- **Source:** <https://github.com/motrixapp/aria2/tree/v1.37.0-motrix.11>
 - **License:** GNU General Public License v2.0 or later (`GPL-2.0-or-later`)
 - **Full license text:** `THIRD_PARTY_LICENSES/aria2-COPYING`
 - **OpenSSL exception / notice:**

--- a/THIRD_PARTY_NOTICES.zh-CN.md
+++ b/THIRD_PARTY_NOTICES.zh-CN.md
@@ -71,8 +71,8 @@ src/renderer/routes/settings/icons/icon-network@2x.png
 
 桌面版随应用打包 `aria2c` 可执行文件，版本由 `scripts/engine.lock.json` 固定：
 
-- **版本：** 1.37.0-motrix.10
-- **对应源码：** <https://github.com/motrixapp/aria2/tree/v1.37.0-motrix.10>
+- **版本：** 1.37.0-motrix.11
+- **对应源码：** <https://github.com/motrixapp/aria2/tree/v1.37.0-motrix.11>
 - **许可证：** GNU General Public License v2.0 or later（`GPL-2.0-or-later`）
 - **完整许可证文本：** `THIRD_PARTY_LICENSES/aria2-COPYING`
 - **OpenSSL 例外条款 / 声明：**

--- a/flatpak/app.motrix.native.yml
+++ b/flatpak/app.motrix.native.yml
@@ -101,7 +101,7 @@ modules:
         set -e
         output="$(src/aria2c --version)"
         printf '%s\n' "$output"
-        printf '%s\n' "$output" | grep -qF 'aria2 version 1.37.0-motrix.10'
+        printf '%s\n' "$output" | grep -qF 'aria2 version 1.37.0-motrix.11'
         for feature in \
           'Async DNS' \
           'BitTorrent' \
@@ -123,8 +123,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/motrixapp/aria2.git
-        tag: v1.37.0-motrix.10
-        commit: 9c48eda5343ee9060ce2136494bdbe3c0a892e8c
+        tag: v1.37.0-motrix.11
+        commit: ab003d49360bac776ada3e967821410f527c00a6
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+-motrix\.\d+)$
@@ -136,9 +136,9 @@ modules:
         commands:
           - |
             sed -i -E \
-              's/AC_INIT\(\[aria2\],\[[^]]+\]/AC_INIT([aria2],[1.37.0-motrix.10]/' \
+              's/AC_INIT\(\[aria2\],\[[^]]+\]/AC_INIT([aria2],[1.37.0-motrix.11]/' \
               configure.ac
-            grep -qF 'AC_INIT([aria2],[1.37.0-motrix.10]' configure.ac
+            grep -qF 'AC_INIT([aria2],[1.37.0-motrix.11]' configure.ac
       - type: script
         dest-filename: autogen.sh
         commands:

--- a/scripts/engine.lock.json
+++ b/scripts/engine.lock.json
@@ -1,50 +1,50 @@
 {
   "engine": "aria2",
   "repo": "motrixapp/aria2",
-  "tag": "v1.37.0-motrix.10",
-  "version": "1.37.0-motrix.10",
+  "tag": "v1.37.0-motrix.11",
+  "version": "1.37.0-motrix.11",
   "assets": {
     "darwin-arm64": {
-      "file": "aria2c-1.37.0-motrix.10-darwin-arm64.tar.gz",
+      "file": "aria2c-1.37.0-motrix.11-darwin-arm64.tar.gz",
       "bin": "aria2c",
-      "archiveSha256": "c4848c92f926d53a445e847b93fb34f3c536ecf2d98861857eb72ff1ec5e935a",
-      "binarySha256": "9c1f5ee711ad8657eef53c8392398c5be961ee1c00afa9692bf282554381e21e"
+      "archiveSha256": "cda62246b0a31d63147d4e706fae50334abf6486d4d6b9d8ba10e5a03f41d110",
+      "binarySha256": "382a2d4d98216368195db5fc7f1e3c859d7b3b46be74d4ab4bbe6e4ab02f7acd"
     },
     "darwin-x64": {
-      "file": "aria2c-1.37.0-motrix.10-darwin-x64.tar.gz",
+      "file": "aria2c-1.37.0-motrix.11-darwin-x64.tar.gz",
       "bin": "aria2c",
-      "archiveSha256": "69ce3fa0895ed4687f188892e6f523d6a1d304cb4a6cb5d806bbb88cf411dc5a",
-      "binarySha256": "437c40c24b71d227a1e47828194ebbe4bc3b0e98fb424513e6fa4e9c22cb318b"
+      "archiveSha256": "bc332ba48439f103d9c067bc2183d4fd96276a1c366561e8995652a3ddf4b981",
+      "binarySha256": "a781a07ff464cd661e567f44bf8bbd9da82673fc2616cd8dcbd5410ba27d1457"
     },
     "win32-x64": {
-      "file": "aria2c-1.37.0-motrix.10-win32-x64.zip",
+      "file": "aria2c-1.37.0-motrix.11-win32-x64.zip",
       "bin": "aria2c.exe",
-      "archiveSha256": "57fec29fac25e40d092aafa12e0d0e0f91766851647354befa024e33a076409d",
-      "binarySha256": "ae8fe4656ebd2f84a4027f67619e6335e2de766ae3e8e729e6b2527ed2455b9a"
+      "archiveSha256": "218b414baf9f25ea4b619bb5d81166be4907736aabf3357cf3c1cf92bb4bcb73",
+      "binarySha256": "810f794962dc7c381e271c2c73d4682708a815fecc59716308ececca786b21db"
     },
     "win32-ia32": {
-      "file": "aria2c-1.37.0-motrix.10-win32-ia32.zip",
+      "file": "aria2c-1.37.0-motrix.11-win32-ia32.zip",
       "bin": "aria2c.exe",
-      "archiveSha256": "68dde2d1265e8c02fb99df0d60c54b0d9920726af485fd639cb2adfc3a6d6b0c",
-      "binarySha256": "04c1c12cb1bc960305b6882b223b85890b378915fdf09d63548a8f9c68617a6b"
+      "archiveSha256": "38c9145577bc668e8771e01f52c72a93bd877cf7aed378a015a08e054ad62494",
+      "binarySha256": "182b0f635926b9d19833f4189d776f7a7a1a0740c43b7faa4f8b4e5679a90bfb"
     },
     "linux-x64": {
-      "file": "aria2c-1.37.0-motrix.10-linux-x64.tar.gz",
+      "file": "aria2c-1.37.0-motrix.11-linux-x64.tar.gz",
       "bin": "aria2c",
-      "archiveSha256": "7e9ed95e1f084d6b37dc720ceaec08d45c1493f8561190930404d905b6bd9bce",
-      "binarySha256": "f3068ee6db15c0448ab1a4509d2da193023dbc7f36abe08621e30732737e3d6b"
+      "archiveSha256": "fdfa0f63281763b66ada47fa824835485ff3eea5ceba6c42abd4034debb63c55",
+      "binarySha256": "2e8a419decb782ff6baffbd6c4c4af007dc94fc4e13b6a1d9e89de586b42ccb5"
     },
     "linux-arm64": {
-      "file": "aria2c-1.37.0-motrix.10-linux-arm64.tar.gz",
+      "file": "aria2c-1.37.0-motrix.11-linux-arm64.tar.gz",
       "bin": "aria2c",
-      "archiveSha256": "a106dd9c65938f922ae2e63f0a1864aac3881f9191dd1cf995316d1eea96ade2",
-      "binarySha256": "6a05f94ae5d1765970bf4a142741d777f9f2f19108efae39c4f7477876a9def5"
+      "archiveSha256": "1ad0f4aa9b70106910def5994d65155f5085ae990d8bab6e8775e04fd838829f",
+      "binarySha256": "6edc0174c8f94b8e005a135f1806de03bafcfb3fd07ba5320222b9c1b9b1f736"
     },
     "linux-arm": {
-      "file": "aria2c-1.37.0-motrix.10-linux-armv7l.tar.gz",
+      "file": "aria2c-1.37.0-motrix.11-linux-armv7l.tar.gz",
       "bin": "aria2c",
-      "archiveSha256": "95d3c097bb8a38eb33314d172e1a3b95d86c182333d02484c1ffb4450e4573be",
-      "binarySha256": "3aae37cf4beec3beeff80b9c0a3a18ca5ce87e454fa59a551dad3de304ff5786"
+      "archiveSha256": "dbb90189eb60f49fb367651a3d3bf7ebb2600e131ed6f73da621d5af9d457dc7",
+      "binarySha256": "f68b85e6faa1aec143331f763b692bd87fa09512286fbd995f3c96904d3aa4c8"
     }
   }
 }

--- a/scripts/verify-flatpak-packaging.mjs
+++ b/scripts/verify-flatpak-packaging.mjs
@@ -18,8 +18,8 @@ export const FLATPAK_BUILDER_TOOLS_COMMIT =
 // tag resolves to is pinned by hand (and cross-checked against the manifest).
 export const ARIA2_SOURCE = Object.freeze({
   url: 'https://github.com/motrixapp/aria2.git',
-  // v1.37.0-motrix.10 — current Motrix aria2 fork release
-  commit: '9c48eda5343ee9060ce2136494bdbe3c0a892e8c',
+  // v1.37.0-motrix.11 — current Motrix aria2 fork release
+  commit: 'ab003d49360bac776ada3e967821410f527c00a6',
 })
 
 const PNPM_SOURCE = Object.freeze({

--- a/src/core/engine/aria2/aria2-process-manager.test.ts
+++ b/src/core/engine/aria2/aria2-process-manager.test.ts
@@ -312,6 +312,27 @@ describe('Aria2ProcessManager', () => {
       })
     })
 
+    it('promotes sparse native RPC diagnostics into production logs', async () => {
+      const mockChild = createMockChildProcess()
+      mockSpawnFn.mockReturnValue(mockChild)
+
+      await manager.spawn('/usr/bin/aria2c', ['--rpc-secret=secret-value'])
+
+      const stdoutHandler = mockChild.stdout.on.mock.calls[0]?.[1]
+      stdoutHandler?.(
+        Buffer.from(
+          'RPC-DIAG CUID#7 first WebSocket response queued: bytes=42\n'
+        )
+      )
+
+      expect(mockLogInfo).toHaveBeenCalledWith(
+        {
+          data: 'RPC-DIAG CUID#7 first WebSocket response queued: bytes=42',
+        },
+        'aria2 RPC diagnostic'
+      )
+    })
+
     it('calls onExit when process exits', async () => {
       const mockChild = createMockChildProcess()
       mockSpawnFn.mockReturnValue(mockChild)

--- a/src/core/engine/aria2/aria2-process-manager.ts
+++ b/src/core/engine/aria2/aria2-process-manager.ts
@@ -21,6 +21,7 @@ const log = getLogger('aria2')
 
 const OWNER_RECORD_VERSION = 1
 const STDERR_TAIL_LIMIT = 32 * 1024
+const RPC_DIAGNOSTIC_MARKER = 'RPC-DIAG'
 const OWNER_MARKER_PREFIXES = [
   '--conf-path=',
   '--save-session=',
@@ -190,10 +191,15 @@ export class Aria2ProcessManager {
     }
 
     child.stdout?.on('data', (data: Buffer) => {
-      log.debug(
-        { data: redactSensitiveText(data.toString().trim(), args) },
-        'aria2 stdout'
-      )
+      const text = redactSensitiveText(data.toString().trim(), args)
+      if (text.includes(RPC_DIAGNOSTIC_MARKER)) {
+        // Native RPC diagnostics are sparse (first queue/send per session and
+        // exceptional states).  Promote only those lines into production logs;
+        // ordinary aria2 stdout remains debug-only.
+        log.info({ data: text }, 'aria2 RPC diagnostic')
+      } else {
+        log.debug({ data: text }, 'aria2 stdout')
+      }
     })
 
     child.stderr?.on('data', (data: Buffer) => {

--- a/src/core/engine/aria2/aria2-trust-store.test.ts
+++ b/src/core/engine/aria2/aria2-trust-store.test.ts
@@ -54,6 +54,41 @@ describe('Aria2TrustStore', () => {
     })
   })
 
+  it('removes external OpenSSL overrides from the bundled Windows engine', async () => {
+    const trustStore = new Aria2TrustStore(userConfigDir, {
+      platform: 'win32',
+      env: {
+        PATH: 'C:\\Windows',
+        OPENSSL_CONF: 'C:\\OpenSSL\\openssl.cnf',
+        OpenSSL_Conf_Include: 'C:\\OpenSSL\\includes',
+        OPENSSL_ENGINES: 'C:\\OpenSSL\\engines',
+        OPENSSL_MODULES: 'C:\\OpenSSL\\modules',
+        OPENSSL_ia32cap: '~0x200000200000000',
+        SSL_CERT_FILE: 'C:\\custom\\roots.pem',
+      },
+    })
+
+    await expect(trustStore.prepareEnvironment()).resolves.toEqual({
+      PATH: 'C:\\Windows',
+      // Trust overrides are separate from provider/config overrides and stay
+      // available for explicit caller policy.
+      SSL_CERT_FILE: 'C:\\custom\\roots.pem',
+    })
+  })
+
+  it('preserves OpenSSL overrides for a system aria2 outside Windows', async () => {
+    const env = {
+      PATH: '/usr/bin',
+      OPENSSL_CONF: '/etc/ssl/custom.cnf',
+    }
+    const trustStore = new Aria2TrustStore(userConfigDir, {
+      platform: 'darwin',
+      env,
+    })
+
+    await expect(trustStore.prepareEnvironment()).resolves.toEqual(env)
+  })
+
   it.each(['SSL_CERT_FILE', 'SSL_CERT_DIR'] as const)(
     'preserves a caller-provided %s',
     async (variable) => {

--- a/src/core/engine/aria2/aria2-trust-store.ts
+++ b/src/core/engine/aria2/aria2-trust-store.ts
@@ -14,6 +14,13 @@ const PROXY_ENVIRONMENT_KEYS = new Set([
   'all_proxy',
   'no_proxy',
 ])
+const WINDOWS_OPENSSL_OVERRIDE_KEYS = new Set([
+  'openssl_conf',
+  'openssl_conf_include',
+  'openssl_engines',
+  'openssl_modules',
+  'openssl_ia32cap',
+])
 
 type Aria2CertificateSource = 'system' | 'bundled'
 
@@ -39,6 +46,16 @@ function withoutProxyEnvironment(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   )
 }
 
+function withoutWindowsOpenSSLOverrides(
+  env: NodeJS.ProcessEnv
+): NodeJS.ProcessEnv {
+  return Object.fromEntries(
+    Object.entries(env).filter(
+      ([key]) => !WINDOWS_OPENSSL_OVERRIDE_KEYS.has(key.toLowerCase())
+    )
+  )
+}
+
 export class Aria2TrustStore {
   private readonly platform: NodeJS.Platform
   private readonly env: NodeJS.ProcessEnv
@@ -59,7 +76,15 @@ export class Aria2TrustStore {
     // Motrix's applied proxy policy must be the only source of aria2 routing.
     // aria2 otherwise imports protocol-specific proxy environment variables,
     // which can override both all-proxy and the metadata client's route.
-    const childEnvironment = withoutProxyEnvironment(this.env)
+    let childEnvironment = withoutProxyEnvironment(this.env)
+    if (this.platform === 'win32') {
+      // The bundled Windows engine statically links OpenSSL and its providers.
+      // Do not let a machine-wide OpenSSL installation replace its config,
+      // provider path, or CPU dispatch.  These overrides also affect aria2's
+      // WebSocket SHA-1 and RPC-secret HMAC, so inheriting them can break local
+      // RPC even when no HTTPS request is made.
+      childEnvironment = withoutWindowsOpenSSLOverrides(childEnvironment)
+    }
     if (this.platform !== 'linux') return childEnvironment
 
     if (this.env.SSL_CERT_FILE?.trim() || this.env.SSL_CERT_DIR?.trim()) {

--- a/src/core/engine/aria2/engine-websocket-contract.integration.test.ts
+++ b/src/core/engine/aria2/engine-websocket-contract.integration.test.ts
@@ -1,0 +1,62 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  type Aria2Handle,
+  bundledAria2Exists,
+  canBindLoopbackTcp,
+  spawnAria2ForTest,
+} from '../../../test-utils/aria2'
+import { Aria2RpcClient } from './aria2-rpc-client'
+import { JsonRpcProtocol } from './json-rpc-protocol'
+import { WebSocketTransport } from './web-socket-transport'
+
+describe.skipIf(!bundledAria2Exists() || !canBindLoopbackTcp())(
+  'bundled aria2 WebSocket contract',
+  () => {
+    let baseDir: string
+    let handle: Aria2Handle
+    let rpc: Aria2RpcClient
+
+    beforeAll(async () => {
+      baseDir = mkdtempSync(path.join(tmpdir(), 'motrix-a2-ws-contract-'))
+      handle = await spawnAria2ForTest({
+        baseDir,
+        waitForHttpRpc: false,
+      })
+
+      const transport = new WebSocketTransport()
+      const protocol = new JsonRpcProtocol(transport, { timeoutMs: 5_000 })
+      rpc = new Aria2RpcClient(transport, protocol, handle.secret)
+      await rpc.connect(handle.port, 40, 250)
+
+      // This is the first round trip EngineSupervisor performs after the
+      // WebSocket upgrade. An open socket without this response is not ready.
+      await expect(rpc.changeGlobalOption({ continue: 'true' })).resolves.toBe(
+        'OK'
+      )
+    }, 20_000)
+
+    afterAll(async () => {
+      rpc?.disconnect()
+      await handle?.kill()
+      if (baseDir) rmSync(baseDir, { recursive: true, force: true })
+    })
+
+    it('returns sequential responses over one connection', async () => {
+      for (let index = 0; index < 25; index += 1) {
+        const version = await rpc.getVersion()
+        expect(version.version).toMatch(/^\d+\.\d+\.\d+/)
+      }
+    })
+
+    it('correlates parallel responses over one connection', async () => {
+      const versions = await Promise.all(
+        Array.from({ length: 16 }, () => rpc.getVersion())
+      )
+      expect(versions).toHaveLength(16)
+      expect(new Set(versions.map((value) => value.version)).size).toBe(1)
+    })
+  }
+)

--- a/src/test-utils/aria2.ts
+++ b/src/test-utils/aria2.ts
@@ -26,6 +26,7 @@ export interface SpawnAria2Options {
   baseDir: string
   port?: number
   secret?: string
+  waitForHttpRpc?: boolean
 }
 
 // Resolve the bundled binary path relative to the repo root.
@@ -38,6 +39,9 @@ export function bundledAria2ExtraDir(): string {
 }
 
 export function resolveBundledAria2(): string {
+  if (process.env.MOTRIX_ARIA2_TEST_BIN) {
+    return path.resolve(process.env.MOTRIX_ARIA2_TEST_BIN)
+  }
   return path.join(
     EXTRA_DIR,
     process.platform,
@@ -115,12 +119,14 @@ export async function spawnAria2ForTest(
   proc.stdout?.on('data', () => {})
   proc.stderr?.on('data', () => {})
 
-  try {
-    await waitForRpc(port, 5000)
-  } catch (err) {
-    // Bail out cleanly if RPC never comes up.
-    if (!proc.killed) proc.kill('SIGKILL')
-    throw err
+  if (opts.waitForHttpRpc !== false) {
+    try {
+      await waitForRpc(port, 5000)
+    } catch (err) {
+      // Bail out cleanly if RPC never comes up.
+      if (!proc.killed) proc.kill('SIGKILL')
+      throw err
+    }
   }
 
   return {

--- a/tests/check-third-party-notices.test.ts
+++ b/tests/check-third-party-notices.test.ts
@@ -408,9 +408,9 @@ describe('third-party graph dependency notices', () => {
 
       expect(notice).toContain('SFNS-Regular.ttf')
       expect(notice).toContain('https://developer.apple.com/fonts/')
-      expect(notice).toContain('1.37.0-motrix.10')
+      expect(notice).toContain('1.37.0-motrix.11')
       expect(notice).toContain(
-        'https://github.com/motrixapp/aria2/tree/v1.37.0-motrix.10'
+        'https://github.com/motrixapp/aria2/tree/v1.37.0-motrix.11'
       )
       expect(notice).toContain('GPL-2.0-or-later')
       expect(notice).toContain('THIRD_PARTY_LICENSES/aria2-COPYING')

--- a/tests/generate-third-party-notices.test.ts
+++ b/tests/generate-third-party-notices.test.ts
@@ -164,7 +164,7 @@ describe('third-party notice generator', () => {
 
     expect(bundle.packageCount).toBeGreaterThan(100)
     expect(inventory).toContain('| @xyflow/react | 12.11.3 |')
-    expect(inventory).toContain('| aria2 | 1.37.0-motrix.10 |')
+    expect(inventory).toContain('| aria2 | 1.37.0-motrix.11 |')
     expect(inventory).toContain('| motrix.filename-template | 1.1.1 |')
     expect(inventory).toContain('Apple San Francisco tray font')
     expect(licenses).toContain('GNU GENERAL PUBLIC LICENSE')


### PR DESCRIPTION
## Summary

- upgrade the bundled engine from `v1.37.0-motrix.10` to the verified `v1.37.0-motrix.11` release across the engine lock, Flatpak, CI, release packaging, and legal notices
- isolate the bundled Windows engine from machine-wide OpenSSL config, provider, engine, and CPU-dispatch overrides while preserving explicit trust-store policy
- promote sparse native `RPC-DIAG` lines into production logs without increasing ordinary aria2 stdout verbosity
- run a real packaged-engine WebSocket contract in Windows CI and release jobs, covering the first RPC response plus sequential and parallel requests on one persistent connection

The WebSocket contract deliberately does not use HTTP RPC readiness or an HTTP fallback.

Closes #2027
Closes #2029

## Validation

- generated the engine lock through `node scripts/fetch-engine.mjs --write-lock --tag v1.37.0-motrix.11`, verifying all seven desktop archives and extracted binary digests
- confirmed the local bundled engine reports `aria2 version 1.37.0-motrix.11`
- passed 155 focused tests, including the real persistent WebSocket contract against the `.11` binary
- passed `pnpm run check:flatpak`
- passed `pnpm run check:third-party-notices`
- passed `pnpm run check:file-names`
- passed `pnpm run check:boundaries`
- passed `pnpm run lint`
- passed `pnpm exec tsc --noEmit`
