### PR TITLE
fix(engine): persist task cookies across restart

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -303,7 +303,7 @@ jobs:
                 -path "*/native-messaging-hosts/*" \
               \) -print -quit)"
               output="$("$aria2c" --version)"
-              printf "%s\n" "$output" | grep -qF "aria2 version 1.37.0-motrix.13"
+              printf "%s\n" "$output" | grep -qF "aria2 version 1.37.0-motrix.14"
               printf "%s\n" "$output" | grep -qF "Async DNS"
               printf "%s\n" "$output" | grep -qF "BitTorrent"
               printf "%s\n" "$output" | grep -qF "HTTPS"

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -83,8 +83,8 @@ must obtain permission or replace the font before distributing the build.
 Desktop builds bundle an `aria2c` executable pinned by
 `scripts/engine.lock.json`:
 
-- **Version:** 1.37.0-motrix.13
-- **Source:** <https://github.com/motrixapp/aria2/tree/v1.37.0-motrix.13>
+- **Version:** 1.37.0-motrix.14
+- **Source:** <https://github.com/motrixapp/aria2/tree/v1.37.0-motrix.14>
 - **License:** GNU General Public License v2.0 or later (`GPL-2.0-or-later`)
 - **Full license text:** `THIRD_PARTY_LICENSES/aria2-COPYING`
 - **OpenSSL exception / notice:**

--- a/THIRD_PARTY_NOTICES.zh-CN.md
+++ b/THIRD_PARTY_NOTICES.zh-CN.md
@@ -71,8 +71,8 @@ src/renderer/routes/settings/icons/icon-network@2x.png
 
 桌面版随应用打包 `aria2c` 可执行文件，版本由 `scripts/engine.lock.json` 固定：
 
-- **版本：** 1.37.0-motrix.13
-- **对应源码：** <https://github.com/motrixapp/aria2/tree/v1.37.0-motrix.13>
+- **版本：** 1.37.0-motrix.14
+- **对应源码：** <https://github.com/motrixapp/aria2/tree/v1.37.0-motrix.14>
 - **许可证：** GNU General Public License v2.0 or later（`GPL-2.0-or-later`）
 - **完整许可证文本：** `THIRD_PARTY_LICENSES/aria2-COPYING`
 - **OpenSSL 例外条款 / 声明：**

--- a/flatpak/app.motrix.native.yml
+++ b/flatpak/app.motrix.native.yml
@@ -101,7 +101,7 @@ modules:
         set -e
         output="$(src/aria2c --version)"
         printf '%s\n' "$output"
-        printf '%s\n' "$output" | grep -qF 'aria2 version 1.37.0-motrix.13'
+        printf '%s\n' "$output" | grep -qF 'aria2 version 1.37.0-motrix.14'
         for feature in \
           'Async DNS' \
           'BitTorrent' \
@@ -123,8 +123,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/motrixapp/aria2.git
-        tag: v1.37.0-motrix.13
-        commit: 45efd7372e17724e5a902e1b114972570fec11db
+        tag: v1.37.0-motrix.14
+        commit: fb5aa179a3fa6649c59fcfe90b69c44165e32be3
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+-motrix\.\d+)$
@@ -136,9 +136,9 @@ modules:
         commands:
           - |
             sed -i -E \
-              's/AC_INIT\(\[aria2\],\[[^]]+\]/AC_INIT([aria2],[1.37.0-motrix.13]/' \
+              's/AC_INIT\(\[aria2\],\[[^]]+\]/AC_INIT([aria2],[1.37.0-motrix.14]/' \
               configure.ac
-            grep -qF 'AC_INIT([aria2],[1.37.0-motrix.13]' configure.ac
+            grep -qF 'AC_INIT([aria2],[1.37.0-motrix.14]' configure.ac
       - type: script
         dest-filename: autogen.sh
         commands:

