### PR TITLE
fix(session): derive bt save directory from the staging workspace

### DIFF
--- a/src/core/session/session-manager.test.ts
+++ b/src/core/session/session-manager.test.ts
@@ -21,6 +21,12 @@ import type { EngineAdapter } from '../engine/engine-adapter'
 import { DIRECT_RESOURCE_METADATA_PROFILE } from '../engine/engine-adapter'
 import { clearStoppedTasks } from '../task/actions/clear-stopped-tasks'
 import { stopSeedingTask } from '../task/actions/stop-seeding-task'
+import type { BtStorageLayoutV1 } from '../task/bt-storage-layout'
+import {
+  btStoragePayload,
+  btWorkspacePath,
+  getBtPayloadPath,
+} from '../task/bt-storage-layout'
 import { TaskManager } from '../task/task-manager'
 import { computeUriHash } from './content-key'
 import type {
@@ -3632,6 +3638,125 @@ describe('SessionManager', () => {
 
       const task = tm.getById('m-no-bt')
       expect(task?.bt).toBeUndefined()
+    })
+  })
+
+  describe('mergeTask — BT save directory', () => {
+    // A BT task downloads inside `<saveDir>/.motrix/<workspace>` and the
+    // engine reports that workspace as its directory. Restoring `saveDir`
+    // from it verbatim moves the task's save directory two levels below the
+    // one the user picked, and everything derived from `saveDir` follows it
+    // there.
+    const btWorkspaceTask = (motrixId: string, saveDir: string) => {
+      const workspace = btWorkspacePath(motrixId, saveDir)
+      const layout: BtStorageLayoutV1 = {
+        version: 1,
+        strategy: 'indexed-staging',
+        workspacePath: workspace,
+        payloadEntry: 'p',
+        torrentRootName: 'movie.mkv',
+        multiFile: false,
+      }
+      return {
+        workspace,
+        seed: {
+          motrixId,
+          gid: `gid-${motrixId}`,
+          name: 'movie.mkv',
+          category: null,
+          priority: 0,
+          createdAt: 0,
+          updatedAt: 0,
+          diskPath: workspace,
+          finalPath: path.join(saveDir, 'movie.mkv'),
+          finalName: 'movie.mkv',
+          transitionPhase: TransitionPhase.Idle,
+          torrentMetaPath: null,
+          infoHash: 'c'.repeat(40),
+          uriHash: null,
+          uris: [],
+          status: TaskStatus.Downloading,
+          payload: btStoragePayload(layout),
+        },
+      }
+    }
+
+    it('restores the save directory the workspace was built from', async () => {
+      const tm = new TaskManager()
+      const localDb = createMockDb()
+      const localRpc = createMockRpc()
+      const sm = new SessionManager(tm, localRpc, localDb, createMockAdapter())
+      const { workspace, seed } = btWorkspaceTask('m-bt-workspace', '/dl')
+      seedAsPair(localDb, seed)
+      localRpc.tellActive = vi.fn(async () => [
+        makeRawStatus({ gid: 'gid-m-bt-workspace', dir: workspace }),
+      ])
+      localRpc.tellWaiting = vi.fn(async () => [])
+      localRpc.tellStopped = vi.fn(async () => [])
+
+      await sm.restore()
+
+      expect(tm.getById('m-bt-workspace')?.saveDir).toBe('/dl')
+    })
+
+    it('keeps the persisted BT storage layout resolvable after restore', async () => {
+      // `isLayoutOwnedByTask` authorizes the persisted layout by rebuilding
+      // `<saveDir>/.motrix` from the task. A save directory restored as the
+      // workspace itself fails that check, so the task loses the mapping to
+      // its own payload file.
+      const tm = new TaskManager()
+      const localDb = createMockDb()
+      const localRpc = createMockRpc()
+      const sm = new SessionManager(tm, localRpc, localDb, createMockAdapter())
+      const { workspace, seed } = btWorkspaceTask('m-bt-layout', '/dl')
+      seedAsPair(localDb, seed)
+      localRpc.tellActive = vi.fn(async () => [
+        makeRawStatus({ gid: 'gid-m-bt-layout', dir: workspace }),
+      ])
+      localRpc.tellWaiting = vi.fn(async () => [])
+      localRpc.tellStopped = vi.fn(async () => [])
+
+      await sm.restore()
+
+      const restored = tm.getById('m-bt-layout')
+      expect(restored).toBeDefined()
+      expect(restored && getBtPayloadPath(restored)).toBe(
+        path.join(workspace, 'p')
+      )
+    })
+
+    it('leaves a non-workspace engine directory untouched', async () => {
+      const tm = new TaskManager()
+      const localDb = createMockDb()
+      const localRpc = createMockRpc()
+      const sm = new SessionManager(tm, localRpc, localDb, createMockAdapter())
+      seedAsPair(localDb, {
+        motrixId: 'm-http-dir',
+        gid: 'gid-http-dir',
+        name: 'file.zip',
+        category: null,
+        priority: 0,
+        createdAt: 0,
+        updatedAt: 0,
+        diskPath: '/dl/file.zip',
+        finalPath: '/dl/file.zip',
+        finalName: 'file.zip',
+        transitionPhase: TransitionPhase.Idle,
+        torrentMetaPath: null,
+        infoHash: null,
+        uriHash: null,
+        uris: ['http://example.com/file.zip'],
+        status: TaskStatus.Downloading,
+      })
+      localRpc.tellActive = vi.fn(async () => [
+        makeRawStatus({ gid: 'gid-http-dir', dir: '/dl' }),
+      ])
+      localRpc.tellWaiting = vi.fn(async () => [])
+      localRpc.tellStopped = vi.fn(async () => [])
+
+      await sm.restore()
+
+      expect(tm.getById('m-http-dir')?.saveDir).toBe('/dl')
     })
   })
 })

