### PR TITLE
chore(release): prepare 2.0.0-beta.32

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. After its remaining release gates pass,
-download [v2.0.0-beta.31 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.31)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.31.md) before
+download [v2.0.0-beta.32 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.32)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.32.md) before
 installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -165,7 +165,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.31'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.32'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。剩余发布门禁通过后，请从 GitHub Releases
-下载 [v2.0.0-beta.31](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.31)，
-并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.31.zh-CN.md)。
+下载 [v2.0.0-beta.32](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.32)，
+并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.32.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -156,7 +156,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.31'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.32'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.32.md
+++ b/docs/release-notes/2.0.0-beta.32.md
@@ -1,0 +1,81 @@
+# Motrix 2.0.0-beta.32
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.32/docs/release-notes/2.0.0-beta.32.zh-CN.md)
+
+Motrix 2.0.0-beta.32 is a focused Windows reliability update. It restores
+normal desktop and browser-extension startup after an unclean shutdown and
+ensures the branded installer artwork reaches the isolated release build. It
+is intended for public distribution only after every protected release gate
+passes.
+
+## Highlights
+
+- On Windows, the desktop now recovers known bridge startup residue only after
+  Electron confirms single-instance ownership. The recovery preserves local
+  tokens and pairing data, remains limited to the default desktop data
+  directory, and leaves custom bridge directories and Server mode on their
+  existing strict paths. Native Messaging endpoint credentials also remain
+  available across valid Windows DACL variations, avoiding an unintended
+  switch to ticketless browser pairing
+  ([#2066](https://github.com/agalwood/Motrix/pull/2066)).
+- Published Windows installers now retain the optional branded header and
+  sidebar artwork through isolated finalization. Present images are staged and
+  verified by digest, while missing optional images safely fall back to the
+  NSIS defaults ([#2067](https://github.com/agalwood/Motrix/pull/2067)).
+
+## Before testing
+
+This is prerelease software. Back up existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. On Windows, pay particular attention to relaunching the
+desktop and pairing Motrix Extension after an unclean shutdown, and confirm
+that the assisted installer displays its branded header and sidebar artwork.
+
+After the protected release completes, Snap testers can install the strictly
+confined build with `sudo snap install motrix --edge`. Existing installations
+tracking `latest/edge` should upgrade to the same beta.32 revision set.
+
+## Planned downloads after release gates pass
+
+| Distribution | Architectures | Planned output |
+|--------------|---------------|----------------|
+| macOS 13 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | AppImage, DEB, and RPM |
+| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.32-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.32` tag in both registries |
+| Snap Store | `amd64`, `arm64` | Verified build set on `latest/edge` |
+
+After every container gate passes, the versioned image references will be
+`docker.io/motrixapp/motrix-server:2.0.0-beta.32` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.32`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.32/docs/docker-server.md)
+for storage, networking, remote Extension pairing, and upgrade guidance.
+
+## Distribution notes
+
+- AppImage desktop integration is opt-in and confined to the current user's
+  XDG data directory. Browser-extension hand-off is not yet available from the
+  AppImage package because its Native Messaging host does not have a stable
+  path outside the mounted image.
+- Flatpak is validated separately and is not published by the release tag; the
+  GitHub prerelease includes its Native Host companion archives.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
+  Download them only from the official GitHub prerelease after it is published.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+- The Snap package is strictly confined. Its approved `personal-files`
+  interface is limited to registering Native Messaging host manifests for
+  supported browsers. Beta publication updates `latest/edge` only; it does not
+  promote the build to `candidate` or `stable`.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.32.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.32.zh-CN.md
@@ -1,0 +1,69 @@
+# Motrix 2.0.0-beta.32
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.32/docs/release-notes/2.0.0-beta.32.md) | 简体中文
+
+Motrix 2.0.0-beta.32 是一次针对 Windows 可靠性的集中更新。本版本恢复非正常
+退出后的桌面应用与浏览器扩展正常启动，并确保品牌安装器图片能进入隔离的正式
+发布构建。只有在所有受保护发布门禁通过后，本版本才适合公开分发。
+
+## 主要改进
+
+- 在 Windows 上，桌面应用只会在 Electron 确认取得单实例所有权后，清理已知的
+  bridge 启动残留。恢复流程会保留本地 token 与配对数据，仅作用于默认桌面数据
+  目录；自定义 bridge 目录和 Server 模式继续使用原有的严格路径。Native
+  Messaging endpoint 凭据也能在有效但形式不同的 Windows DACL 下保持可用，
+  避免浏览器配对意外退化为无 ticket 流程
+  （[#2066](https://github.com/agalwood/Motrix/pull/2066)）。
+- 已发布的 Windows 安装器现在会在隔离收尾过程中保留可选的品牌 header 与
+  sidebar 图片。存在的图片会被纳入暂存并校验摘要；缺少可选图片时，则安全回退
+  到 NSIS 默认样式（[#2067](https://github.com/agalwood/Motrix/pull/2067)）。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1 数据的
+迁移路径尚未经过验证，请勿让本 beta 使用您唯一的一份 v1 数据。
+
+条件允许时，请使用独立的操作系统账号、设备或 Docker 数据目录并行测试 v2。
+在 Windows 上，请重点检查非正常退出后重新启动桌面应用及配对 Motrix
+Extension，并确认引导式安装器能显示品牌 header 与 sidebar 图片。
+
+受保护发布完成后，Snap 测试者可使用
+`sudo snap install motrix --edge` 安装严格限制的构建。已跟踪
+`latest/edge` 的安装应升级到同一组 beta.32 revision。
+
+## 发布门禁通过后计划提供的下载
+
+| 分发方式 | 架构 | 计划产物 |
+|---------|------|---------|
+| macOS 13 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
+| Windows | `x64` | 未签名 NSIS 安装程序（`.exe`）和 ZIP |
+| Linux | `x64`、`arm64` | AppImage、DEB 和 RPM |
+| Flatpak Native Host companion | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.32-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个仓库中的不可变 `2.0.0-beta.32` 标签 |
+| Snap Store | `amd64`、`arm64` | `latest/edge` 上的已验证构建集 |
+
+所有容器门禁通过后，可使用以下带版本镜像：
+`docker.io/motrixapp/motrix-server:2.0.0-beta.32` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.32`。存储、网络、远程 Extension
+配对与升级说明请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.32/docs/docker-server.zh-CN.md)。
+
+## 分发说明
+
+- AppImage 桌面集成需要用户主动启用，且只会写入当前用户的 XDG 数据目录。由于
+  Native Messaging host 在挂载镜像之外没有稳定路径，浏览器扩展暂时无法向
+  AppImage 安装包转交下载任务。
+- Flatpak 单独验证，不由 release tag 发布；GitHub 预发布版会包含它的 Native
+  Host companion 压缩包。
+- 不提供 Windows `arm64` 和所有 32 位安装包。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅从已发布的
+  官方 GitHub 预发布版下载。
+- Beta 容器标签不可变，也不会更新 `latest`、`stable` 或其他稳定通道浮动标签。
+- Snap 安装包使用严格限制。已批准的 `personal-files` interface 仅用于为支持的
+  浏览器注册 Native Messaging host manifest。Beta 发布只会更新
+  `latest/edge`，不会把构建晋级到 `candidate` 或 `stable`。
+
+## 反馈
+
+如遇到可复现问题，请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues)
+反馈，并附上操作系统、架构、安装包类型和复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -76,6 +76,15 @@
   <releases>
     <!-- Update this list on every release; Flathub linter requires the most
          recent version listed here to match the manifest's source tag. -->
+    <release version="2.0.0-beta.32" date="2026-09-05">
+      <description>
+        <p>
+          Restores Windows desktop and browser-extension startup after an
+          unclean shutdown, and preserves optional branded artwork in the
+          isolated Windows release installer build.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.31" date="2026-09-04">
       <description>
         <p>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.31",
+  "version": "2.0.0-beta.32",
   "packageManager": "pnpm@11.25.0+sha512.5cde925b4f075f725eb71fbae18a42ffe784524789f19b61c731cb8721ec28aaee160e01a8d5af4fedb2a42cdbf300efe23db356b0d4a17b4d63e11f8ab7c956",
   "description": "A full-featured download manager",
   "keywords": [],


### PR DESCRIPTION
## Summary

Prepare Motrix 2.0.0-beta.32 for the protected release workflow.

This focused Windows reliability beta includes the two changes merged since
v2.0.0-beta.31:

- recover normal Windows desktop and Motrix Extension startup after an unclean
  shutdown (#2066)
- preserve optional branded NSIS artwork through isolated release finalization
  (#2067)

## Release outputs

- bumps `package.json` and current README references to `2.0.0-beta.32`
- adds aligned English and Simplified Chinese release notes
- adds the matching AppStream release entry dated 2026-09-05
- retains the existing platform matrix and explicitly documents unsigned
  Windows x64 artifacts

## Validation

- architecture boundaries: passed
- Biome: 1,804 files passed
- TypeScript: passed
- Flatpak contract: 4 modules, 998 Node sources, 59 Cargo sources
- file naming: 2,106 Git-visible files passed
- focused release/Flatpak tests: 6 files, 113 tests passed
- full Vitest suite: 743 files passed, 2 skipped; 9,006 tests passed, 3 skipped

The first full-suite attempt in the restricted local sandbox failed only on
tests that bind local sockets (`EPERM`). Re-running the same suite with normal
local permissions passed completely.