--- a/scripts/engine.lock.json
+++ b/scripts/engine.lock.json
@@ -1,50 +1,50 @@
 {
   "engine": "aria2",
   "repo": "motrixapp/aria2",
-  "tag": "v1.37.0-motrix.13",
-  "version": "1.37.0-motrix.13",
+  "tag": "v1.37.0-motrix.14",
+  "version": "1.37.0-motrix.14",
   "assets": {
     "darwin-arm64": {
-      "file": "aria2c-1.37.0-motrix.13-darwin-arm64.tar.gz",
+      "file": "aria2c-1.37.0-motrix.14-darwin-arm64.tar.gz",
       "bin": "aria2c",
-      "archiveSha256": "260f071ed35e505fad022a5ad3cf483a15c06c2aefa5890c3a23aa5d7dae4ab3",
-      "binarySha256": "fecc91561445c5b4d778661cd863a29b37e6a20ff3ff4fcf8d68737aee7c61bd"
+      "archiveSha256": "30dccd659766c92531d810b742ceaf0be978cfe83ff631c0c3c701e26c888832",
+      "binarySha256": "bf71d3fd383ca115348e4cd0d093dac48198282c30590349fef23f832a49b4fc"
     },
     "darwin-x64": {
-      "file": "aria2c-1.37.0-motrix.13-darwin-x64.tar.gz",
+      "file": "aria2c-1.37.0-motrix.14-darwin-x64.tar.gz",
       "bin": "aria2c",
-      "archiveSha256": "f2fcab27cb94fdb1f572e7e249037aeaa89a57ddca0e42329cf134f3bc5fe199",
-      "binarySha256": "d7f223a6b37c6244f081369474c09cd8b3abc5ce4688697c8441a4234cb9d120"
+      "archiveSha256": "56dc4d4dbc29c2a7400f5745eb902d2a0a4ded9139497ca65da4dd31565da408",
+      "binarySha256": "5c41e40931d2dca1fa13d06cb4ba38b82369b3c5accf2abf4ca506c22124f96d"
     },
     "win32-x64": {
-      "file": "aria2c-1.37.0-motrix.13-win32-x64.zip",
+      "file": "aria2c-1.37.0-motrix.14-win32-x64.zip",
       "bin": "aria2c.exe",
-      "archiveSha256": "6067a33dd74a8463ca41d035f643752e335fd4f73fae4dad08bdb4941c42c024",
-      "binarySha256": "e87a1b7e9fcfc83cca8627d7c5839c6b4b4e14d30b1a74c762c81ddf98c4cafc"
+      "archiveSha256": "36334f45437c3e3aa6733825b0d93976b4121f91aee83b2ecfe4bc210b8398df",
+      "binarySha256": "82e367164513a86eb5c52411fb77ad6cb2f6ca9766e6ddb8bd9526010f7fdf73"
     },
     "win32-ia32": {
-      "file": "aria2c-1.37.0-motrix.13-win32-ia32.zip",
+      "file": "aria2c-1.37.0-motrix.14-win32-ia32.zip",
       "bin": "aria2c.exe",
-      "archiveSha256": "05ead6c515a3f0a9ab845d53d51af6b04581f51a6c624d3ed16e4f0a50578e23",
-      "binarySha256": "f31a2b8f2c20f0547e6603954ac8dafbf915ea547d70ac292af67396bfb3669c"
+      "archiveSha256": "bb3b7ee1e24c3c07e29ca674e7dee2cce03009f662d2815d1272ead827e0737b",
+      "binarySha256": "51ad76d9085380098b280e33bd1f7bf320e35d4704b15c301aa63a9835b7c3b2"
     },
     "linux-x64": {
-      "file": "aria2c-1.37.0-motrix.13-linux-x64.tar.gz",
+      "file": "aria2c-1.37.0-motrix.14-linux-x64.tar.gz",
       "bin": "aria2c",
-      "archiveSha256": "30e66a069bcb5123b3c61036f375b4f665a867c2fae461952c8a6087ab35c0c8",
-      "binarySha256": "1eaeb5550f65b8aa0a1074d86e6739ecf0e89e1f9df850b41df9ec90ae747d3b"
+      "archiveSha256": "e4f5dd755de29e5789185afc415ca9190d82a3571f1cacc3072f0f9b840d33dc",
+      "binarySha256": "f694ef272993b66267ffd73e809f32cb14ad318ef5c64d3b835423db173c51e1"
     },
     "linux-arm64": {
-      "file": "aria2c-1.37.0-motrix.13-linux-arm64.tar.gz",
+      "file": "aria2c-1.37.0-motrix.14-linux-arm64.tar.gz",
       "bin": "aria2c",
-      "archiveSha256": "f9225da9bd7d761758d5affc8152a5bac8f5802c388e44750e2ea4f99a736ffc",
-      "binarySha256": "9ad331def5d7e26ca0d8c3207d4991fe27154de996314ebf1b8143232b42fe66"
+      "archiveSha256": "df24bc9d155d5c09dd2fbb116c7e086e7cb846dae795f30f8a4671e626ad05ad",
+      "binarySha256": "686656d927bab1c96d21a320bfb26fc0427cb5bc46cfcc3b7e0cf787be071427"
     },
     "linux-arm": {
-      "file": "aria2c-1.37.0-motrix.13-linux-armv7l.tar.gz",
+      "file": "aria2c-1.37.0-motrix.14-linux-armv7l.tar.gz",
       "bin": "aria2c",
-      "archiveSha256": "9b8002bcd434bd9d1d084bb30192284bf02ed76cd21d0b3280bb429b3d75c3af",
-      "binarySha256": "a01d1cde937c27450f6ee854db95765475d3b1a409b1f74c11703b0971d31747"
+      "archiveSha256": "b5a7c1b8c5f67244f3412504bb3475d3b36a6dda72b848169f0aa0ede2e1f627",
+      "binarySha256": "3e50f8c925d425cd0955fcc3fe2e92813e1f1b8f7e308e015bc868411a989ec6"
     }
   }
 }

