### PR TITLE
chore(l10n): fix some quotes in english and simpchinese

### DIFF
--- a/src/shared/locales/en-US.json
+++ b/src/shared/locales/en-US.json
@@ -1475,7 +1475,7 @@
         "pairToast": {
           "title": "A {{browser}} extension wants to connect to Motrix",
           "extensionId": "ID: {{id}}",
-          "deny": "Don't allow",
+          "deny": "Don’t allow",
           "pairCode": "Pairing code",
           "copyCode": "Copy pairing code",
           "pairCodeHint": "Type this code in the extension",
@@ -1484,7 +1484,7 @@
             "attested": "Verified extension",
             "unverified": "Unverified extension"
           },
-          "identityUnverifiedWarning": "This extension's identity could not be verified. Only continue if you trust it."
+          "identityUnverifiedWarning": "This extension’s identity could not be verified. Only continue if you trust it."
         },
         "pairUnavailable": "This pairing request is no longer pending — retry pairing from the browser extension.",
         "trustedExtensions": "Trusted extensions",
@@ -1502,7 +1502,7 @@
         },
         "degradedPort": {
           "title": "Bridge running on a fallback port",
-          "description": "Ports 16802–16806 were unavailable, so the bridge bound port {{port}} instead. Browser extensions won't find it by probing the standard range — pair using native messaging, or set a fixed port. The Motrix CLI and native host are unaffected."
+          "description": "Ports 16802–16806 were unavailable, so the bridge bound port {{port}} instead. Browser extensions won’t find it by probing the standard range — pair using native messaging, or set a fixed port. The Motrix CLI and native host are unaffected."
         },
         "pairingStateDegraded": {
           "title": "Extension access is temporarily closed",

--- a/src/shared/locales/zh-CN.json
+++ b/src/shared/locales/zh-CN.json
@@ -1593,7 +1593,7 @@
           "untrustedTitle": "FFmpeg 已被 macOS 阻止",
           "usingSource": "当前使用 {{source}}",
           "unavailableDesc": "请设置自定义路径、安装 FFmpeg，或将它加入 PATH 后刷新。",
-          "untrustedDesc": "文件存在，但未通过 macOS 安全验证。请安装可信版本，或在“隐私与安全性”中批准后刷新。",
+          "untrustedDesc": "文件存在，但未通过 macOS 安全验证。请安装可信版本，或在「隐私与安全性」中批准后刷新。",
           "showDetails": "显示检测详情",
           "hideDetails": "隐藏检测详情",
           "sourcesChecked_other": "已检查 {{count}} 个来源",


### PR DESCRIPTION
## Summary / 概述

This PR standardizes the quotation mark style in both English and SimpChinese.

## Related issue / 相关 Issue

N/A

## Changes / 改动

- Replace all English quote marks with curly quotes
- Replace the quote marks in SimpChinese with 「」

## Validation / 验证

<!-- Check every command you ran. Add focused tests and manual checks below. -->

- [x] `pnpm run check:boundaries`
- [x] `pnpm run lint`
- [x] `pnpm exec tsc --noEmit`
- [x] Relevant automated tests / 相关自动化测试
- [x] Manual verification, if applicable / 必要的手动验证

Validation details / 验证详情：

```
$ pnpm run check:boundaries
$ node scripts/check-boundaries.mjs
[PASS] core must not import electron
[PASS] core must not import fastify
[PASS] shared must not use Node-specific APIs or globals
[PASS] renderer must not import core or main
[PASS] server must not import electron
[PASS] server must not import src/main
[PASS] production source must not reference deployment staging contracts
[PASS] add-task UI must not import transport or protocol commands (except the IPC-aware hook/dialog/form)
[PASS] web-services must not reference Electron-only command symbols

$ pnpm run lint
$ biome check .
Checked 1797 files in 2s. No fixes applied.

$ pnpm exec tsc --noEmit

$ pnpm run check:i18n
$ node --import tsx scripts/check-i18n.mjs
check:i18n passed: 3 locales, 1657 logical translation keys.
```

## Checklist / 检查清单

- [x] This pull request targets `main` and contains one focused change.
- [x] User-visible text is localized, and paired English/Chinese documentation stays aligned.
- [x] No credentials, private URLs, personal paths, or other sensitive information are included.
- [x] I have read and followed the [contribution guidelines](https://github.com/agalwood/Motrix/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/agalwood/Motrix/blob/main/CODE_OF_CONDUCT.md).