--- a/src/core/session/session-manager.ts
+++ b/src/core/session/session-manager.ts
@@ -47,7 +47,10 @@ import {
   applyTerminalTransition,
   terminalFieldsFromRow,
 } from '../task/apply-terminal-transition'
-import { shouldPrioritizeBtPreviewPiecesFromMetadata } from '../task/bt-storage-layout'
+import {
+  btSaveDirFromWorkspacePath,
+  shouldPrioritizeBtPreviewPiecesFromMetadata,
+} from '../task/bt-storage-layout'
 import { isCompletedDirectOutput } from '../task/completed-direct-task-policy'
 import {
   canMirrorAria2MetadataHeaders,
@@ -1301,7 +1304,11 @@ export class SessionManager {
         String(downloadedBytes),
         aria2.downloadSpeed
       ),
-      saveDir: aria2.dir,
+      // A BT task runs inside `<saveDir>/.motrix/<workspace>`, so the engine
+      // reports that workspace rather than the directory the user picked.
+      // Every other engine directory passes through unchanged.
+      saveDir:
+        btSaveDirFromWorkspacePath(taskPart.motrixId, aria2.dir) ?? aria2.dir,
       createdAt: taskPart.createdAt,
       updatedAt: now,
       uris: extractUris(aria2),

--- a/src/core/task/bt-storage-layout.test.ts
+++ b/src/core/task/bt-storage-layout.test.ts
@@ -2,6 +2,8 @@ import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
+  btSaveDirFromWorkspacePath,
+  btWorkspacePath,
   buildFinalOutputFilePaths,
   createBtStoragePlan,
   getBtStorageLayout,
@@ -110,5 +112,31 @@ describe('BT indexed storage layout', () => {
         ],
       } as unknown as Parameters<typeof getBtStorageLayout>[0])
     ).toBeNull()
+  })
+})
+
+describe('btSaveDirFromWorkspacePath', () => {
+  it('inverts btWorkspacePath for the task that owns the workspace', () => {
+    const saveDir = path.join(path.sep, 'downloads')
+    expect(
+      btSaveDirFromWorkspacePath('task-1', btWorkspacePath('task-1', saveDir))
+    ).toBe(saveDir)
+  })
+
+  it('returns null for a workspace belonging to another task', () => {
+    const saveDir = path.join(path.sep, 'downloads')
+    expect(
+      btSaveDirFromWorkspacePath('task-2', btWorkspacePath('task-1', saveDir))
+    ).toBeNull()
+  })
+
+  it('returns null for a directory that is not a workspace', () => {
+    expect(
+      btSaveDirFromWorkspacePath('task-1', path.join(path.sep, 'downloads'))
+    ).toBeNull()
+  })
+
+  it('returns null for an empty directory', () => {
+    expect(btSaveDirFromWorkspacePath('task-1', '')).toBeNull()
   })
 })

--- a/src/core/task/bt-storage-layout.ts
+++ b/src/core/task/bt-storage-layout.ts
@@ -153,6 +153,25 @@ export function btWorkspacePath(taskId: string, saveDir: string): string {
   return path.join(saveDir, STORAGE_ROOT, workspaceId)
 }
 