--- a/scripts/verify-flatpak-packaging.mjs
+++ b/scripts/verify-flatpak-packaging.mjs
@@ -18,8 +18,8 @@ export const FLATPAK_BUILDER_TOOLS_COMMIT =
 // tag resolves to is pinned by hand (and cross-checked against the manifest).
 export const ARIA2_SOURCE = Object.freeze({
   url: 'https://github.com/motrixapp/aria2.git',
-  // v1.37.0-motrix.13 — current Motrix aria2 fork release
-  commit: '45efd7372e17724e5a902e1b114972570fec11db',
+  // v1.37.0-motrix.14 — current Motrix aria2 fork release
+  commit: 'fb5aa179a3fa6649c59fcfe90b69c44165e32be3',
 })
 
 const PNPM_SOURCE = Object.freeze({

--- a/src/core/bridge-receiver/task-cookies.integration.test.ts
+++ b/src/core/bridge-receiver/task-cookies.integration.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises'
 import { createServer, type Server } from 'node:http'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
@@ -169,6 +169,87 @@ describe.skipIf(!bundledAria2Exists() || !canBindLoopbackTcp())(
         expect(records).not.toContain(secret)
       }
     }, 20_000)
+
+    it('restores a task cookie from the engine database after restart', async () => {
+      const restartDir = path.join(root, 'restart-cookie')
+      const databasePath = path.join(restartDir, 'aria2.db')
+      const sessionPath = path.join(restartDir, 'aria2.session')
+      await mkdir(restartDir, { recursive: true })
+      const persistenceArgs = [
+        '--enable-sqlite3-persistence=true',
+        `--sqlite3-db-path=${databasePath}`,
+        '--sqlite3-history-limit=-1',
+        '--force-save=true',
+        `--save-session=${sessionPath}`,
+        '--save-session-interval=1',
+      ]
+
+      const first = await spawnAria2ForTest({
+        baseDir: restartDir,
+        extraArgs: persistenceArgs,
+      })
+      const firstWired = await connectAdapter(first)
+      let gid: string
+      try {
+        gid = await firstWired.adapter.createDownload({
+          uris: [`${base}/restart-cookie`],
+          saveDir: restartDir,
+          filename: 'restart-cookie.bin',
+          cookies: [
+            {
+              name: 'sid',
+              value: 'account-restart',
+              domain: '127.0.0.1',
+              path: '/',
+              expiresAt: Date.now() + 300_000,
+            },
+          ],
+          extraEngineOptions: { pause: 'true' },
+        })
+        await vi.waitFor(
+          async () => {
+            expect((await firstWired.rpc.tellStatus(gid)).status).toBe('paused')
+          },
+          { timeout: 10_000, interval: 50 }
+        )
+      } finally {
+        firstWired.disconnect()
+        await first.kill()
+      }
+
+      received.delete('/restart-cookie')
+      const second = await spawnAria2ForTest({
+        baseDir: restartDir,
+        extraArgs: [...persistenceArgs, '--pause=true'],
+      })
+      const secondWired = await connectAdapter(second)
+      try {
+        await vi.waitFor(
+          async () => {
+            expect((await secondWired.rpc.tellStatus(gid)).status).toBe(
+              'paused'
+            )
+          },
+          { timeout: 10_000, interval: 50 }
+        )
+        await secondWired.rpc.unpause(gid)
+        await vi.waitFor(
+          async () => {
+            expect((await secondWired.rpc.tellStatus(gid)).status).toBe(
+              'complete'
+            )
+          },
+          { timeout: 10_000, interval: 50 }
+        )
+        expect(
+          await readFile(path.join(restartDir, 'restart-cookie.bin'), 'utf8')
+        ).toBe('REAL_FILE')
+        expect(received.get('/restart-cookie')).toBe('sid=account-restart;')
+      } finally {
+        secondWired.disconnect()
+        await second.kill()
+      }
+    }, 30_000)
 
     it.runIf(process.env.MOTRIX_LEGACY_ARIA2_TEST_BIN)(
       'rejects an older real engine without submitting an unauthenticated task',

--- a/src/test-utils/aria2.ts
+++ b/src/test-utils/aria2.ts
@@ -26,6 +26,8 @@ export interface SpawnAria2Options {
   baseDir: string
   /** Optional explicit binary for compatibility tests against older engines. */
   binaryPath?: string
+  /** Additional engine flags for focused integration scenarios. */
+  extraArgs?: readonly string[]
   port?: number
   secret?: string
   waitForHttpRpc?: boolean
@@ -114,6 +116,7 @@ export async function spawnAria2ForTest(
       '--rpc-save-upload-metadata=true',
       '--console-log-level=warn',
       `--dir=${opts.baseDir}`,
+      ...(opts.extraArgs ?? []),
     ],
     { stdio: ['ignore', 'pipe', 'pipe'] }
   )

--- a/tests/check-third-party-notices.test.ts
+++ b/tests/check-third-party-notices.test.ts
@@ -412,9 +412,9 @@ describe('third-party graph dependency notices', () => {
 
       expect(notice).toContain('SFNS-Regular.ttf')
       expect(notice).toContain('https://developer.apple.com/fonts/')
-      expect(notice).toContain('1.37.0-motrix.13')
+      expect(notice).toContain('1.37.0-motrix.14')
       expect(notice).toContain(
-        'https://github.com/motrixapp/aria2/tree/v1.37.0-motrix.13'
+        'https://github.com/motrixapp/aria2/tree/v1.37.0-motrix.14'
       )
       expect(notice).toContain('GPL-2.0-or-later')
       expect(notice).toContain('THIRD_PARTY_LICENSES/aria2-COPYING')

--- a/tests/generate-third-party-notices.test.ts
+++ b/tests/generate-third-party-notices.test.ts
@@ -164,7 +164,7 @@ describe('third-party notice generator', () => {
 
     expect(bundle.packageCount).toBeGreaterThan(100)
     expect(inventory).toContain('| @xyflow/react | 12.11.6 |')
-    expect(inventory).toContain('| aria2 | 1.37.0-motrix.13 |')
+    expect(inventory).toContain('| aria2 | 1.37.0-motrix.14 |')
     expect(inventory).toContain('| motrix.filename-template | 1.1.1 |')
     expect(inventory).toContain('Apple San Francisco tray font')
     expect(licenses).toContain('GNU GENERAL PUBLIC LICENSE')


### PR DESCRIPTION
Browser tasks submitted with structured cookies could download correctly on `motrix.13`, but restarting aria2 discarded the in-memory cookie jar and prevented authenticated continuation. This upgrades the bundled engine to `v1.37.0-motrix.14`, which stores each task's cookie context in `aria2.db`, and adds a real-engine restart test proving Motrix can resume without copying cookie values into its own task records.

The change also updates the Flatpak source pin, release checks, and bilingual third-party notices to the verified `.14` release.

Validation:

- `pnpm run check:boundaries`
- `pnpm run lint`
- `pnpm exec tsc --noEmit`
- `pnpm run check:third-party-notices`
- `pnpm run check:flatpak`
- focused engine, packaging, workflow, and restart integration tests: 105 passed, 1 conditional legacy-engine test skipped
- full Vitest suite: 9009 passed, 13 skipped

