### PR TITLE
fix(plugins): complete hook runtime wiring

### DIFF
--- a/src/core/plugin/hooks/hook-orchestrator.test.ts
+++ b/src/core/plugin/hooks/hook-orchestrator.test.ts
@@ -97,7 +97,11 @@ function makeMockWorker(): Worker {
 }
 
 interface MockHostExtras {
-  invocations: Array<{ pluginId: string; hook: string }>
+  invocations: Array<{
+    pluginId: string
+    hook: string
+    ctxPayload?: Record<string, unknown>
+  }>
 }
 
 function makeMockHost(plugins: FixturePlugin[]): {
@@ -121,7 +125,11 @@ function makeMockHost(plugins: FixturePlugin[]): {
   const host: Partial<PluginHost> = {
     allActive: () => active,
     invokeHook: async (id, hook, args) => {
-      extras.invocations.push({ pluginId: id, hook })
+      extras.invocations.push({
+        pluginId: id,
+        hook,
+        ctxPayload: args.ctxPayload,
+      })
       const plugin = plugins.find((p) => p.id === id)
       const bridge = bridges.get(id)
       if (!plugin || !bridge) return
@@ -492,6 +500,39 @@ describe('HookOrchestrator', () => {
   })
 
   describe('runBeforeFinalize', () => {
+    it('passes the full hook DTO into the plugin worker', async () => {
+      const task = { id: 'task-1', saveDir: '/downloads' } as never
+      const initial = makeBeforeFinalizeDto({
+        sourceUrl: 'https://example.com/archive.zip',
+        createdBy: 'protocol',
+        requestedAt: 1_700_000_000_123,
+        task,
+        filePath: '/downloads/archive.zip',
+      })
+      const { host, extras } = makeMockHost([
+        {
+          id: 'plugin-post',
+          role: 'post-process',
+          hooks: ['beforeFinalize'],
+        },
+      ])
+      const orch = new HookOrchestrator({
+        host,
+        hookTimeoutMs: TIMEOUTS,
+        ...ORCH_OPTS_BASE,
+      })
+
+      await orch.runBeforeFinalize(initial, 'task-1')
+
+      expect(extras.invocations[0]?.ctxPayload).toEqual({
+        sourceUrl: initial.sourceUrl,
+        createdBy: initial.createdBy,
+        requestedAt: initial.requestedAt,
+        task,
+        filePath: initial.filePath,
+      })
+    })
+
     it('the last set finalize path wins and propagates through finalFilePath', async () => {
       const { host } = makeMockHost([
         {

--- a/src/core/plugin/hooks/hook-orchestrator.ts
+++ b/src/core/plugin/hooks/hook-orchestrator.ts
@@ -351,6 +351,13 @@ export class HookOrchestrator {
           taskId,
           signal: abort.signal,
           timeoutMs: timeout,
+          ctxPayload: {
+            sourceUrl: initial.sourceUrl,
+            createdBy: initial.createdBy,
+            requestedAt: initial.requestedAt,
+            task: initial.task,
+            filePath: initial.filePath,
+          },
         })
         this.opts.breaker?.success(entry.id, 'beforeFinalize')
       } catch (e) {

--- a/src/core/plugin/hooks/hook-runtime.ts
+++ b/src/core/plugin/hooks/hook-runtime.ts
@@ -1,0 +1,29 @@
+import path from 'node:path'
+import type { PluginHost } from '../host/plugin-host'
+import { HookAuditLog } from './audit-log'
+import { HookOrchestrator } from './hook-orchestrator'
+
+export interface PluginHookRuntime {
+  orchestrator: HookOrchestrator
+  auditLog: HookAuditLog
+}
+
+export function createPluginHookRuntime(opts: {
+  host: PluginHost
+  pluginsDir: string
+  userDataDir: string
+}): PluginHookRuntime {
+  const auditLog = new HookAuditLog(
+    path.join(opts.userDataDir, 'plugin-audit', 'hooks.ndjson')
+  )
+  const orchestrator = new HookOrchestrator({
+    host: opts.host,
+    hookTimeoutMs: { series: 10_000, parallel: 30_000 },
+    pluginsDir: opts.pluginsDir,
+    pluginStorageRootFor: (pluginId) =>
+      path.join(opts.pluginsDir, pluginId, 'storage'),
+    auditLog,
+  })
+
+  return { orchestrator, auditLog }
+}

--- a/src/core/plugin/host/activation-dispatcher.test.ts
+++ b/src/core/plugin/host/activation-dispatcher.test.ts
@@ -526,6 +526,28 @@ describe('ActivationDispatcher', () => {
       })
       expect(host.activate).toHaveBeenCalledWith('url-scoped')
     })
+
+    it('activates wildcard-scoped plugins for nested download paths', async () => {
+      const manifest = makeManifest('nested-path', {
+        activationEvents: ['onTaskType:http'],
+        hostPermissions: ['*://*/*'],
+      })
+      const state: MockHostState = { activeIds: [], meta: [] }
+      const host = makeMockHost(state)
+      const registry = makeMockRegistry([{ manifest }])
+      const dispatcher = new ActivationDispatcher(
+        registry as never,
+        host as never
+      )
+
+      await dispatcher.dispatch({
+        kind: 'taskAdded',
+        taskType: 'http',
+        url: 'https://example.com/releases/v2/archive/file.zip',
+      })
+
+      expect(host.activate).toHaveBeenCalledWith('nested-path')
+    })
   })
 
   describe('AppError typing', () => {

--- a/src/core/plugin/host/activation-dispatcher.ts
+++ b/src/core/plugin/host/activation-dispatcher.ts
@@ -1,6 +1,7 @@
 import { getLogger } from '@core/logger'
 import { AppError, ErrorCode } from '@shared/errors'
 import type { PluginManifest } from '@shared/types/plugin'
+import { urlMatchesHostPermissions } from '../hooks/eligibility'
 import type { PluginRegistry } from '../plugin-registry'
 import {
   type ActiveMeta,
@@ -84,7 +85,7 @@ export class ActivationDispatcher {
       }
       if (
         event.kind === 'taskAdded' &&
-        !hostPermissionsMatch(reg.manifest.hostPermissions ?? [], event.url)
+        !urlMatchesHostPermissions(reg.manifest.hostPermissions, event.url)
       ) {
         skipped.push({
           id: dto.id,
@@ -227,46 +228,6 @@ function effectiveActivationSet(manifest: PluginManifest): Set<string> {
     set.add(`onCommand:${c.id}`)
   }
   return set
-}
-
-function hostPermissionsMatch(
-  patterns: ReadonlyArray<string>,
-  url: string
-): boolean {
-  if (patterns.length === 0) return false
-  let parsed: URL
-  try {
-    parsed = new URL(url)
-  } catch {
-    return false
-  }
-  const scheme = parsed.protocol.replace(':', '')
-  for (const p of patterns) {
-    if (p === '<all_urls>') return true
-    const m = /^(\*|https?):\/\/(\*|(?:\*\.)?[A-Za-z0-9.-]+)(\/.*)?$/.exec(p)
-    if (!m) continue
-    const [, patScheme, patHost, patPath] = m
-    if (patScheme !== '*' && patScheme !== scheme) continue
-    if (patHost !== '*' && !hostMatch(patHost, parsed.hostname)) continue
-    if (patPath && !pathMatch(patPath, parsed.pathname)) continue
-    return true
-  }
-  return false
-}
-
-function hostMatch(pattern: string, host: string): boolean {
-  if (pattern.startsWith('*.')) {
-    const suffix = pattern.slice(2)
-    return host === suffix || host.endsWith(`.${suffix}`)
-  }
-  return host === pattern
-}
-
-function pathMatch(pattern: string, p: string): boolean {
-  const re = new RegExp(
-    `^${pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '[^/]*')}$`
-  )
-  return re.test(p)
 }
 
 // Re-export for test convenience.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -40,6 +40,10 @@ import { NotificationCenter } from '@core/notifications/notification-center'
 import { createNotificationOccurrenceConsumer } from '@core/notifications/occurrence-consumer'
 import { wireCommandSystem } from '@core/plugin/commands/wire'
 import { GrantsManager } from '@core/plugin/grants/grants-manager'
+import {
+  createPluginHookRuntime,
+  type PluginHookRuntime,
+} from '@core/plugin/hooks/hook-runtime'
 import { ActivationDispatcher } from '@core/plugin/host/activation-dispatcher'
 import {
   PluginHost,
@@ -67,7 +71,10 @@ import {
   reAddTask as reAddTaskAction,
   resumeTask as resumeTaskAction,
 } from '@core/task/actions'
-import { finalizeTask } from '@core/task/actions/finalize-task'
+import {
+  type FinalizeTaskDeps,
+  finalizeTask,
+} from '@core/task/actions/finalize-task'
 import { removeTask } from '@core/task/actions/remove-task'
 import { commitPolledTerminalTransition } from '@core/task/actions/shared'
 import { countActiveDownloads } from '@core/task/active-downloads'
@@ -987,7 +994,10 @@ function getFinalizeSettings(): {
   }
 }
 
-function buildFinalizeDeps(adapter: Aria2Adapter) {
+function buildFinalizeDeps(
+  adapter: Aria2Adapter,
+  pluginHooks: PluginHookRuntime
+): FinalizeTaskDeps {
   const activityRecorder = requireTaskActivityService()
   return {
     taskManager: {
@@ -1018,6 +1028,9 @@ function buildFinalizeDeps(adapter: Aria2Adapter) {
     settings: { get: getFinalizeSettings },
     eventBus,
     activityRecorder,
+    orchestrator: pluginHooks.orchestrator,
+    auditLog: pluginHooks.auditLog,
+    db: motrixDb.database,
     recordTransition: (input: RuntimeTransitionInput) =>
       taskInspectorActivityRuntime?.recordTransition(input),
     runTaskMutation: <T>(
@@ -1044,7 +1057,8 @@ function buildFinalizeDeps(adapter: Aria2Adapter) {
 // already acked to the extension points at a task that no longer exists.
 async function startEngineAndRestore(
   sessionSaveInterval: number,
-  adapter: Aria2Adapter
+  adapter: Aria2Adapter,
+  pluginHooks: PluginHookRuntime
 ) {
   log.info({ binaryPath: platform.aria2BinaryPath }, 'resolved aria2 binary')
 
@@ -1157,7 +1171,7 @@ async function startEngineAndRestore(
     // action (rename, reseed, adopt, mark completed/error) so the
     // renderer observes a self-healed state as soon as updates start
     // flowing. See design spec §6.6.
-    const finalizeDepsFactory = () => buildFinalizeDeps(adapter)
+    const finalizeDepsFactory = () => buildFinalizeDeps(adapter, pluginHooks)
     const recoveryService = new TaskRecoveryServiceImpl({
       taskManager: {
         getAll: () => taskManager.getAll(),
@@ -1704,6 +1718,11 @@ async function initializeMainProcess(): Promise<void> {
     ),
   })
   pluginHost = activePluginHost
+  const pluginHooks = createPluginHookRuntime({
+    host: activePluginHost,
+    pluginsDir,
+    userDataDir: platform.userDataDir,
+  })
   // Spec §I30 — real-time grant revocation. On a grants change, deactivate
   // the plugin so the next activation rebuilds its bridge with the new
   // effective permissions. Existing in-flight calls finish; new ones see
@@ -2375,8 +2394,8 @@ async function initializeMainProcess(): Promise<void> {
     pluginGrants,
     capabilityHost: pluginCapHost,
     userDataDir: platform.userDataDir,
-    pluginsDir,
     pluginActivation,
+    pluginHooks,
     // biome-ignore lint/style/noNonNullAssertion: assigned just above in this block
     bridgeManager: bridgeManager!,
     magnetTracker: activeMagnetTracker,
@@ -2482,7 +2501,11 @@ async function initializeMainProcess(): Promise<void> {
       // aria2 route. This prevents a late non-Ready apply result from
       // overwriting the Ready snapshot.
       await proxyReady
-      return startEngineAndRestore(engineSettings.sessionSaveInterval, adapter)
+      return startEngineAndRestore(
+        engineSettings.sessionSaveInterval,
+        adapter,
+        pluginHooks
+      )
     })
     .catch((err) => {
       log.error({ err }, 'engine start/restore failed')

--- a/src/main/ipc/commands.test.ts
+++ b/src/main/ipc/commands.test.ts
@@ -3,6 +3,8 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { NOOP_TASK_ACTIVITY_RECORDER } from '@core/activity'
 import { Aria2Adapter } from '@core/engine/aria2/aria2-adapter'
+import type { PluginHookRuntime } from '@core/plugin/hooks/hook-runtime'
+import { StagedEffectStore } from '@core/plugin/hooks/staged-effects'
 import { AppliedDownloadProxyPolicy } from '@core/proxy/applied-download-proxy-policy'
 import { EXTERNAL_URLS } from '@shared/external-urls'
 import { Commands } from '@shared/protocol/commands'
@@ -76,6 +78,21 @@ vi.mock('./trusted-ipc', () => ({
     listener: (...args: unknown[]) => unknown
   ) => ipcHandleMock(channel, listener),
 }))
+
+function makePluginHooks(): PluginHookRuntime {
+  return {
+    orchestrator: {
+      runBeforeCreateHttp: vi.fn(async (initial) => ({
+        final: initial,
+        contributors: { headers: [] },
+        staged: new StagedEffectStore(),
+      })),
+    } as unknown as PluginHookRuntime['orchestrator'],
+    auditLog: {
+      log: vi.fn(async () => {}),
+    } as unknown as PluginHookRuntime['auditLog'],
+  }
+}
 
 function fakeCtx() {
   // Build the rpc spies first, then wrap them in a real Aria2Adapter so the
@@ -238,6 +255,7 @@ function fakeCtx() {
     pluginActivation: {
       dispatch: vi.fn().mockResolvedValue(undefined),
     },
+    pluginHooks: makePluginHooks(),
     bridgeManager: {
       current: null,
       setEnabled: vi.fn(),

--- a/src/main/ipc/commands.ts
+++ b/src/main/ipc/commands.ts
@@ -14,8 +14,7 @@ import { publishEngineRestartRequired } from '@core/notifications/engine-restart
 import type { NotificationCenter } from '@core/notifications/notification-center'
 import type { CapabilityHost } from '@core/plugin/capabilities/interface'
 import type { GrantsManager } from '@core/plugin/grants/grants-manager'
-import { HookAuditLog } from '@core/plugin/hooks/audit-log'
-import { HookOrchestrator } from '@core/plugin/hooks/hook-orchestrator'
+import type { PluginHookRuntime } from '@core/plugin/hooks/hook-runtime'
 import type { ActivationDispatcher } from '@core/plugin/host/activation-dispatcher'
 import type { PluginHost } from '@core/plugin/host/plugin-host'
 import {
@@ -186,8 +185,8 @@ export interface CommandContext {
   pluginGrants: GrantsManager
   capabilityHost: CapabilityHost
   userDataDir: string
-  pluginsDir: string
   pluginActivation: ActivationDispatcher
+  pluginHooks: PluginHookRuntime
   bridgeManager: BridgeManager
   magnetTracker: MagnetTracker
   activityRecorder: TaskActivityRecorder
@@ -273,8 +272,8 @@ export function buildCommandHandlers(ctx: CommandContext): CommandHandlerMap {
     pluginGrants,
     capabilityHost,
     userDataDir,
-    pluginsDir,
     pluginActivation,
+    pluginHooks,
     bridgeManager,
     activityRecorder,
     persistTask,
@@ -288,22 +287,6 @@ export function buildCommandHandlers(ctx: CommandContext): CommandHandlerMap {
     publishTaskUpdateNow,
   } = ctx
 
-  // Plan C plugin-hook plumbing: instantiate the orchestrator + audit log
-  // once and feed them into createDeps so handleCreateTask's beforeCreate
-  // chain fires. Without this, every plugin's beforeCreate hook is silently
-  // skipped and the user-supplied URL is dispatched to aria2 unchanged.
-  const hookAuditLog = new HookAuditLog(
-    path.join(userDataDir, 'plugin-audit', 'hooks.ndjson')
-  )
-  const hookOrchestrator = new HookOrchestrator({
-    host: pluginHost,
-    hookTimeoutMs: { series: 10_000, parallel: 30_000 },
-    pluginsDir,
-    pluginStorageRootFor: (pluginId) =>
-      path.join(pluginsDir, pluginId, 'storage'),
-    auditLog: hookAuditLog,
-  })
-
   const createDeps: CreateTaskDeps = {
     adapter,
     directResourceValidator: new DirectResourceValidatorService(),
@@ -316,8 +299,8 @@ export function buildCommandHandlers(ctx: CommandContext): CommandHandlerMap {
     eventBus,
     publishTaskUpdate,
     activityRecorder,
-    orchestrator: hookOrchestrator,
-    auditLog: hookAuditLog,
+    orchestrator: pluginHooks.orchestrator,
+    auditLog: pluginHooks.auditLog,
     db: motrixDatabase.database,
     persistTask,
     parentTaskCreated,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -43,6 +43,7 @@ import { projectActiveToLegacy } from '@core/plugin/capabilities/ffmpeg-detect'
 import { wireCommandSystem } from '@core/plugin/commands/wire'
 import { pluginSecretFields } from '@core/plugin/configuration-schema'
 import { GrantsManager } from '@core/plugin/grants/grants-manager'
+import { createPluginHookRuntime } from '@core/plugin/hooks/hook-runtime'
 import { ActivationDispatcher } from '@core/plugin/host/activation-dispatcher'
 import {
   PluginHost,
@@ -69,7 +70,10 @@ import {
   reAddTask as reAddTaskAction,
   resumeTask as resumeTaskAction,
 } from '@core/task/actions'
-import { finalizeTask } from '@core/task/actions/finalize-task'
+import {
+  type FinalizeTaskDeps,
+  finalizeTask,
+} from '@core/task/actions/finalize-task'
 import { removeTask } from '@core/task/actions/remove-task'
 import { commitPolledTerminalTransition } from '@core/task/actions/shared'
 import { handleCreateTask } from '@core/task/create-task-handler'
@@ -523,6 +527,11 @@ async function main() {
       process.env.MOTRIX_PLUGIN_IDLE_DISPOSE_MS
     ),
   })
+  const pluginHooks = createPluginHookRuntime({
+    host: pluginHost,
+    pluginsDir,
+    userDataDir: platform.userDataDir,
+  })
   shutdownActions.drainPluginHost = () => pluginHost.shutdown()
   eventBus.on(Events.PluginGrantsChanged, (...args: unknown[]) => {
     const payload = args[0] as { pluginId?: string } | undefined
@@ -957,9 +966,8 @@ async function main() {
     pluginInstallService,
     pluginGrants,
     capabilityHost: pluginCapHost,
-    userDataDir: platform.userDataDir,
-    pluginsDir,
     pluginActivation,
+    pluginHooks,
     magnetTracker,
     activityRecorder: taskActivityService,
     persistTask,
@@ -1211,7 +1219,7 @@ async function main() {
     // are honored on every reseed (per-finalize, not memoized). Units
     // match aria2's RPC contract: `seedTime` is minutes, `seedRatio` is
     // a unit-less share ratio.
-    const buildFinalizeDeps = () => ({
+    const buildFinalizeDeps = (): FinalizeTaskDeps => ({
       taskManager: {
         getById: (id: string) => taskManager.getById(id),
         getAll: () => taskManager.getAll(),
@@ -1253,6 +1261,9 @@ async function main() {
       },
       eventBus,
       activityRecorder: taskActivityService,
+      orchestrator: pluginHooks.orchestrator,
+      auditLog: pluginHooks.auditLog,
+      db: db.database,
       recordTransition: (input: RuntimeTransitionInput) =>
         taskInspectorActivityRuntime.recordTransition(input),
       runTaskMutation: <T>(

--- a/src/server/ipc/commands.test.ts
+++ b/src/server/ipc/commands.test.ts
@@ -6,6 +6,8 @@ import type { EventBus } from '@core/events/event-bus'
 import { NotificationCenter } from '@core/notifications/notification-center'
 import type { CapabilityHost } from '@core/plugin/capabilities/interface'
 import type { GrantsManager } from '@core/plugin/grants/grants-manager'
+import type { PluginHookRuntime } from '@core/plugin/hooks/hook-runtime'
+import { StagedEffectStore } from '@core/plugin/hooks/staged-effects'
 import type { ActivationDispatcher } from '@core/plugin/host/activation-dispatcher'
 import type { PluginHost } from '@core/plugin/host/plugin-host'
 import type { PluginInstaller } from '@core/plugin/install/plugin-installer'
@@ -44,6 +46,21 @@ const PROXY_OFF = {
   scopes: { download: false, updateApp: false, updateTrackers: false },
 }
 const PROXY_ON = { ...PROXY_OFF, enabled: true, host: 'p.example', port: 80 }
+
+function makePluginHooks(): PluginHookRuntime {
+  return {
+    orchestrator: {
+      runBeforeCreateHttp: vi.fn(async (initial) => ({
+        final: initial,
+        contributors: { headers: [] },
+        staged: new StagedEffectStore(),
+      })),
+    } as unknown as PluginHookRuntime['orchestrator'],
+    auditLog: {
+      log: vi.fn(async () => {}),
+    } as unknown as PluginHookRuntime['auditLog'],
+  }
+}
 
 function makeFakeCtx() {
   return {
@@ -137,6 +154,7 @@ function makeFakeCtx() {
     pluginActivation: {
       dispatch: vi.fn().mockResolvedValue(undefined),
     } as unknown as ActivationDispatcher,
+    pluginHooks: makePluginHooks(),
     magnetTracker: {
       submit: vi.fn().mockResolvedValue(undefined),
       retryMetadata: vi.fn().mockResolvedValue(undefined),

--- a/src/server/ipc/commands.ts
+++ b/src/server/ipc/commands.ts
@@ -1,4 +1,3 @@
-import path from 'node:path'
 import type { Aria2RpcClient } from '@core/engine/aria2/aria2-rpc-client'
 import type { DnsFallbackConsumer } from '@core/engine/aria2/dns-fallback'
 import { dnsModeToAsyncDns } from '@core/engine/aria2/dns-fallback'
@@ -14,8 +13,7 @@ import type { NotificationCenter } from '@core/notifications/notification-center
 import type { CapabilityHost } from '@core/plugin/capabilities/interface'
 import { pluginSecretFields } from '@core/plugin/configuration-schema'
 import type { GrantsManager } from '@core/plugin/grants/grants-manager'
-import { HookAuditLog } from '@core/plugin/hooks/audit-log'
-import { HookOrchestrator } from '@core/plugin/hooks/hook-orchestrator'
+import type { PluginHookRuntime } from '@core/plugin/hooks/hook-runtime'
 import type { ActivationDispatcher } from '@core/plugin/host/activation-dispatcher'
 import type { PluginHost } from '@core/plugin/host/plugin-host'
 import type { PluginInstaller } from '@core/plugin/install/plugin-installer'
@@ -115,9 +113,8 @@ export interface ServerCommandContext {
   pluginInstallService: ServerPluginInstallService
   pluginGrants: GrantsManager
   capabilityHost: CapabilityHost
-  userDataDir: string
-  pluginsDir: string
   pluginActivation: ActivationDispatcher
+  pluginHooks: PluginHookRuntime
   magnetTracker: MagnetTracker
   activityRecorder: TaskActivityRecorder
   persistTask?: NonNullable<TaskActionDeps['persistTask']>
@@ -174,9 +171,8 @@ export function buildServerCommandHandlers(
     pluginInstallService,
     pluginGrants,
     capabilityHost,
-    userDataDir,
-    pluginsDir,
     pluginActivation,
+    pluginHooks,
     magnetTracker,
     activityRecorder,
     persistTask: injectedPersistTask,
@@ -207,22 +203,6 @@ export function buildServerCommandHandlers(
       await persistParent()
     })
 
-  // Plan C plugin-hook plumbing: instantiate the orchestrator + audit log
-  // once and feed them into createDeps so handleCreateTask's beforeCreate
-  // chain fires. Without this, every plugin's beforeCreate hook is silently
-  // skipped and the user-supplied URL is dispatched to aria2 unchanged.
-  const hookAuditLog = new HookAuditLog(
-    path.join(userDataDir, 'plugin-audit', 'hooks.ndjson')
-  )
-  const hookOrchestrator = new HookOrchestrator({
-    host: pluginHost,
-    hookTimeoutMs: { series: 10_000, parallel: 30_000 },
-    pluginsDir,
-    pluginStorageRootFor: (pluginId) =>
-      path.join(pluginsDir, pluginId, 'storage'),
-    auditLog: hookAuditLog,
-  })
-
   const createDeps: CreateTaskDeps = {
     adapter,
     directResourceValidator: new DirectResourceValidatorService(),
@@ -235,8 +215,8 @@ export function buildServerCommandHandlers(
     eventBus,
     publishTaskUpdate,
     activityRecorder,
-    orchestrator: hookOrchestrator,
-    auditLog: hookAuditLog,
+    orchestrator: pluginHooks.orchestrator,
+    auditLog: pluginHooks.auditLog,
     db: motrixDatabase.database,
     persistTask,
     parentTaskCreated,


### PR DESCRIPTION
## Summary / 概述

Complete the plugin hook runtime wiring so task hooks run consistently from creation through finalization in both the Electron and server shells.

Three gaps prevented real plugins from working end to end: lazy activation used a duplicate wildcard matcher that rejected nested URL paths, finalization did not receive the hook orchestrator, and `beforeFinalize` workers received no task context.

## Related issue / 相关 Issue

None.

## Changes / 改动

- Create one shared hook runtime per application shell and reuse it for task creation, recovery, and finalization.
- Inject the orchestrator, audit log, and database into finalization dependencies in Electron and server modes.
- Pass the complete `beforeFinalize` DTO into the plugin worker.
- Reuse the canonical host-permission matcher during lazy activation so `*://*/*` accepts nested download paths.
- Add regression coverage for nested-path activation and finalization payload delivery.

## Validation / 验证

- [x] `pnpm run check:boundaries`
- [x] `pnpm run lint`
- [x] `pnpm exec tsc --noEmit`
- [x] Relevant automated tests / 相关自动化测试
- [x] Manual verification, if applicable / 必要的手动验证

Validation details / 验证详情：

- `pnpm run check:file-names`
- `pnpm exec vitest run src/core/plugin/host/activation-dispatcher.test.ts src/core/plugin/hooks/eligibility.test.ts src/core/plugin/hooks/hook-orchestrator.test.ts src/core/task/actions/finalize-task.test.ts src/main/ipc/commands.test.ts src/server/ipc/commands.test.ts` — 6 files, 261 tests passed.
- `pnpm run check:boundaries`
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `git diff --check`
- `pnpm run verify:electron-package -- --app-dir release/mac-arm64/Motrix.app --platform darwin --arch arm64`
- Manual macOS 26.6.2 arm64 verification: installed an ad-hoc-signed package, downloaded a ZIP from a nested GitHub URL with a configurable File Organizer plugin, and confirmed lazy activation, a committed `beforeFinalize` audit entry, a completed task, and routing into the configured `Compressed` subdirectory.

## Checklist / 检查清单

- [x] This pull request targets `main` and contains one focused change.
- [x] User-visible text is localized, and paired English/Chinese documentation stays aligned.
- [x] No credentials, private URLs, personal paths, or other sensitive information are included.
- [x] I have read and followed the [contribution guidelines](https://github.com/agalwood/Motrix/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/agalwood/Motrix/blob/main/CODE_OF_CONDUCT.md).
