### PR TITLE
fix(release): derive Flatpak companion license manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -492,22 +492,26 @@ jobs:
             "${root}/THIRD_PARTY_NOTICES.md"
             "${root}/THIRD_PARTY_NOTICES.zh-CN.md"
             "${root}/THIRD_PARTY_LICENSES/"
-            "${root}/THIRD_PARTY_LICENSES/MPL-2.0"
-            "${root}/THIRD_PARTY_LICENSES/aria2-COPYING"
-            "${root}/THIRD_PARTY_LICENSES/aria2-LICENSE.OpenSSL"
-            "${root}/THIRD_PARTY_LICENSES/rust-common-LICENSE-APACHE"
-            "${root}/THIRD_PARTY_LICENSES/rust-common-LICENSE-MIT"
-            "${root}/THIRD_PARTY_LICENSES/rust-humantime-LICENSE-MIT"
-            "${root}/THIRD_PARTY_LICENSES/rust-memchr-COPYING"
-            "${root}/THIRD_PARTY_LICENSES/rust-memchr-LICENSE-MIT"
-            "${root}/THIRD_PARTY_LICENSES/rust-memchr-UNLICENSE"
-            "${root}/THIRD_PARTY_LICENSES/rust-unicode-ident-LICENSE-UNICODE"
-            "${root}/THIRD_PARTY_LICENSES/rust-windows-rs-LICENSE-MIT"
+          )
+          while IFS= read -r -d '' source_license; do
+            relative="${source_license#THIRD_PARTY_LICENSES/}"
+            if [[ -d "$source_license" ]]; then
+              expected+=("${root}/THIRD_PARTY_LICENSES/${relative}/")
+            elif [[ -f "$source_license" ]]; then
+              expected+=("${root}/THIRD_PARTY_LICENSES/${relative}")
+            else
+              echo "Unexpected third-party license entry: $source_license" >&2
+              exit 1
+            fi
+          done < <(
+            find THIRD_PARTY_LICENSES -mindepth 1 -print0 |
+              LC_ALL=C sort -z
           )
           mapfile -t actual < <(tar -tzf "$archive")
-          if [[ "${actual[*]}" != "${expected[*]}" ]]; then
+          if ! diff -u \
+            <(printf '%s\n' "${expected[@]}" | LC_ALL=C sort) \
+            <(printf '%s\n' "${actual[@]}" | LC_ALL=C sort); then
             echo "Unexpected Flatpak companion archive contents" >&2
-            printf '  %s\n' "${actual[@]}" >&2
             exit 1
           fi
 

--- a/tests/scripts/workflow-release-matrix.test.ts
+++ b/tests/scripts/workflow-release-matrix.test.ts
@@ -1458,6 +1458,14 @@ describe('release workflow publication contract', () => {
     expect(verificationCommand).toContain('tar -tzf "$archive"')
     expect(verificationCommand).toContain('motrix-flatpak-native-host')
     expect(verificationCommand).toContain('README.zh-CN.md')
+    expect(verificationCommand).toContain(
+      'find THIRD_PARTY_LICENSES -mindepth 1 -print0'
+    )
+    expect(verificationCommand).toContain('LC_ALL=C sort -z')
+    expect(verificationCommand).toContain('diff -u')
+    expect(verificationCommand).not.toContain(
+      'THIRD_PARTY_LICENSES/rust-common-LICENSE-APACHE'
+    )
 
     const uploadInputs = asRecord(upload?.with, 'release input upload')
     expect(stringField(uploadInputs, 'path')).toContain('release/*.tar.gz')


### PR DESCRIPTION
## Summary / 概述

Fix the deterministic Linux release failure that blocked v2.0.0-beta.29. The Flatpak native-host archive verifier now derives its expected third-party license entries from the repository instead of maintaining a stale hard-coded list.

修复阻塞 v2.0.0-beta.29 的 Linux 发布失败。Flatpak Native Host 压缩包校验现在根据仓库中的第三方许可证动态生成期望清单，不再依赖易过期的手写列表。

## Related issue / 相关 Issue

Follow-up to #2043.

## Changes / 改动

- Discover every file and directory under THIRD_PARTY_LICENSES during release verification.
- Keep strict missing/extra archive-entry detection with a sorted diff.
- Add a workflow contract regression test so the verifier cannot silently return to a hard-coded license list.

## Validation / 验证

- [x] pnpm run check:boundaries
- [x] pnpm run lint
- [x] pnpm exec tsc --noEmit
- [x] pnpm exec vitest run tests/scripts/workflow-release-matrix.test.ts tests/scripts/release-version-contract.test.ts — 72 passed
- [x] node --test packages/native-host/package-flatpak-companion.test.mjs — 6 passed
- [x] git diff --check

## Checklist / 检查清单

- [x] This pull request targets main and contains one focused change.
- [x] User-visible text is localized, and paired English/Chinese documentation stays aligned.
- [x] No credentials, private URLs, personal paths, or other sensitive information are included.
- [x] I have read and followed the contribution guidelines and Code of Conduct.