### PR TITLE
chore(release): prepare 2.0.0-beta.31

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. After its remaining release gates pass,
-download [v2.0.0-beta.30 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.30)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.30.md) before
+download [v2.0.0-beta.31 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.31)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.31.md) before
 installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -165,7 +165,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.30'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.31'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。剩余发布门禁通过后，请从 GitHub Releases
-下载 [v2.0.0-beta.30](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.30)，
-并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.30.zh-CN.md)。
+下载 [v2.0.0-beta.31](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.31)，
+并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.31.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -156,7 +156,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.30'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.31'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.31.md
+++ b/docs/release-notes/2.0.0-beta.31.md
@@ -1,0 +1,97 @@
+# Motrix 2.0.0-beta.31
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.31/docs/release-notes/2.0.0-beta.31.zh-CN.md)
+
+Motrix 2.0.0-beta.31 is a reliability and desktop-polish update. It improves
+durable download finalization, fixes Motrix Extension startup in Docker,
+aligns window state and first-run styling across themes, and refreshes the
+Windows installer experience. It is intended for public distribution only
+after every protected release gate passes.
+
+## Highlights
+
+- Download finalization now uses a same-filesystem move when possible instead
+  of copying the completed payload. The durable journal records that choice,
+  recovery can restore an interrupted move safely, and task state is committed
+  without mutating the live task before the filesystem transaction succeeds
+  ([#2056](https://github.com/agalwood/Motrix/pull/2056)).
+- Headless Server containers can start the explicitly enabled remote Motrix
+  Extension bridge on the container interface used by Docker port publishing.
+  Startup diagnostics now identify the bridge ownership stage and fixed reason,
+  and the deployment guide documents safe recovery of a stale or invalid
+  ownership record
+  ([#2055](https://github.com/agalwood/Motrix/pull/2055)).
+- Desktop windows select the correct solid background before the renderer
+  mounts, preventing a light flash in dark mode. Fullscreen transitions now
+  keep custom title-bar controls in sync, hide controls and drag regions while
+  fullscreen, and avoid a duplicate macOS fullscreen menu item
+  ([#2057](https://github.com/agalwood/Motrix/pull/2057),
+  [#2062](https://github.com/agalwood/Motrix/pull/2062)).
+- Downloads handed off by Motrix Extension now inherit the application-wide
+  split and per-server connection settings instead of being forced to a single
+  connection ([#2062](https://github.com/agalwood/Motrix/pull/2062)).
+- The first-run disclaimer restores its intended light appearance and readable
+  highlight contrast in dark mode. English and Simplified Chinese copy also
+  receive small punctuation corrections
+  ([#2052](https://github.com/agalwood/Motrix/pull/2052),
+  [#2062](https://github.com/agalwood/Motrix/pull/2062)).
+- The assisted Windows installer now includes branded header and sidebar
+  artwork ([#2062](https://github.com/agalwood/Motrix/pull/2062)).
+
+## Before testing
+
+This is prerelease software. Back up existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Pay particular attention to large completed downloads,
+recovery after an interrupted finalization, remote Motrix Extension pairing in
+Docker, Extension downloads with custom connection settings, dark-mode startup,
+fullscreen transitions, first-run onboarding, and the Windows installer.
+
+After the protected release completes, Snap testers can install the strictly
+confined build with `sudo snap install motrix --edge`. Existing installations
+tracking `latest/edge` should upgrade to the same beta.31 revision set.
+
+## Planned downloads after release gates pass
+
+| Distribution | Architectures | Planned output |
+|--------------|---------------|----------------|
+| macOS 13 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | AppImage, DEB, and RPM |
+| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.31-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.31` tag in both registries |
+| Snap Store | `amd64`, `arm64` | Verified build set on `latest/edge` |
+
+After every container gate passes, the versioned image references will be
+`docker.io/motrixapp/motrix-server:2.0.0-beta.31` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.31`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.31/docs/docker-server.md)
+for storage, networking, remote Extension pairing, and upgrade guidance.
+
+## Distribution notes
+
+- AppImage desktop integration is opt-in and confined to the current user's
+  XDG data directory. Browser-extension hand-off is not yet available from the
+  AppImage package because its Native Messaging host does not have a stable
+  path outside the mounted image.
+- Flatpak is validated separately and is not published by the release tag; the
+  GitHub prerelease includes its Native Host companion archives.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
+  Download them only from the official GitHub prerelease after it is published.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+- The Snap package is strictly confined. Its approved `personal-files`
+  interface is limited to registering Native Messaging host manifests for
+  supported browsers. Beta publication updates `latest/edge` only; it does not
+  promote the build to `candidate` or `stable`.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.31.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.31.zh-CN.md
@@ -1,0 +1,84 @@
+# Motrix 2.0.0-beta.31
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.31/docs/release-notes/2.0.0-beta.31.md) | 简体中文
+
+Motrix 2.0.0-beta.31 是一次可靠性与桌面体验更新。本版本改进下载完成后的
+持久化收尾，修复 Docker 中的 Motrix Extension 启动，对齐不同主题下的窗口
+状态与首次运行样式，并更新 Windows 安装器体验。只有在所有受保护发布门禁
+通过后，本版本才适合公开分发。
+
+## 主要改进
+
+- 下载完成后，在同一文件系统内会优先移动文件，而不再复制完整 payload。
+  持久化 journal 会记录该选择，恢复流程能够安全还原被中断的移动；文件系统
+  事务成功前也不会提前修改正在运行的任务状态
+  （[#2056](https://github.com/agalwood/Motrix/pull/2056)）。
+- Headless Server 容器可在 Docker 端口发布所需的容器网卡上启动已显式开启的
+  远程 Motrix Extension bridge。启动诊断现会报告 bridge ownership 的具体
+  阶段与固定 reason，部署指南也补充了失效或无效 ownership record 的安全恢复
+  方法（[#2055](https://github.com/agalwood/Motrix/pull/2055)）。
+- Desktop 窗口会在 renderer 挂载前选择正确的纯色背景，避免深色模式启动时闪白。
+  全屏切换现能保持自定义标题栏控件同步，在全屏时隐藏控件与拖拽区域，并避免
+  macOS 出现重复的全屏菜单项
+  （[#2057](https://github.com/agalwood/Motrix/pull/2057)、
+  [#2062](https://github.com/agalwood/Motrix/pull/2062)）。
+- Motrix Extension 转交的下载任务现会继承应用级的 split 与单服务器连接设置，
+  不再被强制限制为单连接
+  （[#2062](https://github.com/agalwood/Motrix/pull/2062)）。
+- 首次运行免责声明恢复预期的浅色外观，深色模式下的重点文字也具有正确对比度；
+  英文和简体中文文案另有少量标点修正
+  （[#2052](https://github.com/agalwood/Motrix/pull/2052)、
+  [#2062](https://github.com/agalwood/Motrix/pull/2062)）。
+- Windows 引导式安装器现带有品牌化的 header 与 sidebar 图片
+  （[#2062](https://github.com/agalwood/Motrix/pull/2062)）。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1 数据的
+迁移路径尚未经过验证，请勿让本 beta 使用您唯一的一份 v1 数据。
+
+条件允许时，请使用独立的操作系统账号、设备或 Docker 数据目录并行测试 v2。
+请重点检查大型下载完成后的处理、收尾中断后的恢复、Docker 中的远程 Motrix
+Extension 配对、带自定义连接设置的 Extension 下载、深色模式启动、全屏切换、
+首次运行引导以及 Windows 安装器。
+
+受保护发布完成后，Snap 测试者可使用
+`sudo snap install motrix --edge` 安装严格限制的构建。已跟踪
+`latest/edge` 的安装应升级到同一组 beta.31 revision。
+
+## 发布门禁通过后计划提供的下载
+
+| 分发方式 | 架构 | 计划产物 |
+|---------|------|---------|
+| macOS 13 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
+| Windows | `x64` | 未签名 NSIS 安装程序（`.exe`）和 ZIP |
+| Linux | `x64`、`arm64` | AppImage、DEB 和 RPM |
+| Flatpak Native Host companion | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.31-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个仓库中的不可变 `2.0.0-beta.31` 标签 |
+| Snap Store | `amd64`、`arm64` | `latest/edge` 上的已验证构建集 |
+
+所有容器门禁通过后，可使用以下带版本镜像：
+`docker.io/motrixapp/motrix-server:2.0.0-beta.31` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.31`。存储、网络、远程 Extension
+配对与升级说明请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.31/docs/docker-server.zh-CN.md)。
+
+## 分发说明
+
+- AppImage 桌面集成需要用户主动启用，且只会写入当前用户的 XDG 数据目录。由于
+  Native Messaging host 在挂载镜像之外没有稳定路径，浏览器扩展暂时无法向
+  AppImage 安装包转交下载任务。
+- Flatpak 单独验证，不由 release tag 发布；GitHub 预发布版会包含它的
+  Native Host companion 压缩包。
+- 不提供 Windows `arm64` 和所有 32 位安装包。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅从已发布的
+  官方 GitHub 预发布版下载。
+- Beta 容器标签不可变，也不会更新 `latest`、`stable` 或其他稳定通道浮动标签。
+- Snap 安装包使用严格限制。已批准的 `personal-files` interface 仅用于为支持的
+  浏览器注册 Native Messaging host manifest。Beta 发布只会更新
+  `latest/edge`，不会把构建晋级到 `candidate` 或 `stable`。
+
+## 反馈
+
+如遇到可复现问题，请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues)
+反馈，并附上操作系统、架构、安装包类型和复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -76,6 +76,15 @@
   <releases>
     <!-- Update this list on every release; Flathub linter requires the most
          recent version listed here to match the manifest's source tag. -->
+    <release version="2.0.0-beta.31" date="2026-09-04">
+      <description>
+        <p>
+          Improves durable download finalization, Docker Extension startup,
+          startup theme and fullscreen behavior, browser hand-off connection
+          settings, first-run styling, and Windows installer branding.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.30" date="2026-09-03">
       <description>
         <p>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.30",
+  "version": "2.0.0-beta.31",
   "packageManager": "pnpm@11.25.0+sha512.5cde925b4f075f725eb71fbae18a42ffe784524789f19b61c731cb8721ec28aaee160e01a8d5af4fedb2a42cdbf300efe23db356b0d4a17b4d63e11f8ab7c956",
   "description": "A full-featured download manager",
   "keywords": [],


### PR DESCRIPTION
## Summary / 概述

Prepare Motrix 2.0.0-beta.31 for the protected beta release workflow. The release focuses on durable finalization, Docker Extension startup, desktop window and onboarding polish, Extension connection settings, and Windows installer branding.

## Related issue / 相关 Issue

Not applicable; this release collects the fixes merged after v2.0.0-beta.30.

## Changes / 改动

- bump the application version and public beta references to 2.0.0-beta.31
- add aligned English and Simplified Chinese release notes
- add the beta.31 Flatpak release metadata entry

## Validation / 验证

- [x] pnpm run check:boundaries
- [x] pnpm run lint
- [x] pnpm exec tsc --noEmit
- [x] Relevant automated tests / 相关自动化测试
- [x] Manual verification, if applicable / 必要的手动验证

Validation details / 验证详情：

- release/version test set: 116 tests passed
- pnpm run check:flatpak
- pnpm run check:file-names
- reviewed the staged diff and ran git diff --cached --check

## Checklist / 检查清单

- [x] This pull request targets main and contains one focused change.
- [x] User-visible text is localized, and paired English/Chinese documentation stays aligned.
- [x] No credentials, private URLs, personal paths, or other sensitive information are included.
- [x] I have read and followed the contribution guidelines and Code of Conduct.