+/**
+ * Recover the save directory a BT workspace was built from. The engine is
+ * pointed at `<saveDir>/<STORAGE_ROOT>/<workspaceId>` and reports that
+ * workspace as its own directory, so the save directory is its grandparent.
+ * Returns null unless `btWorkspacePath` maps that grandparent back to `dir`,
+ * which keeps unrelated directories — plain engine directories included —
+ * from being reinterpreted as workspaces.
+ */
+export function btSaveDirFromWorkspacePath(
+  taskId: string,
+  dir: string
+): string | null {
+  if (!dir) return null
+  const candidate = path.dirname(path.dirname(dir))
+  return path.resolve(btWorkspacePath(taskId, candidate)) === path.resolve(dir)
+    ? candidate
+    : null
+}
+
 export function buildStagingOutputFilePaths(
   parsed: ParsedBtFileLayout,
   layout: BtStorageLayoutV1


### PR DESCRIPTION
## Summary / 概述

A BT task downloads inside `<saveDir>/.motrix/<workspace>`, and `SessionManager.mergeTaskFromPair` restored `task.saveDir` straight from the directory the engine reports — which is that workspace. After a restart the task's save directory therefore sat two levels below the one the user picked, and every consumer of `saveDir` followed it there.

The visible failure is that a BT task waiting to be finalized can never complete. `DurableFinalizeRuntime` builds the hook plan from `task.saveDir`, so `assertValidHookPlan` rejected the plan with `finalize target must be a descendant of saveDir` — `path.relative(saveDir, targetPath)` resolved to `../../<final name>`. Startup recovery re-runs finalize for any task left in the `renaming` transition phase, so once the first attempt fails every later restart repeats the same rejection and the payload never leaves the workspace.

The same value silently broke a second consumer. `isLayoutOwnedByTask` authorizes the persisted BT storage layout by rebuilding `<saveDir>/.motrix` from the task; with `saveDir` already pointing at the workspace it computed `<saveDir>/.motrix/<workspaceId>/.motrix`, so `getBtStorageLayout` and `getBtPayloadPath` returned `null` for a restored task.

The fix inverts `btWorkspacePath` rather than pattern-matching the path. `btSaveDirFromWorkspacePath` rebuilds the workspace from a candidate grandparent and accepts that candidate only when it maps back to the directory the engine reported, so a directory is treated as a workspace only for the task that owns it. Every other engine directory — HTTP tasks and magnet metadata staging included — passes through unchanged.

## Related issue / 相关 Issue

Closes #2076

## Changes / 改动

- Add `btSaveDirFromWorkspacePath` to `src/core/task/bt-storage-layout.ts` as the exact inverse of `btWorkspacePath`, keeping both directions of the mapping in one module so they cannot drift.
- Use it in `SessionManager.mergeTaskFromPair`, falling back to the engine directory when the reported directory is not a workspace this task owns.
- Add regression tests for the restore path and unit tests for the helper.

## Validation / 验证

- [x] `pnpm run check:boundaries`
- [x] `pnpm run lint`
- [x] `pnpm exec tsc --noEmit`
- [x] Relevant automated tests / 相关自动化测试
- [x] Manual verification, if applicable / 必要的手动验证

Validation details / 验证详情：

Environment: macOS 26.2 arm64, Node v25.2.1, pnpm 11.25.0.

```
$ pnpm run check:boundaries
9 checks, all [PASS]; exit 0

$ pnpm run lint
biome check . — checked 1810 files, no errors; exit 0

$ pnpm exec tsc --noEmit
no output; exit 0

$ pnpm exec vitest run src/core/session/session-manager.test.ts src/core/task/bt-storage-layout.test.ts
Test Files  2 passed (2)
     Tests  121 passed (121)
```

Full suite:

```
$ pnpm test
Test Files  2 failed | 743 passed | 3 skipped (748)
     Tests  8 failed | 9039 passed | 16 skipped (9063)
```

The 8 failures are pre-existing on `main` at 58ac857 and unrelated to this change — they reproduce with the branch stashed. They are `src/renderer/lib/initial-theme.test.ts` (6, all `TypeError: window.localStorage.clear is not a function`) and `tests/scripts/smoke-server-package.test.ts` (2). Every other file passes.

Manual verification: reverting only the `mergeTaskFromPair` change and re-running the new tests fails both regression cases as expected — `expected '/dl/.motrix/1b53cff49e182934fb7f' to be '/dl'` and `expected null to be '/dl/.motrix/1852df7cfb4c5c6bb479/p'` — while the non-workspace case still passes. The bug itself was first observed on a 2.0.0-beta.32 desktop install, where a completed single-file torrent stayed stuck in its workspace across restarts.

## Checklist / 检查清单

- [x] This pull request targets `main` and contains one focused change.
- [x] User-visible text is localized, and paired English/Chinese documentation stays aligned.
- [x] No credentials, private URLs, personal paths, or other sensitive information are included.
- [x] I have read and followed the [contribution guidelines](https://github.com/agalwood/Motrix/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/agalwood/Motrix/blob/main/CODE_OF_CONDUCT.md).
