### PR TITLE
fix(settings): fall back when downloads path is unavailable

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,3 +1,5 @@
+import { mkdirSync } from 'node:fs'
+import { homedir } from 'node:os'
 import path from 'node:path'
 import { TaskActivityService, TaskActivityStore } from '@core/activity'
 import { Aria2SegmentClient } from '@core/download/aria2-segment-client'
@@ -288,6 +290,13 @@ const settingsFlatpakEnvironment =
 const defaultSaveDirOptions = resolveDefaultSaveDirOptions({
   snapEnvironment: settingsSnapEnvironment,
   getSystemDownloadsDir: () => app.getPath('downloads'),
+  getHomeDir: homedir,
+  ensureDirectory: (directory) => mkdirSync(directory, { recursive: true }),
+  onSystemDownloadsDirError: (error, fallbackDir) =>
+    log.warn(
+      { err: error, fallbackDir },
+      'system downloads directory unavailable; using home fallback'
+    ),
 })
 const cliToolService = new CliToolService({
   directInstallSupported:

--- a/src/main/platform/default-save-dir.test.ts
+++ b/src/main/platform/default-save-dir.test.ts
@@ -10,24 +10,81 @@ describe('resolveDefaultSaveDirOptions', () => {
     ['Flatpak system folder', '/home/user/Downloads'],
   ])('uses the %s outside Snap', (_label, systemDownloadsDir) => {
     const getSystemDownloadsDir = vi.fn(() => systemDownloadsDir)
+    const getHomeDir = vi.fn(() => '/home/user')
+    const ensureDirectory = vi.fn()
 
     expect(
       resolveDefaultSaveDirOptions({
         snapEnvironment: null,
         getSystemDownloadsDir,
+        getHomeDir,
+        ensureDirectory,
       })
     ).toEqual({ defaultSaveDir: systemDownloadsDir })
     expect(getSystemDownloadsDir).toHaveBeenCalledOnce()
+    expect(getHomeDir).not.toHaveBeenCalled()
+    expect(ensureDirectory).not.toHaveBeenCalled()
+  })
+
+  it('creates a home Downloads fallback when the system folder is unavailable', () => {
+    const getPathError = new Error("Failed to get 'downloads' path")
+    const getSystemDownloadsDir = vi.fn(() => {
+      throw getPathError
+    })
+    const getHomeDir = vi.fn(() => '/home/user')
+    const ensureDirectory = vi.fn()
+    const onSystemDownloadsDirError = vi.fn()
+
+    expect(
+      resolveDefaultSaveDirOptions({
+        snapEnvironment: null,
+        getSystemDownloadsDir,
+        getHomeDir,
+        ensureDirectory,
+        onSystemDownloadsDirError,
+      })
+    ).toEqual({ defaultSaveDir: join('/home/user', 'Downloads') })
+    expect(ensureDirectory).toHaveBeenCalledExactlyOnceWith(
+      join('/home/user', 'Downloads')
+    )
+    expect(onSystemDownloadsDirError).toHaveBeenCalledExactlyOnceWith(
+      getPathError,
+      join('/home/user', 'Downloads')
+    )
+  })
+
+  it('surfaces a failure to create the fallback directory', () => {
+    const createError = new Error('permission denied')
+    const onSystemDownloadsDirError = vi.fn()
+
+    expect(() =>
+      resolveDefaultSaveDirOptions({
+        snapEnvironment: null,
+        getSystemDownloadsDir: () => {
+          throw new Error("Failed to get 'downloads' path")
+        },
+        getHomeDir: () => '/home/user',
+        ensureDirectory: () => {
+          throw createError
+        },
+        onSystemDownloadsDirError,
+      })
+    ).toThrow(createError)
+    expect(onSystemDownloadsDirError).not.toHaveBeenCalled()
   })
 
   it('preserves the real home fallback and migration check for Snap', () => {
     const getSystemDownloadsDir = vi.fn(() => '/unused')
+    const getHomeDir = vi.fn(() => '/unused')
+    const ensureDirectory = vi.fn()
     const options = resolveDefaultSaveDirOptions({
       snapEnvironment: {
         instanceName: 'motrix',
         realHome: '/home/user',
       },
       getSystemDownloadsDir,
+      getHomeDir,
+      ensureDirectory,
     })
 
     expect(options.defaultSaveDir).toBe(join('/home/user', 'Downloads'))
@@ -37,5 +94,7 @@ describe('resolveDefaultSaveDirOptions', () => {
       )
     ).toBe(true)
     expect(getSystemDownloadsDir).not.toHaveBeenCalled()
+    expect(getHomeDir).not.toHaveBeenCalled()
+    expect(ensureDirectory).not.toHaveBeenCalled()
   })
 })

