### PR TITLE
fix(window): align startup themes and fullscreen chrome

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,24 @@
 <html lang="en-US">
   <head>
     <meta charset="UTF-8" />
+    <meta name="color-scheme" content="light dark" />
+    <style id="motrix-theme-bootstrap">
+      html,
+      body {
+        background: #ffffff;
+        color: #18181b;
+        color-scheme: light;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        html,
+        body {
+          background: #09090b;
+          color: #fafafa;
+          color-scheme: dark;
+        }
+      }
+    </style>
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <title>Motrix</title>

--- a/src/core/plugin/finalize/finalize-committer.test.ts
+++ b/src/core/plugin/finalize/finalize-committer.test.ts
@@ -50,12 +50,19 @@ function makePlan(replacement = false): HookPlan {
 class FakeFilesystem implements FinalizeArtifactOperations {
   readonly artifacts = new Map<string, ArtifactIdentity>()
   readonly actions: string[] = []
+  readonly identityReads = new Map<string, number>()
+
+  constructor(private readonly sameDevice = true) {}
 
   async identity(artifactPath: string): Promise<ArtifactIdentity | null> {
+    this.identityReads.set(
+      artifactPath,
+      (this.identityReads.get(artifactPath) ?? 0) + 1
+    )
     return this.artifacts.get(artifactPath) ?? null
   }
   async sameFilesystem(): Promise<boolean> {
-    return true
+    return this.sameDevice
   }
   async materializePrivate(
     sourcePath: string,
@@ -135,6 +142,52 @@ function makeCommitter(
 }
 
 describe('FinalizeCommitter', () => {
+  it('moves an ordinary same-filesystem source without copying it', async () => {
+    const fs = new FakeFilesystem()
+    const plan = makePlan()
+    fs.artifacts.set(plan.sourcePath, sourceIdentity)
+    const { repository, phases } = makeRepository()
+
+    await makeCommitter(fs, repository).commit(plan)
+
+    expect(fs.artifacts.has(plan.sourcePath)).toBe(false)
+    expect(fs.artifacts.get(plan.targetPath)).toBe(sourceIdentity)
+    expect(fs.actions).toContain(`move:${plan.sourcePath}->${plan.targetPath}`)
+    expect(fs.actions.some((action) => action.startsWith('copy:'))).toBe(false)
+    expect(fs.identityReads.get(plan.sourcePath)).toBe(1)
+    expect(fs.identityReads.get(plan.targetPath)).toBe(1)
+    expect(phases).toEqual([
+      'prepared',
+      'target_installed',
+      'db_committed',
+      'cleaned',
+    ])
+  })
+
+  it('falls back to verified copy publication across filesystems', async () => {
+    const fs = new FakeFilesystem(false)
+    const plan = makePlan()
+    fs.artifacts.set(plan.sourcePath, sourceIdentity)
+    const { repository, phases } = makeRepository()
+
+    await makeCommitter(fs, repository).commit(plan)
+
+    expect(fs.actions).toContain(
+      `copy:${plan.sourcePath}->/save/.motrix-private-plan-1`
+    )
+    expect(fs.artifacts.has(plan.sourcePath)).toBe(false)
+    expect(fs.artifacts.get(plan.targetPath)).toMatchObject({
+      sha256: sourceIdentity.sha256,
+    })
+    expect(phases).toEqual([
+      'prepared',
+      'target_staged',
+      'target_installed',
+      'db_committed',
+      'cleaned',
+    ])
+  })
+
   it('installs a replacement and never renames the original over it', async () => {
     const fs = new FakeFilesystem()
     const plan = makePlan(true)
@@ -187,6 +240,8 @@ describe('FinalizeCommitter', () => {
     )
     expect(fs.artifacts.has(plan.targetPath)).toBe(false)
     expect(fs.artifacts.get(plan.sourcePath)).toBe(sourceIdentity)
+    expect(fs.actions).toContain(`move:${plan.targetPath}->${plan.sourcePath}`)
+    expect(fs.actions.some((action) => action.startsWith('copy:'))).toBe(false)
   })
 
   it('quarantines an identity mismatch without deleting unknown bytes', async () => {

--- a/src/core/plugin/finalize/finalize-committer.ts
+++ b/src/core/plugin/finalize/finalize-committer.ts
@@ -19,6 +19,8 @@ export interface FinalizeJournalRecord {
   journalId: string
   phase: FinalizeJournalPhase
   plan: HookPlan
+  /** Missing on journals created before the move fast path; treat as copy. */
+  publicationMode?: 'copy' | 'move'
   privateTargetPath?: string
   privateTargetIdentity?: ArtifactIdentity
   targetIdentity?: ArtifactIdentity
@@ -131,6 +133,7 @@ export class FinalizeCommitter {
       journalId: plan.planId,
       phase: 'prepared',
       plan,
+      publicationMode: 'copy',
     }
     try {
       await this.requireExactIdentity(
@@ -145,6 +148,7 @@ export class FinalizeCommitter {
           record
         )
       }
+      record.publicationMode = await this.selectPublicationMode(plan)
       await this.options.repository.prepare(record)
       return await this.commitPrepared(record, lease)
     } catch (error) {
@@ -164,6 +168,7 @@ export class FinalizeCommitter {
     const selectedPath = plan.replacement?.stagedPath ?? plan.sourcePath
     const selectedIdentity = plan.replacement?.identity ?? plan.sourceIdentity
     const samePath = finalizePathsEquivalent(plan.sourcePath, plan.targetPath)
+    const movesSource = record.publicationMode === 'move'
 
     if (samePath && !plan.replacement) {
       await this.requireExactIdentity(
@@ -172,6 +177,15 @@ export class FinalizeCommitter {
         record
       )
       await this.options.fs.makeDurable(plan.sourcePath)
+    } else if (movesSource) {
+      // moveNoReplace validates the expected source identity while holding the
+      // artifact and both roots. Avoid hashing large artifacts once more here.
+      await this.options.fs.moveNoReplace(
+        plan.sourcePath,
+        plan.sourceIdentity,
+        plan.targetPath
+      )
+      await this.options.fs.makeDurable(plan.targetPath)
     } else {
       if (samePath) {
         record.rollbackPath = this.options.rollbackPathFor(plan)
@@ -227,13 +241,18 @@ export class FinalizeCommitter {
       await this.options.fs.makeDurable(plan.targetPath)
     }
 
-    const targetIdentity = await this.requireExactIdentity(
-      plan.targetPath,
-      samePath && !plan.replacement
-        ? plan.sourceIdentity
-        : (record.privateTargetIdentity as ArtifactIdentity),
-      record
-    )
+    // A same-filesystem rename preserves the platform file identity and the
+    // move operation already verifies the installed target. Persist that
+    // identity directly, then retain the final pre-DB verification below.
+    const targetIdentity = movesSource
+      ? plan.sourceIdentity
+      : await this.requireExactIdentity(
+          plan.targetPath,
+          samePath && !plan.replacement
+            ? plan.sourceIdentity
+            : (record.privateTargetIdentity as ArtifactIdentity),
+          record
+        )
     record.targetIdentity = targetIdentity
     await this.options.repository.advance(
       record.journalId,
@@ -249,7 +268,7 @@ export class FinalizeCommitter {
     record.phase = 'db_committed'
     let cleanupPending = false
     try {
-      if (!samePath) {
+      if (!samePath && !movesSource) {
         await this.requireExactIdentity(
           plan.sourcePath,
           plan.sourceIdentity,
@@ -303,19 +322,31 @@ export class FinalizeCommitter {
   ): Promise<void> {
     if (record.phase === 'db_committed' || record.phase === 'cleaned') return
     try {
+      const movesSource = record.publicationMode === 'move'
       const installedIdentity =
-        record.targetIdentity ?? record.privateTargetIdentity
+        record.targetIdentity ??
+        record.privateTargetIdentity ??
+        (movesSource ? record.plan.sourceIdentity : undefined)
       const target = await this.options.fs.identity(record.plan.targetPath)
       if (
         target &&
         installedIdentity &&
         this.options.exactIdentity(target, installedIdentity)
       ) {
-        await this.removeTracked(
-          record,
-          record.plan.targetPath,
-          installedIdentity
-        )
+        if (movesSource) {
+          await this.options.fs.moveNoReplace(
+            record.plan.targetPath,
+            installedIdentity,
+            record.plan.sourcePath
+          )
+          await this.options.fs.makeDurable(record.plan.sourcePath)
+        } else {
+          await this.removeTracked(
+            record,
+            record.plan.targetPath,
+            installedIdentity
+          )
+        }
       } else if (target) {
         await this.quarantine(record, 'compensation target identity mismatch')
       }
@@ -368,6 +399,23 @@ export class FinalizeCommitter {
         { cause: compensationError }
       )
     }
+  }
+
+  private async selectPublicationMode(
+    plan: HookPlan
+  ): Promise<'copy' | 'move'> {
+    if (
+      plan.replacement ||
+      finalizePathsEquivalent(plan.sourcePath, plan.targetPath)
+    ) {
+      return 'copy'
+    }
+    return (await this.options.fs.sameFilesystem(
+      plan.sourcePath,
+      plan.targetPath
+    ))
+      ? 'move'
+      : 'copy'
   }
 
   private async requireExactIdentity(

--- a/src/core/plugin/finalize/finalize-recovery.test.ts
+++ b/src/core/plugin/finalize/finalize-recovery.test.ts
@@ -181,6 +181,61 @@ describe('FinalizeRecovery', () => {
     expect(state.phases).toEqual(['cleaned'])
   })
 
+  it('cleans a prepared move journal when publication never started', async () => {
+    const prepared = record('prepared')
+    prepared.publicationMode = 'move'
+    prepared.targetIdentity = undefined
+    const state = fixture({ '/save/source': sourceIdentity })
+
+    await state.recovery.recover(prepared)
+
+    expect(state.artifacts.get('/save/source')).toBe(sourceIdentity)
+    expect(state.artifacts.has('/save/target')).toBe(false)
+    expect(state.phases).toEqual(['cleaned'])
+  })
+
+  it('restores a move published before target_installed was journaled', async () => {
+    const prepared = record('prepared')
+    prepared.publicationMode = 'move'
+    prepared.targetIdentity = undefined
+    const state = fixture({ '/save/target': sourceIdentity })
+
+    await state.recovery.recover(prepared)
+
+    expect(state.artifacts.get('/save/source')).toBe(sourceIdentity)
+    expect(state.artifacts.has('/save/target')).toBe(false)
+    expect(state.phases).toEqual(['cleaned'])
+  })
+
+  it('rolls an uncommitted move publication back to its source name', async () => {
+    const installed = record('target_installed')
+    installed.publicationMode = 'move'
+    installed.targetIdentity = sourceIdentity
+    const state = fixture(
+      { '/save/target': sourceIdentity },
+      { rollForwardTargetInstalled: false }
+    )
+
+    await state.recovery.recover(installed)
+
+    expect(state.artifacts.get('/save/source')).toBe(sourceIdentity)
+    expect(state.artifacts.has('/save/target')).toBe(false)
+    expect(state.phases).toEqual(['cleaned'])
+  })
+
+  it('keeps a committed move publication without source cleanup', async () => {
+    const committed = record('db_committed')
+    committed.publicationMode = 'move'
+    committed.targetIdentity = sourceIdentity
+    const state = fixture({ '/save/target': sourceIdentity })
+
+    await state.recovery.recover(committed)
+
+    expect(state.artifacts.get('/save/target')).toBe(sourceIdentity)
+    expect(state.artifacts.has('/save/source')).toBe(false)
+    expect(state.phases).toEqual(['cleaned'])
+  })
+
   it('rolls back a target moved before target_installed was journaled', async () => {
     const staged = record('target_staged')
     staged.privateTargetPath = '/save/.private'

--- a/src/core/plugin/finalize/finalize-recovery.ts
+++ b/src/core/plugin/finalize/finalize-recovery.ts
@@ -80,6 +80,8 @@ export class FinalizeRecovery {
               privateTarget,
               replacement
             )
+          } else if (record.publicationMode === 'move') {
+            await this.restoreMovedSource(record, source, target)
           } else {
             await this.restore(
               record,
@@ -89,6 +91,10 @@ export class FinalizeRecovery {
               replacement
             )
           }
+          return
+        }
+        if (record.publicationMode === 'move') {
+          await this.restoreMovedSource(record, source, target)
           return
         }
         await this.restore(record, target, rollback, privateTarget, replacement)
@@ -165,6 +171,10 @@ export class FinalizeRecovery {
       }
 
       if (record.phase === 'prepared') {
+        if (record.publicationMode === 'move') {
+          await this.restoreMovedSource(record, source, target)
+          return
+        }
         await this.restorePrepared(
           record,
           source,
@@ -247,7 +257,14 @@ export class FinalizeRecovery {
     privateTarget: Awaited<ReturnType<FinalizeArtifactOperations['identity']>>,
     replacement: Awaited<ReturnType<FinalizeArtifactOperations['identity']>>
   ): Promise<void> {
+    if (record.publicationMode === 'move' && source) {
+      await this.quarantine(
+        record,
+        'moved source path unexpectedly exists after commit'
+      )
+    }
     if (
+      record.publicationMode !== 'move' &&
       source &&
       !finalizePathsEquivalent(record.plan.sourcePath, record.plan.targetPath)
     ) {
@@ -291,6 +308,43 @@ export class FinalizeRecovery {
       )
     }
     await this.removeReplacement(record, replacement)
+    await this.options.repository.advance(record.journalId, 'cleaned')
+  }
+
+  private async restoreMovedSource(
+    record: FinalizeJournalRecord,
+    source: Awaited<ReturnType<FinalizeArtifactOperations['identity']>>,
+    target: Awaited<ReturnType<FinalizeArtifactOperations['identity']>>
+  ): Promise<void> {
+    if (
+      record.plan.replacement ||
+      finalizePathsEquivalent(record.plan.sourcePath, record.plan.targetPath)
+    ) {
+      await this.quarantine(record, 'invalid move publication journal')
+    }
+    if (source && target) {
+      await this.quarantine(
+        record,
+        'source and target both exist during move recovery'
+      )
+    }
+    if (source) {
+      if (!this.options.exactIdentity(source, record.plan.sourceIdentity)) {
+        await this.quarantine(record, 'moved source identity mismatch')
+      }
+      await this.options.repository.advance(record.journalId, 'cleaned')
+      return
+    }
+    const expectedTarget = record.targetIdentity ?? record.plan.sourceIdentity
+    if (!target || !this.options.exactIdentity(target, expectedTarget)) {
+      await this.quarantine(record, 'moved target is missing or changed')
+    }
+    await this.options.fs.moveNoReplace(
+      record.plan.targetPath,
+      expectedTarget,
+      record.plan.sourcePath
+    )
+    await this.options.fs.makeDurable(record.plan.sourcePath)
     await this.options.repository.advance(record.journalId, 'cleaned')
   }
 

--- a/src/core/session/durable-finalize-runtime.test.ts
+++ b/src/core/session/durable-finalize-runtime.test.ts
@@ -40,7 +40,7 @@ describe('DurableFinalizeRuntime', () => {
     const fs = {
       identity: async (artifactPath: string) =>
         artifactPath === sourcePath ? readArtifactIdentity(artifactPath) : null,
-      sameFilesystem: async () => true,
+      sameFilesystem: async () => false,
       materializePrivate: async (
         _source: string,
         identity: ArtifactIdentity

--- a/src/core/session/finalize-journal-repository.test.ts
+++ b/src/core/session/finalize-journal-repository.test.ts
@@ -57,6 +57,30 @@ describe('SqliteFinalizeJournalRepository', () => {
     })
   })
 
+  it('persists the direct-move mode and its shorter phase transition', async () => {
+    const repository = new SqliteFinalizeJournalRepository(db, {
+      now: () => 5,
+      commitTerminalBoundary: vi.fn(),
+    })
+    const record = {
+      ...makeRecord('plan-move'),
+      publicationMode: 'move' as const,
+    }
+
+    await repository.prepare(record)
+    await repository.advance(record.journalId, 'target_installed', {
+      targetIdentity: record.plan.sourceIdentity,
+    })
+
+    expect(await repository.listRecoverable()).toEqual([
+      {
+        ...record,
+        phase: 'target_installed',
+        targetIdentity: record.plan.sourceIdentity,
+      },
+    ])
+  })
+
   it('rolls the journal and terminal callback writes back on failure', async () => {
     db.exec('CREATE TABLE terminal_probe (value TEXT NOT NULL)')
     const repository = new SqliteFinalizeJournalRepository(db, {

--- a/src/core/session/finalize-journal-repository.ts
+++ b/src/core/session/finalize-journal-repository.ts
@@ -3,6 +3,7 @@ import type {
   FinalizeJournalRecord,
   FinalizeJournalRepository,
 } from '@core/plugin/finalize/finalize-committer'
+import { finalizePathsEquivalent } from '@core/plugin/finalize/finalize-committer'
 import { assertValidHookPlan } from '@core/plugin/finalize/hook-plan'
 import type Database from 'better-sqlite3'
 
@@ -141,7 +142,7 @@ export class SqliteFinalizeJournalRepository
     this.db.transaction(() => {
       const current = this.requireRecord(journalId)
       if (current.phase === phase) return
-      if (!transitionAllowed(current.phase, phase)) {
+      if (!transitionAllowed(current, phase)) {
         throw new Error(
           `invalid finalize transition ${current.phase} -> ${phase}`
         )
@@ -254,6 +255,20 @@ function parseRecord(raw: RawFinalizeJournal): FinalizeJournalRecord {
   if (record.phase !== raw.phase) {
     throw new TypeError('journal phase column does not match record')
   }
+  if (
+    record.publicationMode !== undefined &&
+    record.publicationMode !== 'copy' &&
+    record.publicationMode !== 'move'
+  ) {
+    throw new TypeError('journal publication mode is invalid')
+  }
+  if (
+    record.publicationMode === 'move' &&
+    (record.plan.replacement !== undefined ||
+      finalizePathsEquivalent(record.plan.sourcePath, record.plan.targetPath))
+  ) {
+    throw new TypeError('journal move publication plan is invalid')
+  }
   assertValidHookPlan(record.plan)
   const sourceIdentity = JSON.stringify(record.plan.sourceIdentity)
   if (sourceIdentity !== JSON.stringify(JSON.parse(raw.source_identity_json))) {
@@ -270,12 +285,16 @@ function parseRecord(raw: RawFinalizeJournal): FinalizeJournalRecord {
 }
 
 function transitionAllowed(
-  from: FinalizeJournalPhase,
+  record: FinalizeJournalRecord,
   to: FinalizeJournalPhase
 ): boolean {
+  const from = record.phase
   return (
     (from === 'prepared' &&
       (to === 'source_preserved' || to === 'target_staged')) ||
+    (from === 'prepared' &&
+      record.publicationMode === 'move' &&
+      to === 'target_installed') ||
     (from === 'source_preserved' && to === 'target_staged') ||
     (from === 'target_staged' && to === 'target_installed') ||
     ((from === 'prepared' ||

--- a/src/core/session/motrix-database.test.ts
+++ b/src/core/session/motrix-database.test.ts
@@ -203,6 +203,48 @@ describe('saveTaskWithInstances + getAllTasks (Plan A v1 schema)', () => {
     db.close()
   })
 
+  it('rebases persisted task files inside the terminal commit transaction', () => {
+    const db = new MotrixDatabase(':memory:')
+    db.init()
+    const task = makeTaskRow('m-finalize-files', TaskKind.Direct)
+    const sourcePath = '/downloads/file.bin.motrix'
+    const targetPath = '/downloads/file.bin'
+    db.saveTaskWithInstances({ task, instances: [] })
+    db.replaceTaskFiles(task.motrixId, [
+      {
+        fileIndex: 7,
+        path: sourcePath,
+        size: 42,
+        selected: false,
+      },
+    ])
+
+    expect(() =>
+      db.commitTerminalHookBoundary({
+        payload: {
+          task: {
+            ...task,
+            finalPath: targetPath,
+            aggStatus: TaskStatus.Completed,
+          },
+          instances: [],
+        },
+        occurrence: null,
+        fileRebase: { sourceRoot: sourcePath, targetRoot: targetPath },
+      })
+    ).not.toThrow()
+    expect(db.getTaskFiles(task.motrixId)).toEqual([
+      {
+        fileIndex: 7,
+        path: targetPath,
+        size: 42,
+        selected: false,
+      },
+    ])
+
+    db.close()
+  })
+
   it.each(Object.values(TaskType))(
     'round-trips canonical task type %s',
     (taskType) => {

--- a/src/core/session/motrix-database.ts
+++ b/src/core/session/motrix-database.ts
@@ -966,7 +966,7 @@ export class MotrixDatabase {
     sourceRoot: string,
     targetRoot: string
   ): void {
-    const rows = this.stmtGetFiles.all(taskId) as TaskFileRow[]
+    const rows = this.getTaskFiles(taskId)
     let changed = false
     const rebased = rows.map((row) => {
       if (!row.path) return row

--- a/src/core/task/actions/finalize-task.test.ts
+++ b/src/core/task/actions/finalize-task.test.ts
@@ -1851,6 +1851,63 @@ describe('finalizeTask plugin-hook chain (Plan C / T15)', () => {
     expect(task.status).toBe(TaskStatus.Completed)
   })
 
+  it('HTTP: durable commit failure preserves the recoverable rename intent', async () => {
+    const deps: FinalizeTaskDeps = {
+      ...makeDeps(),
+      orchestrator: makeOrchestrator(makeBeforeFinalizeCommit()),
+      auditLog: makeAuditLog(),
+      commitFinalizedArtifact: vi.fn(async () => {
+        throw new Error('database unavailable')
+      }),
+    }
+    const task = makeTask({ instances: [makePrimaryInstance()] })
+    ;(deps.taskManager.getById as ReturnType<typeof vi.fn>).mockReturnValue(
+      task
+    )
+
+    await expect(finalizeTask('t1', deps)).rejects.toThrow(
+      'Failed to commit finalized file: database unavailable'
+    )
+
+    expect(task).toMatchObject({
+      status: TaskStatus.Error,
+      diskPath: '/d/foo.mp4.motrix',
+      finalPath: '/d/foo.mp4',
+      transitionPhase: TransitionPhase.Renaming,
+    })
+    expect(task.instances[0]).toMatchObject({
+      diskPath: '/d/foo.mp4.motrix',
+      transitionPhase: TransitionPhase.Renaming,
+    })
+    expect(deps.activityRecorder.recordDownloadCompleted).not.toHaveBeenCalled()
+  })
+
+  it('BT: durable commit failure preserves the recoverable rename intent', async () => {
+    const deps: FinalizeTaskDeps = {
+      ...makeDeps(),
+      orchestrator: makeOrchestrator(makeBeforeFinalizeCommit()),
+      auditLog: makeAuditLog(),
+      commitFinalizedArtifact: vi.fn(async () => {
+        throw new Error('database unavailable')
+      }),
+    }
+    const task = makeBtTask()
+    ;(deps.taskManager.getById as ReturnType<typeof vi.fn>).mockReturnValue(
+      task
+    )
+
+    await expect(finalizeTask('t1', deps)).rejects.toThrow(
+      'Failed to commit finalized directory: database unavailable'
+    )
+
+    expect(task).toMatchObject({
+      status: TaskStatus.Error,
+      diskPath: '/d/torrent.motrix',
+      finalPath: '/d/torrent',
+      transitionPhase: TransitionPhase.Renaming,
+    })
+  })
+
   it('HTTP: beforeFinalize can route a GitHub ZIP into Compressed through the durable seam', async () => {
     const commitFinalizedArtifact = vi.fn(async () => {})
     const deps: FinalizeTaskDeps = {

--- a/src/core/task/actions/finalize-task.ts
+++ b/src/core/task/actions/finalize-task.ts
@@ -30,6 +30,7 @@ import { fireAfterComplete, fireOnError } from '../hook-dispatch'
 import { normalizeTerminalRuntimeMetrics } from '../normalize-terminal-runtime-metrics'
 import type { OccurrenceDispatcher } from '../occurrences/occurrence-dispatcher'
 import {
+  applyCompletedTaskAfterRename,
   applyTerminalStatusToTask,
   completeTaskAfterRename,
   setTaskTransitionPhase,
@@ -343,17 +344,13 @@ async function commitHttpArtifactDurably(
 ): Promise<void> {
   const completedAt = Date.now()
   const previousStatus = task.status
-  task.finalPath = desiredFinalPath
-  completeTaskAfterRename(
-    task,
-    desiredFinalPath,
-    completedAt,
-    deps.activityRecorder
-  )
-  syncCompletionMetrics(task)
-  normalizeTerminalRuntimeMetrics(task)
+  const completedTask = structuredClone(task)
+  completedTask.finalPath = desiredFinalPath
+  applyCompletedTaskAfterRename(completedTask, desiredFinalPath, completedAt)
+  syncCompletionMetrics(completedTask)
+  normalizeTerminalRuntimeMetrics(completedTask)
   const occurrence = buildTerminalOccurrence(
-    terminalSnapshotFromTask(task),
+    terminalSnapshotFromTask(completedTask),
     previousStatus,
     'finalize',
     completedAt
@@ -361,7 +358,7 @@ async function commitHttpArtifactDurably(
   if (!occurrence)
     throw new Error('HTTP finalize did not produce an occurrence')
   await deps.commitFinalizedArtifact?.({
-    task,
+    task: completedTask,
     occurrence,
     sourcePath: renameSource,
     targetPath: desiredFinalPath,
@@ -373,17 +370,21 @@ async function commitHttpArtifactDurably(
       targetRoot: desiredFinalPath,
     },
   })
-  deps.taskManager.set(task.id, structuredClone(task))
-  await recordTaskTransitionOrWarn(task, previousStatus, deps, {
+  deps.activityRecorder.recordDownloadCompleted({
+    taskId: completedTask.id,
+    occurredAt: completedAt,
+  })
+  deps.taskManager.set(completedTask.id, structuredClone(completedTask))
+  await recordTaskTransitionOrWarn(completedTask, previousStatus, deps, {
     occurredAt: completedAt,
     accuracy: TaskActivityAccuracy.Exact,
     occurrenceId: occurrence.occurrenceId,
     failureMessage: FINALIZE_RECORD_FAILURE_MESSAGE,
   })
   await deps.occurrenceDispatcher?.dispatch(occurrence)
-  deps.eventBus.emit(Events.TaskFilesUpdated, { taskId: task.id })
+  deps.eventBus.emit(Events.TaskFilesUpdated, { taskId: completedTask.id })
   deps.publishTaskUpdateNow()
-  deps.log.info({ taskId: task.id }, 'finalize_http_completed')
+  deps.log.info({ taskId: completedTask.id }, 'finalize_http_completed')
 }
 
 /**
@@ -552,22 +553,13 @@ async function finalizeBt(
   await deps.adapter.removeDownloadResult(task.engineTaskId)
 
   const completedAt = Date.now()
-  task.finalPath = desiredFinalPath
-  task.diskPath = desiredFinalPath
-  // Same instance-row sync as finalizeHttp: the on-disk rename just
-  // happened, so the instance rows must stop pointing at the `.motrix`
-  // container or restore() resurrects it after a restart. Status is
-  // left alone here — the task still heads into reseed and its
-  // terminal state (Seeding/Completed) is decided below.
-  for (const inst of task.instances) {
-    inst.diskPath = desiredFinalPath
-  }
-  setTaskTransitionPhase(task, TransitionPhase.Reseeding)
 
   if (deps.commitFinalizedArtifact) {
+    const renamedTask = structuredClone(task)
+    applyBtTaskAfterRename(renamedTask, desiredFinalPath)
     try {
       await deps.commitFinalizedArtifact({
-        task,
+        task: renamedTask,
         occurrence: null,
         sourcePath: renameSource,
         targetPath: desiredFinalPath,
@@ -579,6 +571,7 @@ async function finalizeBt(
           targetRoot: desiredFinalPath,
         },
       })
+      Object.assign(task, structuredClone(renamedTask))
       deps.taskManager.set(task.id, structuredClone(task))
       deps.eventBus.emit(Events.TaskFilesUpdated, { taskId: task.id })
     } catch (e) {
@@ -622,6 +615,7 @@ async function finalizeBt(
         'finalize_bt_metadata_commit_failed'
       )
     }
+    applyBtTaskAfterRename(task, desiredFinalPath)
     await persistTaskState(task, deps)
   }
 
@@ -643,6 +637,21 @@ async function finalizeBt(
     occurredAt: completedAt,
   })
   await finalizeBtAfterRename(task, deps, completedAt, unselectedRelPaths)
+}
+
+function applyBtTaskAfterRename(
+  task: DownloadTask,
+  desiredFinalPath: string
+): void {
+  task.finalPath = desiredFinalPath
+  task.diskPath = desiredFinalPath
+  // The instance rows must stop pointing at the `.motrix` container or
+  // restore() resurrects it after a restart. Status is left alone here — the
+  // task still heads into reseed and its terminal state is decided below.
+  for (const inst of task.instances) {
+    inst.diskPath = desiredFinalPath
+  }
+  setTaskTransitionPhase(task, TransitionPhase.Reseeding)
 }
 
 async function finalizeBtAfterRename(

--- a/src/core/task/task-instance.ts
+++ b/src/core/task/task-instance.ts
@@ -131,11 +131,10 @@ export function applyTerminalStatusToTask(
  * instance path would resurrect the now-nonexistent placeholder after an
  * app restart, breaking reveal-in-folder and delete-with-files.
  */
-export function completeTaskAfterRename(
+export function applyCompletedTaskAfterRename(
   task: DownloadTask,
   finalDiskPath: string,
-  completedAt: number,
-  activityRecorder: TaskActivityRecorder
+  completedAt: number
 ): void {
   task.diskPath = finalDiskPath
   setTaskTransitionPhase(task, TransitionPhase.Idle)
@@ -143,12 +142,21 @@ export function completeTaskAfterRename(
   for (const instance of task.instances) {
     instance.diskPath = finalDiskPath
   }
-  activityRecorder.recordDownloadCompleted({
-    taskId: task.id,
-    occurredAt: completedAt,
-  })
   Object.assign(
     task,
     applyTerminalTransition(task, TaskStatus.Completed, {}, completedAt)
   )
+}
+
+export function completeTaskAfterRename(
+  task: DownloadTask,
+  finalDiskPath: string,
+  completedAt: number,
+  activityRecorder: TaskActivityRecorder
+): void {
+  applyCompletedTaskAfterRename(task, finalDiskPath, completedAt)
+  activityRecorder.recordDownloadCompleted({
+    taskId: task.id,
+    occurredAt: completedAt,
+  })
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -133,6 +133,7 @@ import {
   autoUpdater as nativeAutoUpdater,
   powerMonitor,
   shell,
+  systemPreferences,
 } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import { bootstrapBridge, createNativeMessagingInstaller } from './bridge'
@@ -168,6 +169,7 @@ import { i18n } from './lib/i18n'
 import { setupLogger } from './logger'
 import { MainProcessWorkCoordinator } from './main-process-work-coordinator'
 import { installAllMenubarContributions } from './menu/contributions'
+import { suppressMacOSAutomaticFullscreenMenuItem } from './menu/macos-fullscreen-menu'
 import { MenuManager } from './menu/menu-manager'
 import { MenuRegistry } from './menu/menu-registry'
 import { createNatManager } from './nat/nat-manager-factory'
@@ -206,6 +208,8 @@ import { WindowManager } from './window/window-manager'
 import { resolveMainWindowStartupPlan } from './window/window-startup-plan'
 
 // ─── Platform Early Setup ───────────────────────────────
+
+suppressMacOSAutomaticFullscreenMenuItem(process.platform, systemPreferences)
 
 if (process.platform === 'win32') {
   app.setAppUserModelId(APP_ID)

--- a/src/main/ipc/commands.test.ts
+++ b/src/main/ipc/commands.test.ts
@@ -749,6 +749,7 @@ describe('buildCommandHandlers', () => {
     fromWebContentsMock
       .mockReturnValueOnce({
         isDestroyed: vi.fn(() => false),
+        isFullScreen: vi.fn(() => false),
         isMaximizable: vi.fn(() => true),
         isMaximized: vi.fn(() => false),
         maximize,
@@ -756,6 +757,7 @@ describe('buildCommandHandlers', () => {
       })
       .mockReturnValueOnce({
         isDestroyed: vi.fn(() => false),
+        isFullScreen: vi.fn(() => false),
         isMaximizable: vi.fn(() => true),
         isMaximized: vi.fn(() => true),
         maximize,
@@ -776,6 +778,32 @@ describe('buildCommandHandlers', () => {
     expect(fromWebContentsMock).toHaveBeenNthCalledWith(2, fakeSender)
     expect(maximize).toHaveBeenCalledOnce()
     expect(unmaximize).toHaveBeenCalledOnce()
+  })
+
+  it('ignores maximize requests while the sender window is full-screen', async () => {
+    const maximize = vi.fn()
+    const unmaximize = vi.fn()
+    const isMaximizable = vi.fn(() => true)
+    const fakeSender = {} as never
+    fromWebContentsMock.mockReturnValueOnce({
+      isDestroyed: vi.fn(() => false),
+      isFullScreen: vi.fn(() => true),
+      isMaximizable,
+      isMaximized: vi.fn(() => false),
+      maximize,
+      unmaximize,
+    })
+    const ctx = fakeCtx()
+    // @ts-expect-error partial ctx
+    const handlers = buildCommandHandlers(ctx)
+
+    await expect(
+      handlers[Commands.ToggleMaximizeCurrentWindow]?.(fakeSender)
+    ).resolves.toEqual({ ok: true })
+
+    expect(isMaximizable).not.toHaveBeenCalled()
+    expect(maximize).not.toHaveBeenCalled()
+    expect(unmaximize).not.toHaveBeenCalled()
   })
 
   it('routes direct shell commands to their owning collaborators', async () => {
@@ -1107,6 +1135,7 @@ describe('buildCommandHandlers', () => {
     await minimizeRegistration?.[1]({ sender })
     fromWebContentsMock.mockReturnValueOnce({
       isDestroyed: () => false,
+      isFullScreen: () => false,
       isMaximizable: () => true,
       isMaximized: () => false,
       maximize: vi.fn(),

--- a/src/main/ipc/commands.ts
+++ b/src/main/ipc/commands.ts
@@ -1137,7 +1137,12 @@ export function buildCommandHandlers(ctx: CommandContext): CommandHandlerMap {
 
     [Commands.ToggleMaximizeCurrentWindow]: async (sender: WebContents) => {
       const win = BrowserWindow.fromWebContents(sender)
-      if (win && !win.isDestroyed() && win.isMaximizable()) {
+      if (
+        win &&
+        !win.isDestroyed() &&
+        !win.isFullScreen() &&
+        win.isMaximizable()
+      ) {
         if (win.isMaximized()) {
           win.unmaximize()
         } else {

--- a/src/main/menu/application-menu-snapshot.test.ts
+++ b/src/main/menu/application-menu-snapshot.test.ts
@@ -141,7 +141,6 @@ function createManager(
     title: 'menu.help.website',
     run: hiddenRun,
   })
-
   menuRegistry.appendItem({
     id: MenuItemIds.AppAbout,
     type: 'normal',
@@ -244,6 +243,7 @@ function createManager(
   })
   return {
     manager,
+    menuRegistry,
     contextStore,
     aboutRun,
     protectedRun,
@@ -268,6 +268,39 @@ describe('MenuManager application-menu snapshot', () => {
     electronMenu.applicationMenus.length = 0
     electronMenu.buildFromTemplate.mockClear()
     electronMenu.setApplicationMenu.mockClear()
+  })
+
+  it('leaves the full-screen role label and accelerator to Electron', () => {
+    const { manager, menuRegistry } = createManager()
+    menuRegistry.appendItem({
+      id: MenuItemIds.WindowToggleFullscreen,
+      type: 'normal',
+      menuId: MenuIds.MenubarWindow,
+      group: '1_window',
+      order: 20,
+      role: 'togglefullscreen',
+      visible: false,
+    })
+
+    manager.install()
+
+    const applicationTemplate =
+      electronMenu.buildFromTemplate.mock.calls[0]?.[0]
+    const windowMenu = applicationTemplate?.find(
+      (item) => item.id === MenuIds.MenubarWindow
+    )
+    const windowSubmenu = Array.isArray(windowMenu?.submenu)
+      ? (windowMenu.submenu as Array<Record<string, unknown>>)
+      : []
+    const fullscreenItem = windowSubmenu.find(
+      (item) => item.id === MenuItemIds.WindowToggleFullscreen
+    )
+    expect(fullscreenItem).toMatchObject({
+      role: 'togglefullscreen',
+      visible: false,
+    })
+    expect(fullscreenItem).not.toHaveProperty('label')
+    expect(fullscreenItem).not.toHaveProperty('accelerator')
   })
 
   it('publishes an initially evaluated, stable dropdown projection', () => {

--- a/src/main/menu/contributions/index.test.ts
+++ b/src/main/menu/contributions/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { MenuIds } from '../menu-ids'
+import { MenuIds, MenuItemIds } from '../menu-ids'
 import { MenuRegistry } from '../menu-registry'
 import { installAllMenubarContributions } from './index'
 
@@ -26,6 +26,21 @@ describe('installAllMenubarContributions', () => {
         .some((item) => item.platforms?.includes('darwin'))
     ).toBe(false)
     expect(reg.getItems(MenuIds.MenubarApp, 'win32')).not.toHaveLength(0)
+  })
+
+  it('registers exactly one hidden native full-screen role on every platform', () => {
+    const reg = new MenuRegistry()
+    installAllMenubarContributions(reg)
+
+    for (const platform of ['darwin', 'win32', 'linux'] as const) {
+      const items = reg.getItems(MenuIds.MenubarWindow, platform)
+      const fullscreenItems = items.filter(
+        (item) => item.role === 'togglefullscreen'
+      )
+      expect(fullscreenItems).toHaveLength(1)
+      expect(fullscreenItems[0]?.id).toBe(MenuItemIds.WindowToggleFullscreen)
+      expect(fullscreenItems[0]?.visible).toBe(false)
+    }
   })
 
   it('task menu starts with New/NewBt/OpenFile', () => {

--- a/src/main/menu/contributions/shared.ts
+++ b/src/main/menu/contributions/shared.ts
@@ -215,7 +215,7 @@ export function contributeSharedMenubar(menuReg: MenuRegistry): void {
     group: '1_basic',
     order: 50,
     role: 'togglefullscreen',
-    titleOverride: 'menu.window.toggleFullscreen',
+    visible: false,
   })
 
   // Help menu

--- a/src/main/menu/macos-fullscreen-menu.test.ts
+++ b/src/main/menu/macos-fullscreen-menu.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  MACOS_AUTOMATIC_FULLSCREEN_MENU_ITEM_KEY,
+  suppressMacOSAutomaticFullscreenMenuItem,
+} from './macos-fullscreen-menu'
+
+describe('suppressMacOSAutomaticFullscreenMenuItem', () => {
+  it('disables the AppKit-injected full-screen row on macOS', () => {
+    const setUserDefault = vi.fn()
+
+    suppressMacOSAutomaticFullscreenMenuItem('darwin', { setUserDefault })
+
+    expect(setUserDefault).toHaveBeenCalledOnce()
+    expect(setUserDefault).toHaveBeenCalledWith(
+      MACOS_AUTOMATIC_FULLSCREEN_MENU_ITEM_KEY,
+      'boolean',
+      false
+    )
+  })
+
+  it.each(['win32', 'linux'] as const)(
+    'does not write macOS defaults on %s',
+    (platform) => {
+      const setUserDefault = vi.fn()
+
+      suppressMacOSAutomaticFullscreenMenuItem(platform, { setUserDefault })
+
+      expect(setUserDefault).not.toHaveBeenCalled()
+    }
+  )
+})

--- a/src/main/menu/macos-fullscreen-menu.ts
+++ b/src/main/menu/macos-fullscreen-menu.ts
@@ -1,0 +1,23 @@
+export const MACOS_AUTOMATIC_FULLSCREEN_MENU_ITEM_KEY =
+  'NSFullScreenMenuItemEverywhere'
+
+interface UserDefaultsWriter {
+  setUserDefault(key: string, type: 'boolean', value: boolean): void
+}
+
+/**
+ * AppKit can inject its own Globe-F full-screen item next to Electron's
+ * togglefullscreen role. Disable that automatic row for this app so Electron
+ * remains the single owner of the menu item, label, shortcut, and action.
+ */
+export function suppressMacOSAutomaticFullscreenMenuItem(
+  platform: NodeJS.Platform,
+  preferences: UserDefaultsWriter
+): void {
+  if (platform !== 'darwin') return
+  preferences.setUserDefault(
+    MACOS_AUTOMATIC_FULLSCREEN_MENU_ITEM_KEY,
+    'boolean',
+    false
+  )
+}

--- a/src/main/menu/menu-manager.ts
+++ b/src/main/menu/menu-manager.ts
@@ -267,10 +267,11 @@ export class MenuManager {
     platform: MenuPlatform
   ): MenuItemConstructorOptions {
     const state = this.evaluateItem(item, this.deps.contextStore.get())
+    const label = this.resolveLabel(item)
     const base: MenuItemConstructorOptions = {
       id: item.id,
       type: item.type,
-      label: this.resolveLabel(item),
+      ...(label ? { label } : {}),
       enabled: state.enabled,
       visible: state.visible,
       checked: state.checked,
@@ -334,13 +335,15 @@ export class MenuManager {
     }
   }
 
-  private resolveLabel(item: MenuItem): string {
+  private resolveLabel(item: MenuItem): string | undefined {
     if (item.titleOverride) return i18n.t(item.titleOverride)
     if (item.commandId) {
       const command = this.deps.commandRegistry.get(item.commandId)
       return command ? i18n.t(command.title) : item.commandId
     }
-    return ''
+    // Role labels are intentionally omitted so Electron/AppKit can supply the
+    // platform-native label. Passing an empty string suppresses that default.
+    return undefined
   }
 
   private reevaluate(): void {

--- a/src/main/window/platform-options.test.ts
+++ b/src/main/window/platform-options.test.ts
@@ -14,6 +14,14 @@ describe('buildPlatformOptions', () => {
     const opts = buildPlatformOptions('win32')
     expect(opts.titleBarStyle).toBe('hidden')
     expect(opts.titleBarOverlay).toBeUndefined()
+    expect(opts.backgroundColor).toBe('#ffffff')
+  })
+
+  it('uses a dark first-paint background for Windows', () => {
+    const opts = buildPlatformOptions('win32', {
+      shouldUseDarkColors: true,
+    })
+    expect(opts.backgroundColor).toBe('#09090b')
   })
 
   it('returns hidden titleBarStyle for Linux', () => {
@@ -21,6 +29,14 @@ describe('buildPlatformOptions', () => {
     expect(opts.titleBarStyle).toBe('hidden')
     expect(opts.titleBarOverlay).toBeUndefined()
     expect(opts.vibrancy).toBeUndefined()
+    expect(opts.backgroundColor).toBe('#ffffff')
+  })
+
+  it('uses a dark first-paint background for Linux', () => {
+    const opts = buildPlatformOptions('linux', {
+      shouldUseDarkColors: true,
+    })
+    expect(opts.backgroundColor).toBe('#09090b')
   })
 
   it('omits vibrancy and uses solid backgroundColor on macOS when vibrancy: false', () => {
@@ -29,6 +45,14 @@ describe('buildPlatformOptions', () => {
     expect(opts.vibrancy).toBeUndefined()
     expect(opts.visualEffectState).toBeUndefined()
     expect(opts.backgroundColor).toBe('#ffffff')
+  })
+
+  it('uses a dark solid macOS background when vibrancy is unavailable', () => {
+    const opts = buildPlatformOptions('darwin', {
+      vibrancy: false,
+      shouldUseDarkColors: true,
+    })
+    expect(opts.backgroundColor).toBe('#09090b')
   })
 
   it('uses transparent macOS chrome without vibrancy for Liquid Glass', () => {

--- a/src/main/window/platform-options.ts
+++ b/src/main/window/platform-options.ts
@@ -3,12 +3,26 @@ import type { BrowserWindowConstructorOptions } from 'electron'
 export interface PlatformOptionsInput {
   vibrancy?: boolean
   liquidGlass?: boolean
+  shouldUseDarkColors?: boolean
 }
+
+export const WINDOW_BACKGROUND = {
+  light: '#ffffff',
+  dark: '#09090b',
+} as const
 
 export function buildPlatformOptions(
   platform: string = process.platform,
-  { vibrancy = true, liquidGlass = false }: PlatformOptionsInput = {}
+  {
+    vibrancy = true,
+    liquidGlass = false,
+    shouldUseDarkColors = false,
+  }: PlatformOptionsInput = {}
 ): BrowserWindowConstructorOptions {
+  const solidBackground = shouldUseDarkColors
+    ? WINDOW_BACKGROUND.dark
+    : WINDOW_BACKGROUND.light
+
   switch (platform) {
     case 'darwin':
       if (liquidGlass) {
@@ -29,16 +43,18 @@ export function buildPlatformOptions(
           }
         : {
             titleBarStyle: 'hiddenInset',
-            backgroundColor: '#ffffff',
+            backgroundColor: solidBackground,
             trafficLightPosition: { x: 20, y: 20 },
           }
     case 'win32':
       return {
         titleBarStyle: 'hidden',
+        backgroundColor: solidBackground,
       }
     default:
       return {
         titleBarStyle: 'hidden',
+        backgroundColor: solidBackground,
       }
   }
 }

--- a/src/main/window/window-manager.test.ts
+++ b/src/main/window/window-manager.test.ts
@@ -53,6 +53,7 @@ vi.mock('electron', () => {
     isVisible = vi.fn(() => this._visible)
     isFocused = vi.fn(() => true)
     isMaximized = vi.fn(() => false)
+    isFullScreen = vi.fn(() => false)
     getBounds = vi.fn(() => ({ ...this._bounds }))
     getNormalBounds = vi.fn(() => ({ ...this._bounds }))
     maximize = vi.fn()
@@ -97,13 +98,14 @@ vi.mock('electron', () => {
 
   return {
     BrowserWindow: MockBrowserWindow,
+    nativeTheme: { shouldUseDarkColors: false },
     screen: mockScreen,
     shell: { openExternal: vi.fn() },
   }
 })
 
 import type { SettingsManager } from '@core/settings/settings-manager'
-import { BrowserWindow } from 'electron'
+import { BrowserWindow, nativeTheme } from 'electron'
 import type { LiquidGlassController } from './liquid-glass'
 import { initializeRendererUrlPolicy } from './renderer-url-policy'
 import { WINDOW_CONFIGS } from './window-configs'
@@ -127,6 +129,9 @@ function createMockSettingsManager(
 describe('WindowManager', () => {
   beforeEach(() => {
     ;(BrowserWindow as unknown as { instances: unknown[] }).instances.length = 0
+    ;(
+      nativeTheme as unknown as { shouldUseDarkColors: boolean }
+    ).shouldUseDarkColors = false
     vi.clearAllMocks()
   })
 
@@ -158,6 +163,23 @@ describe('WindowManager', () => {
     expect(options.titleBarOverlay).toBeUndefined()
   })
 
+  it('matches the first-paint window background to the resolved native theme', () => {
+    ;(
+      nativeTheme as unknown as { shouldUseDarkColors: boolean }
+    ).shouldUseDarkColors = true
+    const wm = new WindowManager({
+      settingsManager: createMockSettingsManager(),
+      preloadPath: '/fake/preload.cjs',
+      loadUrl: vi.fn(),
+      platform: 'win32',
+    })
+
+    const win = wm.open('main')
+    const options = (win as unknown as { options: Record<string, unknown> })
+      .options
+    expect(options.backgroundColor).toBe('#09090b')
+  })
+
   it('publishes the owning window maximize state after load and on changes', () => {
     const wm = new WindowManager({
       settingsManager: createMockSettingsManager(),
@@ -181,6 +203,12 @@ describe('WindowManager', () => {
     const unmaximize = windowListeners.find(
       ([event]) => event === 'unmaximize'
     )?.[1] as (() => void) | undefined
+    const enterFullScreen = windowListeners.find(
+      ([event]) => event === 'enter-full-screen'
+    )?.[1] as (() => void) | undefined
+    const leaveFullScreen = windowListeners.find(
+      ([event]) => event === 'leave-full-screen'
+    )?.[1] as (() => void) | undefined
     const resized = windowListeners.find(
       ([event]) => event === 'resized'
     )?.[1] as (() => void) | undefined
@@ -188,14 +216,29 @@ describe('WindowManager', () => {
     didFinishLoad?.()
     expect(win.webContents.send).toHaveBeenLastCalledWith(
       Events.WindowMaximizedChanged,
-      { maximized: false }
+      { maximized: false, fullscreen: false }
     )
 
     vi.mocked(win.isMaximized).mockReturnValue(true)
     maximize?.()
     expect(win.webContents.send).toHaveBeenLastCalledWith(
       Events.WindowMaximizedChanged,
-      { maximized: true }
+      { maximized: true, fullscreen: false }
+    )
+
+    vi.mocked(win.isMaximized).mockReturnValue(false)
+    vi.mocked(win.isFullScreen).mockReturnValue(true)
+    enterFullScreen?.()
+    expect(win.webContents.send).toHaveBeenLastCalledWith(
+      Events.WindowMaximizedChanged,
+      { maximized: false, fullscreen: true }
+    )
+
+    vi.mocked(win.isFullScreen).mockReturnValue(false)
+    leaveFullScreen?.()
+    expect(win.webContents.send).toHaveBeenLastCalledWith(
+      Events.WindowMaximizedChanged,
+      { maximized: false, fullscreen: false }
     )
 
     // macOS can finish a manual resize without sending unmaximize. The final
@@ -204,7 +247,7 @@ describe('WindowManager', () => {
     resized?.()
     expect(win.webContents.send).toHaveBeenLastCalledWith(
       Events.WindowMaximizedChanged,
-      { maximized: false }
+      { maximized: false, fullscreen: false }
     )
 
     vi.mocked(win.isMaximized).mockReturnValue(true)
@@ -213,7 +256,7 @@ describe('WindowManager', () => {
     unmaximize?.()
     expect(win.webContents.send).toHaveBeenLastCalledWith(
       Events.WindowMaximizedChanged,
-      { maximized: false }
+      { maximized: false, fullscreen: false }
     )
   })
 

--- a/src/main/window/window-manager.ts
+++ b/src/main/window/window-manager.ts
@@ -6,7 +6,7 @@ import {
 } from '@shared/protocol/events'
 import type { AddTaskUrlParams } from '@shared/schemas/add-task'
 import type { WindowBounds, WindowState } from '@shared/types/settings'
-import { BrowserWindow, screen, shell } from 'electron'
+import { BrowserWindow, nativeTheme, screen, shell } from 'electron'
 import type { LiquidGlassController } from './liquid-glass'
 import { buildPlatformOptions } from './platform-options'
 import {
@@ -368,6 +368,7 @@ export class WindowManager {
     const platformOpts = buildPlatformOptions(platform, {
       vibrancy: config.vibrancy && !liquidGlass,
       liquidGlass,
+      shouldUseDarkColors: nativeTheme.shouldUseDarkColors,
     })
 
     const win = new BrowserWindow({
@@ -513,17 +514,20 @@ export class WindowManager {
       if (win.isDestroyed()) return
       const payload: WindowMaximizedChangedPayload = {
         maximized: win.isMaximized(),
+        fullscreen: win.isFullScreen(),
       }
       win.webContents.send(Events.WindowMaximizedChanged, payload)
     }
 
-    // did-finish-load supplies the initial snapshot; maximize/unmaximize keep
-    // it correct for caption clicks, title-bar double-clicks, and OS actions.
+    // did-finish-load supplies the initial snapshot; native state events keep
+    // custom caption controls correct for title-bar, OS, and fullscreen actions.
     // Cocoa can leave the maximized state via a manual resize without emitting
     // unmaximize, so reconcile once the resize gesture finishes as well.
     win.webContents.on('did-finish-load', publish)
     win.on('maximize', publish)
     win.on('unmaximize', publish)
+    win.on('enter-full-screen', publish)
+    win.on('leave-full-screen', publish)
     win.on('resized', publish)
   }
 

--- a/src/preload/preload.test.ts
+++ b/src/preload/preload.test.ts
@@ -88,17 +88,26 @@ describe('preload latest-value replay buffers', () => {
     expect(callback).toHaveBeenCalledTimes(1)
   })
 
-  it('replays only the latest maximize state before chrome subscribes', async () => {
+  it('replays only the latest window state before chrome subscribes', async () => {
     await import('./preload')
-    emit(Events.WindowMaximizedChanged, { maximized: false })
-    emit(Events.WindowMaximizedChanged, { maximized: true })
+    emit(Events.WindowMaximizedChanged, {
+      maximized: false,
+      fullscreen: false,
+    })
+    emit(Events.WindowMaximizedChanged, {
+      maximized: false,
+      fullscreen: true,
+    })
 
     const callback = vi.fn()
     mocks.exposed?.on(Events.WindowMaximizedChanged, callback)
     await Promise.resolve()
 
     expect(callback).toHaveBeenCalledOnce()
-    expect(callback).toHaveBeenCalledWith({ maximized: true })
+    expect(callback).toHaveBeenCalledWith({
+      maximized: false,
+      fullscreen: true,
+    })
   })
 })
 

--- a/src/renderer/components/onboarding/disclaimer-step.test.tsx
+++ b/src/renderer/components/onboarding/disclaimer-step.test.tsx
@@ -69,7 +69,7 @@ describe('DisclaimerStep', () => {
     await waitFor(() => expect(invoke).toHaveBeenCalledTimes(2))
   })
 
-  it('renders professional copy through black Blur Highlights', () => {
+  it('renders professional copy through theme-aware Blur Highlights', () => {
     render(<DisclaimerStep />)
 
     expect(screen.getByRole('heading', { name: 'Usage Notice' })).toBeVisible()
@@ -81,8 +81,14 @@ describe('DisclaimerStep', () => {
     ]
     expect(highlightRoot.textContent).toBe(i18n.t('onboarding.disclaimer.body'))
     expect(highlightRoot.style.getPropertyValue('--blur-highlight-color')).toBe(
-      '#171717'
+      'currentColor'
     )
+    expect(screen.getByTestId('disclaimer-panel')).toHaveClass(
+      'bg-card',
+      'text-card-foreground',
+      'border-border'
+    )
+    expect(highlightRoot).toHaveClass('text-card-foreground')
     expect(highlightedBits.map((bit) => bit.textContent)).toEqual([
       'provides download management only',
       'legally authorized',

--- a/src/renderer/components/onboarding/disclaimer-step.tsx
+++ b/src/renderer/components/onboarding/disclaimer-step.tsx
@@ -31,11 +31,11 @@ export function DisclaimerStep() {
   }
 
   return (
-    <main className="flex min-h-0 flex-1 flex-col px-5 pt-4 pb-5 text-[#1d1d1f]">
+    <main className="flex min-h-0 flex-1 flex-col px-5 pt-4 pb-5 text-foreground">
       <section
         data-testid="disclaimer-panel"
         aria-labelledby="disclaimer-title"
-        className="min-h-0 flex-1 overflow-y-auto rounded-xl border border-black/14 bg-white px-6 py-6 shadow-[0_1px_2px_rgba(0,0,0,0.02)]"
+        className="min-h-0 flex-1 overflow-y-auto rounded-xl border border-border bg-card px-6 py-6 text-card-foreground shadow-sm"
       >
         <div className="space-y-4">
           <h1
@@ -44,7 +44,7 @@ export function DisclaimerStep() {
           >
             {t('onboarding.disclaimer.title')}
           </h1>
-          <p className="text-[14px] leading-6 text-[#3f3f46]">
+          <p className="text-[14px] leading-6 text-card-foreground/80">
             {t('onboarding.disclaimer.summary')}
           </p>
         </div>
@@ -56,11 +56,11 @@ export function DisclaimerStep() {
             t('onboarding.disclaimer.highlights.authorized'),
             t('onboarding.disclaimer.highlights.responsibility'),
           ]}
-          highlightColor="#171717"
+          highlightColor="currentColor"
           highlightClassName="font-medium"
           viewportOptions={{ once: true, amount: 0.5 }}
           className={cn(
-            'mt-6 text-[14px] tracking-[-0.006em] text-[#1d1d1f]',
+            'mt-6 text-[14px] tracking-[-0.006em] text-card-foreground',
             useCjkSpacing ? 'leading-[2.5]' : 'leading-[1.9]'
           )}
         >
@@ -69,7 +69,7 @@ export function DisclaimerStep() {
 
         <p
           className={cn(
-            'text-[13px] leading-5 text-[#6e6e73]',
+            'text-[13px] leading-5 text-muted-foreground',
             useCjkSpacing ? 'mt-8' : 'mt-6'
           )}
         >

--- a/src/renderer/components/onboarding/onboarding-language-select.tsx
+++ b/src/renderer/components/onboarding/onboarding-language-select.tsx
@@ -47,7 +47,7 @@ export function OnboardingLanguageSelect() {
           data-testid="onboarding-language"
           size="sm"
           aria-label={t('onboarding.disclaimer.language')}
-          className="h-8 min-w-28 max-w-64 border-black/10 bg-white/88 text-[13px] text-[#1d1d1f] shadow-[0_1px_3px_rgba(0,0,0,0.08)] backdrop-blur-xl hover:bg-white"
+          className="h-8 min-w-28 max-w-64 border-border bg-card/88 text-[13px] text-card-foreground shadow-sm backdrop-blur-xl hover:bg-card"
         >
           <SelectValue />
         </SelectTrigger>

--- a/src/renderer/components/onboarding/onboarding-surface.tsx
+++ b/src/renderer/components/onboarding/onboarding-surface.tsx
@@ -8,8 +8,7 @@ export function OnboardingSurface({ children }: OnboardingSurfaceProps) {
   return (
     <div
       data-slot="onboarding-surface"
-      className="relative isolate flex h-screen min-h-0 flex-col overflow-hidden bg-[#f7f7f8] text-[#1d1d1f]"
-      style={{ colorScheme: 'light' }}
+      className="relative isolate flex h-screen min-h-0 flex-col overflow-hidden bg-[#f7f7f8] text-foreground dark:bg-[#161617]"
     >
       {children}
     </div>

--- a/src/renderer/components/window-chrome/window-chrome.test.tsx
+++ b/src/renderer/components/window-chrome/window-chrome.test.tsx
@@ -84,6 +84,26 @@ describe('WindowChrome', () => {
     expect((container.firstChild as HTMLElement).style.paddingLeft).toBe('94px')
   })
 
+  it('removes the macOS traffic-light inset while full-screen', () => {
+    const { container } = render(
+      <WindowChrome variant="overlay">
+        <button type="button">App action</button>
+      </WindowChrome>
+    )
+
+    act(() => {
+      emit(Events.WindowMaximizedChanged, {
+        maximized: false,
+        fullscreen: true,
+      })
+    })
+
+    const chrome = container.firstChild as HTMLElement
+    expect(chrome.style.paddingLeft).toBe('')
+    expect(chrome.style.paddingInlineStart).toBe('12px')
+    expect(screen.getByRole('button', { name: 'App action' })).toBeVisible()
+  })
+
   it('renders the title text in titled variant', () => {
     render(<WindowChrome variant="titled" title="My Window" />)
     expect(screen.getByText('My Window')).toBeInTheDocument()
@@ -273,7 +293,10 @@ describe('WindowChrome', () => {
     )
 
     act(() => {
-      emit(Events.WindowMaximizedChanged, { maximized: true })
+      emit(Events.WindowMaximizedChanged, {
+        maximized: true,
+        fullscreen: false,
+      })
     })
 
     const restore = screen.getByRole('button', { name: 'Restore' })
@@ -282,6 +305,88 @@ describe('WindowChrome', () => {
       'data-caption-icon',
       'restore'
     )
+  })
+
+  it.each(['win32', 'linux'] as const)(
+    'keeps %s app actions but hides caption controls while full-screen',
+    (platform) => {
+      setPlatform(platform)
+      const { container } = render(
+        <WindowChrome
+          variant="overlay"
+          leading={<button type="button">Motrix menu</button>}
+        >
+          <button type="button">App action</button>
+        </WindowChrome>
+      )
+
+      act(() => {
+        emit(Events.WindowMaximizedChanged, {
+          maximized: false,
+          fullscreen: true,
+        })
+      })
+
+      const chrome = container.querySelector('.window-chrome')
+      expect(chrome).toBeVisible()
+      expect(chrome).toHaveAttribute('data-fullscreen', 'true')
+      expect(chrome).not.toHaveClass('app-drag')
+      expect(screen.getByRole('button', { name: 'Motrix menu' })).toBeVisible()
+      expect(screen.getByRole('button', { name: 'App action' })).toBeVisible()
+      expect(screen.queryByRole('button', { name: 'Minimize' })).toBeNull()
+      expect(screen.queryByRole('button', { name: 'Maximize' })).toBeNull()
+      expect(screen.queryByRole('button', { name: 'Close' })).toBeNull()
+
+      act(() => {
+        emit(Events.WindowMaximizedChanged, {
+          maximized: false,
+          fullscreen: false,
+        })
+      })
+      expect(container.querySelector('.window-chrome')).toHaveAttribute(
+        'data-fullscreen',
+        'false'
+      )
+      expect(container.querySelector('.window-chrome')).toHaveClass('app-drag')
+      expect(screen.getByRole('button', { name: 'Maximize' })).toBeVisible()
+    }
+  )
+
+  it('uses the same full-screen chrome behavior in the macOS desktop-controls preview', () => {
+    setPlatform('darwin')
+    const { container } = render(
+      <WindowChrome
+        variant="overlay"
+        previewDesktopControls
+        leading={<button type="button">Motrix menu</button>}
+      >
+        <button type="button">App action</button>
+      </WindowChrome>
+    )
+
+    act(() => {
+      emit(Events.WindowMaximizedChanged, {
+        maximized: false,
+        fullscreen: true,
+      })
+    })
+
+    const chrome = container.querySelector('.window-chrome')
+    expect(chrome).toBeVisible()
+    expect(chrome).toHaveAttribute('data-fullscreen', 'true')
+    expect(screen.getByRole('button', { name: 'Motrix menu' })).toBeVisible()
+    expect(screen.getByRole('button', { name: 'App action' })).toBeVisible()
+    expect(screen.queryByRole('button', { name: 'Minimize' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Maximize' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Close' })).toBeNull()
+
+    act(() => {
+      emit(Events.WindowMaximizedChanged, {
+        maximized: false,
+        fullscreen: false,
+      })
+    })
+    expect(screen.getByRole('button', { name: 'Maximize' })).toBeVisible()
   })
 
   it('uses theme-aware caption colors with a readable destructive hover', () => {

--- a/src/renderer/components/window-chrome/window-chrome.tsx
+++ b/src/renderer/components/window-chrome/window-chrome.tsx
@@ -62,20 +62,15 @@ export function WindowChromeCaptionIcon({ name }: { name: CaptionIconName }) {
 }
 
 function DesktopWindowControls({
+  maximized,
   maximizable,
   separateFromActions,
 }: {
+  maximized: boolean
   maximizable: boolean
   separateFromActions: boolean
 }) {
   const { t } = useTranslation()
-  const [maximized, setMaximized] = useState(false)
-  useIpcEvent(Events.WindowMaximizedChanged, (...args) => {
-    const payload = args[0] as WindowMaximizedChangedPayload | undefined
-    if (typeof payload?.maximized === 'boolean') {
-      setMaximized(payload.maximized)
-    }
-  })
 
   const minimize = () => {
     void transport.invoke(Commands.MinimizeCurrentWindow)
@@ -171,6 +166,19 @@ export function WindowChrome({
   children,
 }: WindowChromeProps) {
   const platform = transport.platform
+  const [windowState, setWindowState] = useState({
+    maximized: false,
+    fullscreen: false,
+  })
+  useIpcEvent(Events.WindowMaximizedChanged, (...args) => {
+    const payload = args[0] as WindowMaximizedChangedPayload | undefined
+    if (
+      typeof payload?.maximized === 'boolean' &&
+      typeof payload.fullscreen === 'boolean'
+    ) {
+      setWindowState(payload)
+    }
+  })
   const showDesktopControls = shouldShowDesktopWindowControls(
     platform,
     previewDesktopControls
@@ -178,7 +186,10 @@ export function WindowChrome({
   const isOverlay = variant === 'overlay'
   const isMac = platform === 'darwin'
   const showTrafficLight =
-    __MOTRIX_TARGET__ === 'electron' && isMac && !previewDesktopControls
+    __MOTRIX_TARGET__ === 'electron' &&
+    isMac &&
+    !previewDesktopControls &&
+    !windowState.fullscreen
   const offsetStartActionsForDesktopMenu =
     showDesktopControls && leading != null && actionsPosition === 'start'
 
@@ -214,7 +225,11 @@ export function WindowChrome({
   )
 
   return (
-    <div className="window-chrome app-drag" style={containerStyle}>
+    <div
+      className={cn('window-chrome', !windowState.fullscreen && 'app-drag')}
+      data-fullscreen={windowState.fullscreen}
+      style={containerStyle}
+    >
       {!isOverlay && title && (
         <div className="pt-[14px] text-[13px] font-[600]">{title}</div>
       )}
@@ -233,8 +248,9 @@ export function WindowChrome({
         className="min-w-16 flex-1"
       />
       {actionsPosition === 'end' && actionSlot}
-      {showDesktopControls && (
+      {showDesktopControls && !windowState.fullscreen && (
         <DesktopWindowControls
+          maximized={windowState.maximized}
           maximizable={maximizable}
           separateFromActions={actionsPosition === 'end'}
         />

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -6,6 +6,7 @@ import {
   bootstrapRendererLocale,
   type RendererWindowId,
 } from '@renderer/lib/bootstrap-locale'
+import { applyInitialRendererTheme } from '@renderer/lib/initial-theme'
 import { transport } from '@renderer/lib/transport'
 import { ThemeProvider } from 'next-themes'
 import { lazy, type ReactNode, Suspense } from 'react'
@@ -43,14 +44,16 @@ const windowId: RendererWindowId =
 
 document.documentElement.classList.add(`platform-${transport.platform}`)
 document.documentElement.classList.add(`window-${windowId}`)
+// Apply the resolved class before the locale IPC and React mount. The native
+// BrowserWindow background uses the same Electron nativeTheme value, so the
+// compositor and renderer agree from the first visible frame.
+applyInitialRendererTheme()
 
 function Root({
   children,
-  forcedTheme,
   syncSettings = true,
 }: {
   children: ReactNode
-  forcedTheme?: string
   syncSettings?: boolean
 }) {
   return (
@@ -58,7 +61,6 @@ function Root({
       attribute="class"
       defaultTheme="system"
       enableSystem
-      forcedTheme={forcedTheme}
       disableTransitionOnChange
     >
       <LocaleDirectionProvider>
@@ -84,7 +86,7 @@ async function startRenderer(rootContainer: HTMLElement): Promise<void> {
     )
   } else if (windowId === 'onboarding') {
     root.render(
-      <Root syncSettings={false} forcedTheme="light">
+      <Root syncSettings={false}>
         <Suspense>
           <OnboardingWindow />
         </Suspense>

--- a/src/renderer/lib/initial-theme.test.ts
+++ b/src/renderer/lib/initial-theme.test.ts
@@ -1,0 +1,71 @@
+import '@testing-library/jest-dom/vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  applyInitialRendererTheme,
+  resolveInitialRendererTheme,
+} from './initial-theme'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  window.localStorage.clear()
+  document.documentElement.classList.remove('light', 'dark')
+  document.documentElement.style.colorScheme = ''
+  document.getElementById('motrix-theme-bootstrap')?.remove()
+})
+
+describe('resolveInitialRendererTheme', () => {
+  it.each([
+    [true, 'dark'],
+    [false, 'light'],
+  ] as const)(
+    'uses Electron nativeTheme propagation when prefersDark=%s',
+    (prefersDark, expected) => {
+      expect(
+        resolveInitialRendererTheme({
+          target: 'electron',
+          storedTheme: expected === 'dark' ? 'light' : 'dark',
+          prefersDark,
+        })
+      ).toBe(expected)
+    }
+  )
+
+  it.each(['light', 'dark'] as const)(
+    'honors the web renderer stored theme %s',
+    (storedTheme) => {
+      expect(
+        resolveInitialRendererTheme({
+          target: 'web',
+          storedTheme,
+          prefersDark: storedTheme === 'light',
+        })
+      ).toBe(storedTheme)
+    }
+  )
+
+  it('falls back to the system preference for web system mode', () => {
+    expect(
+      resolveInitialRendererTheme({
+        target: 'web',
+        storedTheme: 'system',
+        prefersDark: true,
+      })
+    ).toBe('dark')
+  })
+
+  it('applies the pre-React class and removes the temporary bootstrap style', () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({ matches: true }))
+    )
+    const bootstrapStyle = document.createElement('style')
+    bootstrapStyle.id = 'motrix-theme-bootstrap'
+    document.head.append(bootstrapStyle)
+
+    expect(applyInitialRendererTheme('electron')).toBe('dark')
+    expect(document.documentElement).toHaveClass('dark')
+    expect(document.documentElement).not.toHaveClass('light')
+    expect(document.documentElement.style.colorScheme).toBe('dark')
+    expect(document.getElementById('motrix-theme-bootstrap')).toBeNull()
+  })
+})

--- a/src/renderer/lib/initial-theme.ts
+++ b/src/renderer/lib/initial-theme.ts
@@ -1,0 +1,52 @@
+export type ResolvedRendererTheme = 'light' | 'dark'
+
+interface ResolveInitialRendererThemeInput {
+  target: 'electron' | 'web'
+  storedTheme?: string | null
+  prefersDark: boolean
+}
+
+/**
+ * Resolve the class used before React mounts. Electron's main process applies
+ * the persisted preference to nativeTheme before opening a window, so its
+ * prefers-color-scheme value is authoritative. The web renderer has no native
+ * theme bridge and therefore consults next-themes' localStorage value first.
+ */
+export function resolveInitialRendererTheme({
+  target,
+  storedTheme,
+  prefersDark,
+}: ResolveInitialRendererThemeInput): ResolvedRendererTheme {
+  if (target === 'web' && (storedTheme === 'light' || storedTheme === 'dark')) {
+    return storedTheme
+  }
+  return prefersDark ? 'dark' : 'light'
+}
+
+export function applyInitialRendererTheme(
+  target: 'electron' | 'web' = __MOTRIX_TARGET__
+): ResolvedRendererTheme {
+  let storedTheme: string | null = null
+  if (target === 'web') {
+    try {
+      storedTheme = window.localStorage.getItem('theme')
+    } catch {
+      // Storage may be disabled; the system preference remains a safe default.
+    }
+  }
+
+  const theme = resolveInitialRendererTheme({
+    target,
+    storedTheme,
+    prefersDark: window.matchMedia('(prefers-color-scheme: dark)').matches,
+  })
+  const root = document.documentElement
+  root.classList.remove(theme === 'dark' ? 'light' : 'dark')
+  root.classList.add(theme)
+  root.style.colorScheme = theme
+  // The inline head style protects the blank document before the renderer
+  // bundle loads. Once the semantic stylesheet and theme class are ready it
+  // must be removed so platform rules such as macOS transparency can win.
+  document.getElementById('motrix-theme-bootstrap')?.remove()
+  return theme
+}

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -210,6 +210,21 @@
   --window-chrome-safe-area-trailing: 112px;
 }
 
+/* Fullscreen hides desktop caption controls but retains the Motrix menu and app
+   actions. Release only the trailing safe area; the leading 160px still keeps
+   compact PanelShell content clear of menu/sidebar/add-task controls. The
+   macOS desktop-controls mode previews the same behavior. */
+.platform-linux.window-main
+.electron-window-chrome:has(.window-chrome[data-fullscreen="true"]),
+.platform-darwin.window-main
+  .electron-window-chrome.preview-desktop-window-controls:has(
+    .window-chrome[data-fullscreen="true"]
+  ),
+.platform-win32.window-main
+  .electron-window-chrome:has(.window-chrome[data-fullscreen="true"]) {
+  --window-chrome-safe-area-trailing: 24px;
+}
+
 @media (width >= 48rem) {
   .electron-window-chrome.group\/sidebar-wrapper[data-state="expanded"]
     .panel-action-align-visual-end {
@@ -287,9 +302,17 @@
   background-color: rgb(247 247 248 / 72%);
 }
 
+.dark.platform-darwin.window-onboarding [data-slot="onboarding-surface"] {
+  background-color: rgb(22 22 23 / 76%);
+}
+
 @media (prefers-reduced-transparency: reduce) {
   .platform-darwin.window-onboarding [data-slot="onboarding-surface"] {
     background-color: #f7f7f8;
+  }
+
+  .dark.platform-darwin.window-onboarding [data-slot="onboarding-surface"] {
+    background-color: #161617;
   }
 }
 

--- a/src/renderer/windows/onboarding-window.test.tsx
+++ b/src/renderer/windows/onboarding-window.test.tsx
@@ -31,5 +31,14 @@ describe('OnboardingWindow', () => {
       'pt-3.5'
     )
     expect(screen.getByRole('heading', { name: '使用声明' })).toBeVisible()
+    const surface = document.querySelector(
+      '[data-slot="onboarding-surface"]'
+    ) as HTMLElement
+    expect(surface).toHaveClass(
+      'bg-[#f7f7f8]',
+      'dark:bg-[#161617]',
+      'text-foreground'
+    )
+    expect(surface.style.colorScheme).toBe('')
   })
 })

--- a/src/shared/protocol/events.ts
+++ b/src/shared/protocol/events.ts
@@ -6,6 +6,7 @@ export interface LocaleChangedPayload {
 
 export interface WindowMaximizedChangedPayload {
   maximized: boolean
+  fullscreen: boolean
 }
 
 export const Events = {


### PR DESCRIPTION
## Summary

- eliminate the dark-mode startup white flash by aligning the native window background and pre-React renderer theme
- make the Usage Notice follow the system light or dark appearance with shared semantic color tokens
- publish fullscreen state to window chrome, hide desktop caption controls while fullscreen, and reject maximize requests in fullscreen
- keep the Electron fullscreen role hidden and suppress the duplicate AppKit fullscreen menu item on macOS
- preserve Motrix menu, sidebar toggle, and new-task actions while removing fullscreen-only window insets

## Testing

- ./node_modules/.bin/biome check .
- ./node_modules/.bin/tsc --noEmit
- 81 focused window, menu, preload, and onboarding tests passed
- Vite main, preload, worker, and renderer builds passed
- full Vitest run: 8,778 passed; 205 tests in 17 pre-existing HTTP/WebSocket suites could not bind local ports in the restricted sandbox and failed with listen EPERM; an unsandboxed rerun was requested twice but permission review timed out
- manually inspected the running macOS Window menu after the fullscreen role was hidden

Closes #2050
Closes #2051
Closes #2053