### PR TITLE
chore(release): prepare 2.0.0-beta.33

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. After its remaining release gates pass,
-download [v2.0.0-beta.32 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.32)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.32.md) before
+download [v2.0.0-beta.33 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.33)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.33.md) before
 installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -174,7 +174,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.32'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.33'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。剩余发布门禁通过后，请从 GitHub Releases
-下载 [v2.0.0-beta.32](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.32)，
-并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.32.zh-CN.md)。
+下载 [v2.0.0-beta.33](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.33)，
+并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.33.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -165,7 +165,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.32'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.33'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.33.md
+++ b/docs/release-notes/2.0.0-beta.33.md
@@ -1,0 +1,95 @@
+# Motrix 2.0.0-beta.33
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.33/docs/release-notes/2.0.0-beta.33.zh-CN.md)
+
+Motrix 2.0.0-beta.33 adds direct installation links for the published browser
+extension and improves download recovery, authenticated downloads, and large-file
+finalization. It also adds a Reduce motion preference. It is intended for public
+distribution only after every protected release gate passes.
+
+## Highlights
+
+- Settings now provides four equal-width installation cards: Chrome Web Store,
+  Microsoft Edge Add-ons, Firefox (coming soon), and GitHub development builds.
+  The cards use original brand artwork and colors. The two official Chromium
+  extension IDs under Trusted extensions link to their matching store pages.
+  Both READMEs also link to the stores and pairing guide
+  ([8bc7660a](https://github.com/agalwood/Motrix/commit/8bc7660af85a5f6ba741a39eac7962b49285e797)).
+- Browser downloads use the task-cookie RPC, and bundled aria2 is updated to
+  `1.37.0-motrix.14` for durable task cookies. Download request context is retained
+  without putting cookies in task records or plaintext cookie files; unsupported
+  engines are rejected instead of retrying without authentication
+  ([#2073](https://github.com/agalwood/Motrix/pull/2073),
+  [#2074](https://github.com/agalwood/Motrix/pull/2074)).
+- Completed RPC downloads no longer restart after relaunch. Completion is saved
+  before engine cleanup, failed cleanup is retried, and historical completed
+  engine tasks are reconciled without changing other tasks' run intent
+  ([#2075](https://github.com/agalwood/Motrix/pull/2075)).
+- Task recovery preserves the selected save directory and repairs historical
+  inconsistencies between task and instance completion states. Large-file
+  finalization reuses unchanged digests, hashes in a worker, and no longer applies
+  fixed deadlines to filesystem work. Native sidecar recovery avoids replaying
+  file mutations ([#2080](https://github.com/agalwood/Motrix/pull/2080)).
+- **Settings → Appearance → Reduce motion** reduces interface animation,
+  including the Downloads page's glass effects. The preference is saved and
+  synchronized across views, while the operating system's reduced-motion
+  preference is also respected
+  ([#2082](https://github.com/agalwood/Motrix/pull/2082)).
+
+## Before testing
+
+This is prerelease software. Back up existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Check browser-extension installation and pairing,
+authenticated downloads after pause and resume, completed tasks after relaunch,
+and the final save location of large downloads. Also check Reduce motion with
+both the application and system preferences.
+
+After the protected release completes, Snap testers can install the strictly
+confined build with `sudo snap install motrix --edge`. Existing installations
+tracking `latest/edge` should upgrade to the same beta.33 revision set.
+
+## Planned downloads after release gates pass
+
+| Distribution | Architectures | Planned output |
+|--------------|---------------|----------------|
+| macOS 13 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | AppImage, DEB, and RPM |
+| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.33-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.33` tag in both registries |
+| Snap Store | `amd64`, `arm64` | Verified build set on `latest/edge` |
+
+After every container gate passes, the versioned image references will be
+`docker.io/motrixapp/motrix-server:2.0.0-beta.33` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.33`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.33/docs/docker-server.md)
+for storage, networking, remote Extension pairing, and upgrade guidance.
+
+## Distribution notes
+
+- AppImage desktop integration is opt-in and confined to the current user's
+  XDG data directory. Browser-extension hand-off is not yet available from the
+  AppImage package because its Native Messaging host does not have a stable
+  path outside the mounted image.
+- Flatpak is validated separately and is not published by the release tag; the
+  GitHub prerelease includes its Native Host companion archives.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
+  Download them only from the official GitHub prerelease after it is published.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+- The Snap package is strictly confined. Its approved `personal-files`
+  interface is limited to registering Native Messaging host manifests for
+  supported browsers. Beta publication updates `latest/edge` only; it does not
+  promote the build to `candidate` or `stable`.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.33.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.33.zh-CN.md
@@ -1,0 +1,80 @@
+# Motrix 2.0.0-beta.33
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.33/docs/release-notes/2.0.0-beta.33.md) | 简体中文
+
+Motrix 2.0.0-beta.33 新增已上架浏览器扩展的直接安装入口，改进下载恢复、需要
+登录状态的下载与大文件收尾，并加入“减少动态效果”设置。只有在所有受保护
+发布门禁通过后，本版本才适合公开分发。
+
+## 主要改进
+
+- 设置中新增四个等宽安装入口：Chrome Web Store、Microsoft Edge Add-ons、
+  Firefox（即将推出）与 GitHub 开发版。入口保留品牌原始图标与配色；“受信任的
+  扩展”中的两个官方 Chromium 扩展 ID 可直接打开对应商店。中英文 README
+  也加入了商店与配对指南链接
+  （[8bc7660a](https://github.com/agalwood/Motrix/commit/8bc7660af85a5f6ba741a39eac7962b49285e797)）。
+- 浏览器下载改用 task-cookie RPC，内置 aria2 升级至 `1.37.0-motrix.14`，支持
+  持久保存任务 Cookie。下载请求上下文得以保留，Cookie 不会写入任务记录或明文
+  Cookie 文件；遇到不支持的引擎会拒绝提交，避免丢失登录状态后重试
+  （[#2073](https://github.com/agalwood/Motrix/pull/2073)、
+  [#2074](https://github.com/agalwood/Motrix/pull/2074)）。
+- 已完成的 RPC 下载不再因重新启动应用而重下。完成状态会先于引擎清理保存，清理
+  失败会重试；历史遗留的已完成引擎任务也会被核对，同时保留其他任务原有的运行
+  意图（[#2075](https://github.com/agalwood/Motrix/pull/2075)）。
+- 任务恢复会保留用户选择的保存目录，并修复历史数据中任务与实例完成状态不一致
+  的问题。大文件收尾会复用未变化的摘要、在 worker 中计算哈希，并移除文件系统
+  操作的固定超时；原生辅助进程恢复时不会重复执行文件变更
+  （[#2080](https://github.com/agalwood/Motrix/pull/2080)）。
+- **设置 → 外观 → 减少动态效果** 可减少界面动画，包括下载页的玻璃效果。
+  设置会保存并在各视图间同步，同时尊重操作系统的减少动态效果偏好
+  （[#2082](https://github.com/agalwood/Motrix/pull/2082)）。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1 数据的
+迁移路径尚未经过验证，请勿让本 beta 使用您唯一的一份 v1 数据。
+
+条件允许时，请使用独立的操作系统账号、设备或 Docker 数据目录并行测试 v2。
+请重点检查浏览器扩展安装与配对、暂停后继续需要登录状态的下载、重启后的已完成
+任务，以及大文件最终保存的位置。也请结合应用和系统设置检查减少动态效果。
+
+受保护发布完成后，Snap 测试者可使用
+`sudo snap install motrix --edge` 安装严格限制的构建。已跟踪
+`latest/edge` 的安装应升级到同一组 beta.33 revision。
+
+## 发布门禁通过后计划提供的下载
+
+| 分发方式 | 架构 | 计划产物 |
+|---------|------|---------|
+| macOS 13 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
+| Windows | `x64` | 未签名 NSIS 安装程序（`.exe`）和 ZIP |
+| Linux | `x64`、`arm64` | AppImage、DEB 和 RPM |
+| Flatpak Native Host companion | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.33-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个仓库中的不可变 `2.0.0-beta.33` 标签 |
+| Snap Store | `amd64`、`arm64` | `latest/edge` 上的已验证构建集 |
+
+所有容器门禁通过后，可使用以下带版本镜像：
+`docker.io/motrixapp/motrix-server:2.0.0-beta.33` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.33`。存储、网络、远程 Extension
+配对与升级说明请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.33/docs/docker-server.zh-CN.md)。
+
+## 分发说明
+
+- AppImage 桌面集成需要用户主动启用，且只会写入当前用户的 XDG 数据目录。由于
+  Native Messaging host 在挂载镜像之外没有稳定路径，浏览器扩展暂时无法向
+  AppImage 安装包转交下载任务。
+- Flatpak 单独验证，不由 release tag 发布；GitHub 预发布版会包含它的 Native
+  Host companion 压缩包。
+- 不提供 Windows `arm64` 和所有 32 位安装包。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅从已发布的
+  官方 GitHub 预发布版下载。
+- Beta 容器标签不可变，也不会更新 `latest`、`stable` 或其他稳定通道浮动标签。
+- Snap 安装包使用严格限制。已批准的 `personal-files` interface 仅用于为支持的
+  浏览器注册 Native Messaging host manifest。Beta 发布只会更新
+  `latest/edge`，不会把构建晋级到 `candidate` 或 `stable`。
+
+## 反馈
+
+如遇到可复现问题，请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues)
+反馈，并附上操作系统、架构、安装包类型和复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -74,6 +74,17 @@
   </screenshots>
 
   <releases>
+    <release version="2.0.0-beta.33" date="2026-09-07">
+      <description>
+        <p>
+          Settings links to the published Chrome and Edge extensions, Firefox
+          development builds, and trusted extension store pages. This release
+          adds a reduced-motion preference, updates aria2 to 1.37.0-motrix.14
+          for durable task cookies, and improves completed-task recovery,
+          save-directory restoration, and large-file finalization.
+        </p>
+      </description>
+    </release>
     <!-- Update this list on every release; Flathub linter requires the most
          recent version listed here to match the manifest's source tag. -->
     <release version="2.0.0-beta.32" date="2026-09-05">

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.32",
+  "version": "2.0.0-beta.33",
   "packageManager": "pnpm@11.25.0+sha512.5cde925b4f075f725eb71fbae18a42ffe784524789f19b61c731cb8721ec28aaee160e01a8d5af4fedb2a42cdbf300efe23db356b0d4a17b4d63e11f8ab7c956",
   "description": "A full-featured download manager",
   "keywords": [],


### PR DESCRIPTION
Prepare Motrix 2.0.0-beta.33 from the changes merged since v2.0.0-beta.32 (6d9fbffc through 8bc7660a). This beta adds published browser-extension store links, original brand icons, trusted-ID store links, and reduced-motion settings; it also includes durable task-cookie support with aria2 1.37.0-motrix.14, completed-task recovery, save-directory restoration, and large-file finalization fixes.

Package metadata, both READMEs, bilingual tag-pinned release notes, and Flatpak AppStream metadata now agree on beta.33. The protected tag workflow will build macOS DMG/ZIP, unsigned Windows x64 installer/ZIP, Linux AppImage/DEB/RPM, Native Host companions, immutable amd64/arm64 Server images, and verified Snap edge builds. Windows signing and AppImage browser-integration limitations remain explicit.

Validation passed: architecture boundaries, full lint, TypeScript, Flatpak packaging contract, file names, 104 focused release/version tests, and the complete local suite (9,108 passed; 4 skipped). Extension UI checks additionally covered all three locales, official artwork notices, and installation/trusted-ID links. The pinned dependency graph is unchanged; local pnpm only warned about the workspace-version change instead of reinstalling dependencies.
