### PR TITLE
fix(task): sync instance status on polled terminal transition

### DIFF
--- a/src/core/task/merge-engine-task.test.ts
+++ b/src/core/task/merge-engine-task.test.ts
@@ -1,6 +1,10 @@
 import { DownloadErrorCode } from '@shared/errors'
 import type { DownloadTask } from '@shared/types/task'
-import { TaskStatus, TransitionPhase } from '@shared/types/task'
+import {
+  TaskInstancePhase,
+  TaskStatus,
+  TransitionPhase,
+} from '@shared/types/task'
 import { makeDownloadTask } from '@test-utils/task'
 import { describe, expect, it } from 'vitest'
 import { mergeEngineTask } from './merge-engine-task'
@@ -131,6 +135,48 @@ describe('mergeEngineTask', () => {
       finishedAt: 20_000,
       errorMessage: 'network failed',
       errorCode: DownloadErrorCode.NetworkError,
+    })
+  })
+
+  it('keeps durable instance status in lockstep with a polled error', () => {
+    const existing = baseTask({
+      status: TaskStatus.Downloading,
+      instances: [
+        {
+          instanceId: 'instance-1',
+          motrixId: 't1',
+          gid: 'gid1',
+          phase: TaskInstancePhase.HttpDownload,
+          status: TaskStatus.Downloading,
+          progress: 0.25,
+          totalBytes: 1_000,
+          downloadedBytes: 250,
+          uploadedBytes: 0,
+          diskPath: '/downloads/a.motrix',
+          transitionPhase: TransitionPhase.Idle,
+          uris: ['https://example.com/a'],
+          uriHash: null,
+          payload: {},
+          createdAt: 1_000,
+          updatedAt: 1_000,
+        },
+      ],
+    })
+    const engineTask = baseTask({
+      status: TaskStatus.Error,
+      errorMessage: 'Timeout',
+      errorCode: DownloadErrorCode.Timeout,
+    })
+
+    const merged = mergeEngineTask(existing, engineTask, 20_000)
+
+    expect(merged.instances[0]).toMatchObject({
+      status: TaskStatus.Error,
+      updatedAt: 20_000,
+    })
+    expect(existing.instances[0]).toMatchObject({
+      status: TaskStatus.Downloading,
+      updatedAt: 1_000,
     })
   })
 

--- a/src/core/task/merge-engine-task.ts
+++ b/src/core/task/merge-engine-task.ts
@@ -1,5 +1,5 @@
 import type { DownloadTask } from '@shared/types/task'
-import { TransitionPhase } from '@shared/types/task'
+import { TaskStatus, TransitionPhase } from '@shared/types/task'
 import { applyTerminalTransition } from './apply-terminal-transition'
 import { isCompletedDirectOutput } from './completed-direct-task-policy'
 import { nonZeroMerge } from './non-zero-merge'
@@ -60,9 +60,24 @@ export function mergeEngineTask(
     },
     now
   )
+  // task_instances is durable state, not a renderer-only detail. Polling used
+  // to commit the aggregate Error/Completed transition while retaining the
+  // instance's earlier queued/downloading status. That contradictory snapshot
+  // then survived restart and could make recovery decisions from stale input.
+  // Keep this merge pure and only replace rows whose status actually changed,
+  // so same-state polls do not churn instance timestamps.
+  const instances =
+    nextStatus === TaskStatus.Completed || nextStatus === TaskStatus.Error
+      ? existing.instances.map((instance) =>
+          instance.status === nextStatus
+            ? instance
+            : { ...instance, status: nextStatus, updatedAt: now }
+        )
+      : existing.instances
   return {
     ...existing,
     ...terminalFields,
+    instances,
     progress,
     totalBytes: protected_.totalBytes,
     sizeWhenDone: protected_.sizeWhenDone,


### PR DESCRIPTION
## Summary / 概述

Keep persisted `task_instances.status` in lockstep when an authoritative engine poll moves the aggregate task to `Error` or `Completed`.

Previously `mergeEngineTask` updated the aggregate terminal fields but retained `existing.instances` unchanged. A task could therefore be persisted with `tasks.agg_status = 'error'` while its only HTTP instance still said `downloading` or `queued`, leaving contradictory input for startup recovery.

The merge remains pure: only instance rows whose status changes are copied, and repeated terminal polls do not churn their timestamps.

## Related issue / 相关 Issue

Closes #2079

## Changes / 改动

- Synchronize every durable instance to the aggregate `Error`/`Completed` status during polling merge.
- Stamp changed instances with the same merge timestamp.
- Add a regression test that reproduces a polled HTTP timeout and verifies the input task is not mutated.

## Validation / 验证

- [x] `pnpm run check:boundaries`
- [x] `pnpm run lint`
- [x] `pnpm exec tsc --noEmit`
- [x] Relevant automated tests / 相关自动化测试
- [x] Manual verification, if applicable / 必要的手动验证

Validation details / 验证详情：

- `MOTRIX_SKIP_BUILTIN_FETCH=1 pnpm exec vitest run src/core/task/merge-engine-task.test.ts src/core/task/actions/shared.test.ts src/core/task/lifecycle-persistence.test.ts` — 3 files, 40 tests passed.
- Confirmed the new regression test fails before the production change (`instance.status` remains `downloading`) and passes afterward (`error`, timestamp synchronized).
- `pnpm run check:boundaries` — passed.
- `pnpm run lint` — 1,810 files checked, passed.
- `pnpm exec tsc --noEmit` — passed.
- No visible UI change; manual screenshot is not applicable.
- An additional full `pnpm test` attempt on local Node 26 was not used as a passing signal: unrelated package/notices, server-package smoke, and Node-26 renderer-environment tests failed and the runner retained open handles. The focused suites and all required static checks above pass.

## Checklist / 检查清单

- [x] This pull request targets `main` and contains one focused change.
- [x] User-visible text is localized, and paired English/Chinese documentation stays aligned (no user-visible text changed).
- [x] No credentials, private URLs, personal paths, or other sensitive information are included.
- [x] I have read and followed the contribution guidelines and Code of Conduct.