--- a/src/main/platform/default-save-dir.ts
+++ b/src/main/platform/default-save-dir.ts
@@ -8,6 +8,9 @@ export interface DefaultSaveDirOptionsInput {
     'instanceName' | 'realHome'
   > | null
   getSystemDownloadsDir: () => string
+  getHomeDir: () => string
+  ensureDirectory: (directory: string) => void
+  onSystemDownloadsDirError?: (error: unknown, fallbackDir: string) => void
 }
 
 export interface DefaultSaveDirOptions {
@@ -19,9 +22,19 @@ export interface DefaultSaveDirOptions {
 export function resolveDefaultSaveDirOptions({
   snapEnvironment,
   getSystemDownloadsDir,
+  getHomeDir,
+  ensureDirectory,
+  onSystemDownloadsDirError,
 }: DefaultSaveDirOptionsInput): DefaultSaveDirOptions {
   if (snapEnvironment === null) {
-    return { defaultSaveDir: getSystemDownloadsDir() }
+    try {
+      return { defaultSaveDir: getSystemDownloadsDir() }
+    } catch (error) {
+      const fallbackDir = join(getHomeDir(), 'Downloads')
+      ensureDirectory(fallbackDir)
+      onSystemDownloadsDirError?.(error, fallbackDir)
+      return { defaultSaveDir: fallbackDir }
+    }
   }
 
   // Electron resolves Downloads from Snap's revision-scoped HOME. Strict


### PR DESCRIPTION
## Summary / 概述

Prevent the Electron main process from crashing during startup when the operating system download folder cannot be resolved. Electron documents that app.getPath() throws when path resolution fails, which occurs on Windows when the Downloads known folder points to a disconnected drive.

The fallback is platform-neutral for non-Snap desktop environments and resolves to the current user home Downloads directory. On Windows, Node resolves the home directory from USERPROFILE when available. Snap keeps its existing real-home behavior.

## Related issue / 相关 Issue

Closes #2034

## Changes / 改动

- Catch failures from the system Downloads path lookup before settings initialization.
- Create and use the user home Downloads directory as the fallback.
- Log the original path-resolution failure only after the fallback directory is ready.
- Preserve the existing Snap real-home default and persisted custom-directory behavior.
- Add success, fallback, fallback-creation failure, and no-side-effect regression coverage.

## Validation / 验证

- [x] `node scripts/check-boundaries.mjs`
- [x] `node_modules/.bin/biome check .`
- [x] `node_modules/.bin/tsc --noEmit`
- [x] Relevant automated tests / 相关自动化测试
- [ ] Manual verification, if applicable / 必要的手动验证

Validation details / 验证详情：

- `node_modules/.bin/vitest run src/main/platform/default-save-dir.test.ts` — 7 tests passed.
- `node_modules/.bin/vite build --config vite.main.config.ts` — Electron main-process production build passed.
- `git diff --check` and `git diff --cached --check` passed.
- Automated fault injection covers the reported Electron exception. Manual disconnected-drive verification was not available on the macOS development host.
- The isolated worktree reused the main checkout installed toolchain, so the underlying boundary, Biome, TypeScript, Vitest, and Vite entry points were invoked directly instead of through pnpm wrappers.

## Checklist / 检查清单

- [x] This pull request targets `main` and contains one focused change.
- [x] User-visible text is localized, and paired English/Chinese documentation stays aligned. No user-visible text or documentation changed.
- [x] No credentials, private URLs, personal paths, or other sensitive information are included.
- [x] I have read and followed the [contribution guidelines](https://github.com/agalwood/Motrix/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/agalwood/Motrix/blob/main/CODE_OF_CONDUCT.md).