### PR TITLE
fix(bt): isolate web seed failures and extend magnet timeout

### DIFF
--- a/src/core/engine/aria2/aria2-adapter.test.ts
+++ b/src/core/engine/aria2/aria2-adapter.test.ts
@@ -784,6 +784,30 @@ describe('Aria2Adapter', () => {
       ).rejects.toThrow('instead of reserved gid')
     })
 
+    it.each([
+      ['magnet:?xt=urn:btih:aabb', '0'],
+      ['MAGNET:?xt=urn:btih:aabb', '0'],
+      ['https://example.com/magnet:fixture.bin', '10'],
+    ])(
+      'isolates Web Seed 404s only for magnet URIs: %s',
+      async (uri, limit) => {
+        const rpc = createMockRpc()
+        vi.mocked(rpc.addUri).mockResolvedValue('gid-new')
+        const adapter = new Aria2Adapter(rpc)
+
+        await adapter.createDownload({
+          uris: [uri],
+          saveDir: '/d',
+          extraEngineOptions: { 'max-file-not-found': '10' },
+        })
+
+        expect(rpc.addUri).toHaveBeenCalledWith(
+          [uri],
+          expect.objectContaining({ 'max-file-not-found': limit })
+        )
+      }
+    )
+
     it('createDownload maps connections to split + max-connection-per-server', async () => {
       const rpc = createMockRpc()
       vi.mocked(rpc.addUri).mockResolvedValue('gidXYZ')
@@ -1562,6 +1586,7 @@ describe('Aria2Adapter', () => {
         'seed-time': '60',
         'seed-ratio': '1',
         'bt-seed-unverified': 'true',
+        'max-file-not-found': '0',
         pause: 'false',
       })
     })

--- a/src/core/engine/aria2/aria2-adapter.ts
+++ b/src/core/engine/aria2/aria2-adapter.ts
@@ -517,6 +517,12 @@ export class Aria2Adapter implements EngineAdapter {
     }
     options.continue = resumePolicy === 'sequential-prefix' ? 'true' : 'false'
 
+    // A magnet can spawn a BT payload with HTTP Web Seeds. Their 404s must
+    // not halt the entire torrent before a healthy source sends any data.
+    if (params.uris.some((uri) => /^magnet:/i.test(uri))) {
+      options['max-file-not-found'] = '0'
+    }
+
     const actualGid = await this.addUriWithConnectionFallback(
       params.uris,
       options,
@@ -757,6 +763,10 @@ export class Aria2Adapter implements EngineAdapter {
     if (requestedGid !== undefined) {
       opts.gid = requestedGid
     }
+    // aria2 applies this HTTP/FTP threshold to the whole BT RequestGroup.
+    // Override both user configuration and stale task options so a failed
+    // Web Seed cannot abort peers or other Web Seeds before their first byte.
+    opts['max-file-not-found'] = '0'
     const b64 = Buffer.from(params.metadata).toString('base64')
     const actualGid = await this.rpc.addTorrent(b64, [], opts)
     if (

--- a/src/core/engine/aria2/bt-webseed-policy.integration.test.ts
+++ b/src/core/engine/aria2/bt-webseed-policy.integration.test.ts
@@ -1,0 +1,236 @@
+// @vitest-environment node
+
+import { createHash } from 'node:crypto'
+import { mkdir, mkdtemp, open, rm, stat } from 'node:fs/promises'
+import http from 'node:http'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import {
+  createBtStoragePlan,
+  parseBtFileLayout,
+} from '@core/task/bt-storage-layout'
+import {
+  type Aria2Handle,
+  bundledAria2Exists,
+  canBindLoopbackTcp,
+  connectAdapter,
+  spawnAria2ForTest,
+} from '@test-utils/aria2'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { Aria2RawStatus } from './types'
+
+const PIECE_LENGTH = 256 * 1024
+const PAYLOAD_LENGTH = 128 * 1024 * 1024
+const PAYLOAD_BYTE = 97
+
+function bencodedString(value: string | Buffer): Buffer {
+  const bytes = typeof value === 'string' ? Buffer.from(value) : value
+  return Buffer.concat([Buffer.from(`${bytes.length}:`), bytes])
+}
+
+function createWebSeedTorrent(baseUrl: string): Buffer {
+  const pieceHash = createHash('sha1')
+    .update(Buffer.alloc(PIECE_LENGTH, PAYLOAD_BYTE))
+    .digest()
+  const pieces = Buffer.concat(
+    Array.from({ length: PAYLOAD_LENGTH / PIECE_LENGTH }, () => pieceHash)
+  )
+  return Buffer.concat([
+    Buffer.from('d8:announce'),
+    bencodedString(`${baseUrl}/announce`),
+    Buffer.from(`4:infod6:lengthi${PAYLOAD_LENGTH}e4:name`),
+    bencodedString('fixture.bin'),
+    Buffer.from(`12:piece lengthi${PIECE_LENGTH}e6:pieces`),
+    bencodedString(pieces),
+    Buffer.from('e8:url-listl'),
+    bencodedString(`${baseUrl}/missing-a`),
+    bencodedString(`${baseUrl}/missing-b`),
+    bencodedString(`${baseUrl}/healthy`),
+    Buffer.from('ee'),
+  ])
+}
+
+describe.skipIf(!bundledAria2Exists() || !canBindLoopbackTcp())(
+  'BitTorrent Web Seed failure isolation (real aria2)',
+  () => {
+    let baseDir: string | undefined
+    let handle: Aria2Handle | undefined
+    let disconnect: (() => void) | undefined
+    let server: http.Server | undefined
+    const replyTimers = new Set<ReturnType<typeof setTimeout>>()
+
+    afterEach(async () => {
+      disconnect?.()
+      await handle?.kill()
+      for (const timer of replyTimers) clearTimeout(timer)
+      replyTimers.clear()
+      if (server) {
+        server.closeAllConnections()
+        await new Promise<void>((resolve, reject) => {
+          server?.close((error) => (error ? reject(error) : resolve()))
+        })
+      }
+      if (baseDir) await rm(baseDir, { recursive: true, force: true })
+      baseDir = undefined
+      handle = undefined
+      disconnect = undefined
+      server = undefined
+    })
+
+    it.each([false, true])(
+      'isolates a failed Web Seed with the BT adapter policy: %s',
+      async (useAdapter) => {
+        baseDir = await mkdtemp(path.join(tmpdir(), 'motrix-bt-webseed-'))
+        let missingResponses = 0
+        const healthyReplies: Array<() => void> = []
+        let healthyReleased = false
+        let releaseScheduled = false
+        server = http.createServer((request, response) => {
+          if (request.url === '/announce') {
+            response.end('d8:intervali60e5:peers0:e')
+            return
+          }
+          if (request.url?.startsWith('/missing')) {
+            missingResponses++
+            response.writeHead(404, { 'content-length': 0 })
+            response.end()
+            if (missingResponses >= 10 && !releaseScheduled) {
+              releaseScheduled = true
+              // Two missing URLs ensure enough concurrent 404s even when
+              // aria2 shuffles the Web Seeds. Let it consume the fatal
+              // threshold before any healthy source contributes bytes.
+              // The raw-RPC control below proves
+              // that this fixture still reproduces the original failure.
+              replyTimers.add(
+                setTimeout(() => {
+                  healthyReleased = true
+                  for (const reply of healthyReplies.splice(0)) reply()
+                }, 500)
+              )
+            }
+            return
+          }
+          const range = /^bytes=(\d+)-(\d*)$/.exec(request.headers.range ?? '')
+          if (request.url !== '/healthy' || !range) {
+            response.writeHead(400)
+            response.end()
+            return
+          }
+          const start = Number(range[1])
+          const end = range[2] ? Number(range[2]) : PAYLOAD_LENGTH - 1
+          const reply = () => {
+            if (response.destroyed) return
+            response.writeHead(206, {
+              'content-length': end - start + 1,
+              'content-range': `bytes ${start}-${end}/${PAYLOAD_LENGTH}`,
+            })
+            response.end(Buffer.alloc(end - start + 1, PAYLOAD_BYTE))
+          }
+          if (healthyReleased) reply()
+          else healthyReplies.push(reply)
+        })
+        await new Promise<void>((resolve, reject) => {
+          server?.once('error', reject)
+          server?.listen(0, '127.0.0.1', resolve)
+        })
+        const address = server.address()
+        if (!address || typeof address === 'string') {
+          throw new Error('Missing fixture server address')
+        }
+        const baseUrl = `http://127.0.0.1:${address.port}`
+        handle = await spawnAria2ForTest({
+          baseDir,
+          extraArgs: [
+            '--max-file-not-found=10',
+            '--split=16',
+            '--max-connection-per-server=64',
+            '--min-split-size=4M',
+            '--file-allocation=none',
+            '--seed-time=0',
+            '--bt-enable-lpd=false',
+            '--enable-dht6=false',
+            '--all-proxy=',
+            '--http-proxy=',
+            '--https-proxy=',
+            '--no-proxy=*',
+            '--enable-sqlite3-persistence=true',
+            `--sqlite3-db-path=${path.join(baseDir, 'aria2.db')}`,
+          ],
+        })
+        const wired = await connectAdapter(handle)
+        disconnect = wired.disconnect
+        const metadata = createWebSeedTorrent(baseUrl)
+        const plan = createBtStoragePlan(
+          'webseed-policy',
+          baseDir,
+          await parseBtFileLayout(metadata)
+        )
+        const saveDir = plan.layout.workspacePath
+        await mkdir(saveDir, { recursive: true })
+        const gid = useAdapter
+          ? await wired.adapter.addTorrent({
+              metadata,
+              saveDir,
+              selectedFiles: [1],
+              outputFilePaths: plan.outputFilePaths,
+              // A stale task override must not re-enable the fatal policy.
+              extraEngineOptions: { 'max-file-not-found': '10' },
+            })
+          : await wired.rpc.addTorrent(metadata.toString('base64'), [], {
+              dir: saveDir,
+              'index-out': ['1=p'],
+            })
+
+        let terminal: Aria2RawStatus | undefined
+        await expect
+          .poll(
+            async () => {
+              terminal = await wired.rpc.tellStatus(gid)
+              return terminal.status
+            },
+            { timeout: 12_000, interval: 100 }
+          )
+          .toMatch(/^(complete|error)$/)
+        expect(missingResponses).toBeGreaterThanOrEqual(10)
+        expect((await wired.rpc.getGlobalOption())['max-file-not-found']).toBe(
+          '10'
+        )
+
+        if (!useAdapter) {
+          expect(terminal).toMatchObject({
+            status: 'error',
+            errorCode: '4',
+            errorMessage: 'Reached max-file-not-found count=10',
+            completedLength: '0',
+          })
+          return
+        }
+        expect(terminal).toMatchObject({
+          status: 'complete',
+          completedLength: String(PAYLOAD_LENGTH),
+          infoHash: (await parseBtFileLayout(metadata)).infoHash,
+        })
+        const payloadPath = path.join(saveDir, 'p')
+        expect((await stat(payloadPath)).size).toBe(PAYLOAD_LENGTH)
+        const file = await open(payloadPath, 'r')
+        try {
+          const prefix = Buffer.alloc(64)
+          await file.read(prefix, 0, prefix.length, 0)
+          expect(prefix).toEqual(Buffer.alloc(prefix.length, PAYLOAD_BYTE))
+        } finally {
+          await file.close()
+        }
+
+        const httpGid = await wired.adapter.createDownload({
+          uris: [`${baseUrl}/missing`],
+          saveDir: baseDir,
+          pause: true,
+        })
+        expect((await wired.rpc.getOption(httpGid))['max-file-not-found']).toBe(
+          '10'
+        )
+      },
+      20_000
+    )
+  }
+)

--- a/src/core/session/session-manager.test.ts
+++ b/src/core/session/session-manager.test.ts
@@ -3976,6 +3976,7 @@ describe('restore() with task_instances (Plan A Task 7)', () => {
         'bt-metadata-only': 'true',
         dir: '/tmp/motrix-magnet-metadata-xyz',
         'follow-torrent': 'false',
+        'max-file-not-found': '0',
       })
     )
 

--- a/src/core/session/session-manager.ts
+++ b/src/core/session/session-manager.ts
@@ -1807,6 +1807,7 @@ export class SessionManager {
 
     try {
       const newGid = await this.rpc.addUri([magnetUri], {
+        'max-file-not-found': '0',
         'bt-load-saved-metadata': 'false',
         'bt-metadata-only': 'true',
         dir: metadataDir,

--- a/src/core/settings/migrations.test.ts
+++ b/src/core/settings/migrations.test.ts
@@ -87,8 +87,8 @@ describe('migrate', () => {
 })
 
 describe('migration v3 → v4', () => {
-  it('targets version 10', () => {
-    expect(CURRENT_SETTINGS_VERSION).toBe(10)
+  it('targets version 11', () => {
+    expect(CURRENT_SETTINGS_VERSION).toBe(11)
   })
 
   it('adds dhtListenPort defaulting to listenPort value', () => {
@@ -198,8 +198,8 @@ describe('migration v5 → v6 (media namespace)', () => {
 })
 
 describe('migration v6 → v7 (speedLimit namespace)', () => {
-  it('targets version 10', () => {
-    expect(CURRENT_SETTINGS_VERSION).toBe(10)
+  it('targets version 11', () => {
+    expect(CURRENT_SETTINGS_VERSION).toBe(11)
   })
 
   it('v6→v7: maps a configured limit to base, turtle off', () => {
@@ -359,12 +359,44 @@ describe('migration v9 → v10 (bridge fixed port and instance id)', () => {
     // below vacuously (undefined === undefined).
     expect(instanceId).toEqual(expect.stringMatching(UUID_PATTERN))
 
-    // migrate() short-circuits at version === CURRENT_SETTINGS_VERSION
-    // (migrations.ts), so a v10 document never re-enters migrateV9ToV10.
+    // A document at or beyond v10 never re-enters migrateV9ToV10.
     const migratedTwice = migrate(migratedOnce)
 
     expect((migratedTwice.bridge as Record<string, unknown>).instanceId).toBe(
       instanceId
     )
+  })
+})
+
+describe('migration v10 → v11 (magnet metadata timeout)', () => {
+  it('upgrades the former timeout default without mutating the input', () => {
+    const input = {
+      version: 10,
+      engine: { magnetResolveTimeout: 120, dhtEnabled: false },
+      app: { theme: 'dark' },
+    }
+
+    expect(migrate(input)).toEqual({
+      ...input,
+      version: CURRENT_SETTINGS_VERSION,
+      engine: { ...input.engine, magnetResolveTimeout: 600 },
+    })
+    expect(input.engine.magnetResolveTimeout).toBe(120)
+  })
+
+  it.each([30, 90, 180, 300, 600])(
+    'preserves an existing %i-second timeout',
+    (magnetResolveTimeout) => {
+      const engine = { magnetResolveTimeout }
+      expect(migrate({ version: 10, engine }).engine).toEqual(engine)
+    }
+  )
+
+  it('preserves an explicit 120-second choice after the upgrade', () => {
+    const input = {
+      version: CURRENT_SETTINGS_VERSION,
+      engine: { magnetResolveTimeout: 120 },
+    }
+    expect(migrate(input)).toEqual(input)
   })
 })

--- a/src/core/settings/migrations.ts
+++ b/src/core/settings/migrations.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 
-export const CURRENT_SETTINGS_VERSION = 10
+export const CURRENT_SETTINGS_VERSION = 11
 
 interface Migration {
   version: number
@@ -234,6 +234,22 @@ function migrateV9ToV10(
   }
 }
 
+function migrateV10ToV11(
+  data: Record<string, unknown>
+): Record<string, unknown> {
+  const engine = (data.engine ?? {}) as Record<string, unknown>
+  return {
+    ...data,
+    version: 11,
+    // Persisted settings do not distinguish the former default from an
+    // explicit 120-second choice. Upgrade that value once; all other values
+    // remain user-controlled, including 120 selected again after migration.
+    ...(engine.magnetResolveTimeout === 120
+      ? { engine: { ...engine, magnetResolveTimeout: 600 } }
+      : {}),
+  }
+}
+
 const migrations: Migration[] = [
   { version: 1, migrate: migrateV0ToV1 },
   { version: 2, migrate: migrateV1ToV2 },
@@ -245,6 +261,7 @@ const migrations: Migration[] = [
   { version: 8, migrate: migrateV7ToV8 },
   { version: 9, migrate: migrateV8ToV9 },
   { version: 10, migrate: migrateV9ToV10 },
+  { version: 11, migrate: migrateV10ToV11 },
 ]
 
 export function migrate(

--- a/src/core/settings/settings-manager.test.ts
+++ b/src/core/settings/settings-manager.test.ts
@@ -309,6 +309,35 @@ describe('SettingsManager', () => {
       expect(manager.get().dashboard).toEqual(DEFAULT_DASHBOARD_LAYOUT)
     })
 
+    it('persists the longer legacy magnet timeout and preserves later edits', async () => {
+      mockedFs.readFile.mockResolvedValue(
+        JSON.stringify({
+          version: 10,
+          engine: { magnetResolveTimeout: 120 },
+        })
+      )
+      mockedFs.mkdir.mockResolvedValue(undefined)
+      mockedFs.writeFile.mockResolvedValue(undefined)
+
+      await manager.load()
+
+      expect(manager.getEngine().magnetResolveTimeout).toBe(600)
+      expect(JSON.parse(mockedFs.writeFile.mock.lastCall?.[1])).toMatchObject({
+        version: CURRENT_SETTINGS_VERSION,
+        engine: { magnetResolveTimeout: 600 },
+      })
+
+      await manager.update({ engine: { magnetResolveTimeout: 120 } })
+      mockedFs.readFile.mockResolvedValue(mockedFs.writeFile.mock.lastCall?.[1])
+      await manager.load()
+      expect(manager.getEngine().magnetResolveTimeout).toBe(120)
+
+      await manager.update({ engine: { magnetResolveTimeout: 900 } })
+      mockedFs.readFile.mockResolvedValue(mockedFs.writeFile.mock.lastCall?.[1])
+      await manager.load()
+      expect(manager.getEngine().magnetResolveTimeout).toBe(900)
+    })
+
     it('falls back to defaults on corrupted JSON', async () => {
       mockedFs.readFile.mockResolvedValue('not valid json {{{')
       mockedFs.mkdir.mockResolvedValue(undefined)

--- a/src/core/torrent/magnet-tracker.test.ts
+++ b/src/core/torrent/magnet-tracker.test.ts
@@ -17,6 +17,7 @@ import type { TaskManager } from '@core/task/task-manager'
 import { DownloadErrorCode, ErrorCode } from '@shared/errors'
 import { Events } from '@shared/protocol/events'
 import { magnetFileSelectionPayloadSchema } from '@shared/schemas/add-task'
+import { DEFAULT_ENGINE_SETTINGS } from '@shared/schemas/engine-settings'
 import type { DownloadTask } from '@shared/types/task'
 import {
   makeDefaultBtExtension,
@@ -82,7 +83,9 @@ function createMockSettingsManager(overrides?: {
       magnetFileSelection: overrides?.magnetFileSelection ?? true,
     }),
     getEngine: vi.fn().mockReturnValue({
-      magnetResolveTimeout: overrides?.magnetResolveTimeout ?? 120,
+      magnetResolveTimeout:
+        overrides?.magnetResolveTimeout ??
+        DEFAULT_ENGINE_SETTINGS.magnetResolveTimeout,
     }),
   }
 }
@@ -404,6 +407,7 @@ describe('MagnetTracker', () => {
     const metadataDir = lastMetadataDir()
     expect(metadataDir).not.toBe(dir)
     expect(rpc.addUri).toHaveBeenCalledWith(['magnet:?xt=urn:btih:abc123'], {
+      'max-file-not-found': '0',
       'bt-load-saved-metadata': 'false',
       'bt-metadata-only': 'true',
       dir: metadataDir,
@@ -1103,6 +1107,7 @@ describe('MagnetTracker', () => {
 
     expect(rpc.addUri).toHaveBeenCalledWith(['magnet:?xt=urn:btih:abc123'], {
       dir: '/downloads',
+      'max-file-not-found': '0',
     })
   })
 
@@ -1900,6 +1905,37 @@ describe('MagnetTracker', () => {
 
   // ── 7. Timeout ────────────────────────────────────────────────
 
+  it('waits ten minutes initially and twenty minutes on retry with default settings', async () => {
+    const dir = await makeTempDir()
+    const tracker = createMagnetTracker(
+      rpc as never,
+      eventBus as never,
+      settings as never,
+      db,
+      taskManager,
+      torrentParser
+    )
+    const taskId = await tracker.submit('magnet:?xt=urn:btih:slow-peers', dir)
+
+    await vi.advanceTimersByTimeAsync(120_000)
+    expect(db.getTask(taskId)?.task.aggStatus).toBe(TaskStatus.FetchingMetadata)
+    expect(rpc.forceRemove).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(479_999)
+    expect(db.getTask(taskId)?.task.aggStatus).toBe(TaskStatus.FetchingMetadata)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(db.getTask(taskId)?.task.aggStatus).toBe(TaskStatus.Error)
+
+    await tracker.retryMetadata(taskId)
+    await vi.advanceTimersByTimeAsync(1_199_999)
+    expect(db.getTask(taskId)?.task.aggStatus).toBe(TaskStatus.FetchingMetadata)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(db.getTask(taskId)?.task).toMatchObject({
+      aggStatus: TaskStatus.Error,
+      errorCode: DownloadErrorCode.Timeout,
+    })
+  })
+
   it('cleans up after magnetResolveTimeout expires', async () => {
     const dir = await makeTempDir()
     settings = createMockSettingsManager({ magnetResolveTimeout: 60 })
@@ -2209,6 +2245,8 @@ describe('MagnetTracker', () => {
     expect(rpc.addUri).toHaveBeenCalledTimes(2)
     expect(firstOptions?.['bt-load-saved-metadata']).toBe('false')
     expect(secondOptions?.['bt-load-saved-metadata']).toBe('false')
+    expect(firstOptions?.['max-file-not-found']).toBe('0')
+    expect(secondOptions?.['max-file-not-found']).toBe('0')
     expect(secondOptions?.gid).not.toBe(firstOptions?.gid)
     expect(secondOptions?.dir).not.toBe(firstOptions?.dir)
     expect(db.getTask(taskId)).toMatchObject({

--- a/src/core/torrent/magnet-tracker.ts
+++ b/src/core/torrent/magnet-tracker.ts
@@ -437,7 +437,11 @@ export class MagnetTracker {
     const { magnetFileSelection } = this.settingsManager.getApp()
 
     if (!magnetFileSelection) {
-      const gid = await this.rpcClient.addUri([uri], { dir: saveDir })
+      const gid = await this.rpcClient.addUri([uri], {
+        dir: saveDir,
+        // The automatically followed BT payload inherits these options.
+        'max-file-not-found': '0',
+      })
       if (this.stopped) return ''
       log.info({ gid, uri }, 'magnet added (file selection disabled)')
       return ''
@@ -630,6 +634,7 @@ export class MagnetTracker {
 
           engineDispatchStarted = true
           const returnedGid = await this.rpcClient.addUri([uri], {
+            'max-file-not-found': '0',
             'bt-load-saved-metadata': 'false',
             'bt-metadata-only': 'true',
             dir: metadataDir,
@@ -854,6 +859,7 @@ export class MagnetTracker {
 
       engineDispatchStarted = true
       const returnedGid = await this.rpcClient.addUri([magnetUri], {
+        'max-file-not-found': '0',
         'bt-load-saved-metadata': 'false',
         'bt-metadata-only': 'true',
         dir: metadataDir,

--- a/src/renderer/routes/settings/cards/downloads-dialog.test.tsx
+++ b/src/renderer/routes/settings/cards/downloads-dialog.test.tsx
@@ -108,6 +108,28 @@ describe('<DownloadsDialog>', () => {
     expect(onClose).toHaveBeenCalled()
   })
 
+  it('allows saving a 900-second magnet metadata timeout', async () => {
+    render(
+      <DownloadsDialog
+        open
+        onClose={vi.fn()}
+        labelKey="settings.cards.downloads.title"
+        descKey="settings.cards.downloads.desc"
+      />
+    )
+
+    const input = await screen.findByLabelText(/magnet resolve timeout/i)
+    await waitFor(() => expect(input).toHaveValue(120))
+    expect(input).toHaveAttribute('max', '900')
+    fireEvent.change(input, { target: { value: '900' } })
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: /save/i }))
+    expect(transport.invoke).toHaveBeenCalledWith(Commands.UpdateSettings, {
+      engine: { magnetResolveTimeout: 900 },
+    })
+  })
+
   it('exposes the Motrix aria2 connection limit in the performance settings', async () => {
     render(
       <DownloadsDialog

--- a/src/renderer/routes/settings/cards/engine-tuning-section.tsx
+++ b/src/renderer/routes/settings/cards/engine-tuning-section.tsx
@@ -250,7 +250,7 @@ export function EngineTuningSection({
         'magnetResolveTimeout',
         'settings.downloads.magnet.magnetResolveTimeout',
         'settings.downloads.magnet.magnetResolveTimeoutDesc',
-        { min: 30, max: 600 }
+        { min: 30, max: 900 }
       )}
     </>
   )

--- a/src/shared/schemas/engine-settings.ts
+++ b/src/shared/schemas/engine-settings.ts
@@ -91,7 +91,7 @@ export const engineSettingsSchema = z
       .catch(-1),
 
     // Magnet (motrix-turbo timer)
-    magnetResolveTimeout: z.number().int().min(30).max(600).catch(120),
+    magnetResolveTimeout: z.number().int().min(30).max(900).catch(600),
   })
   .transform(applyEnginePerformanceProfile)
 


### PR DESCRIPTION
## Summary / 概述

A torrent with a missing HTTP Web Seed could fail with `Reached max-file-not-found count=10` before a healthy source delivered any data. Apply `max-file-not-found=0` to BT submissions so the failed source does not halt the entire torrent, while preserving ordinary HTTP download policy. Extend the default magnet metadata timeout to 600 seconds and allow up to 900 seconds in settings, giving slow peer discovery more time.

包含失效 HTTP Web Seed 的 torrent 可能在健康来源传回数据前，以 `Reached max-file-not-found count=10` 失败。为 BT 提交单独设置 `max-file-not-found=0`，避免失效来源中止整个 torrent，并保留普通 HTTP 下载策略。magnet 元数据解析默认等待时间延长至 600 秒，设置页允许最大 900 秒，为较慢的 peer 发现过程留出更多时间。

## Related issue / 相关 Issue

Refs #2085

## Changes / 改动

- Apply the BT option after caller-supplied engine options, including stale overrides. Cover torrent/magnet submission, metadata retry and recovery, and torrent re-add paths.
- Raise the timeout default from 120 to 600 seconds and the settings limit from 600 to 900 seconds. Preserve the existing 2x retry timeout, giving 1,200 seconds at the new default.
- Migrate settings to version 11: upgrade a persisted 120-second value once; preserve other values and subsequent user edits. Legacy settings cannot distinguish an explicit 120-second choice from the former default.
- Add a real-engine regression with missing and delayed healthy Web Seeds, indexed staging, and SQLite persistence, plus focused option, timer, migration, persistence, and form tests.

- 在调用方引擎参数之后应用 BT 专用选项，覆盖旧任务中的正数配置；覆盖 torrent/magnet 提交、元数据重试与恢复，以及 torrent 重新添加入口。
- 默认超时由 120 秒改为 600 秒，设置上限由 600 秒改为 900 秒；保留重试时的 2 倍超时，因此默认重试等待 1,200 秒。
- 设置版本升级到 11：一次性迁移已保存的 120 秒值，保留其他值及迁移后的用户修改。旧配置无法区分用户明确选择的 120 秒与旧默认值。
- 增加真实引擎回归，覆盖失效及延迟响应的健康 Web Seed、indexed staging 和 SQLite 持久化，并补充参数、计时器、迁移、持久化与设置表单测试。

## Validation / 验证

- [x] `pnpm run check:boundaries`
- [x] `pnpm run lint`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm run check:file-names`
- [x] Relevant automated tests / 相关自动化测试

Validation details / 验证详情：

- Focused Vitest unit/component suite: **550 passed**, covering adapter options, session recovery, settings migration/persistence, magnet timers, and the settings form.
- `pnpm exec vitest run src/core/engine/aria2/bt-webseed-policy.integration.test.ts`: **2 passed** on macOS arm64 with bundled aria2 `1.37.0-motrix.14`. The raw RPC control fails with error code 4 and zero downloaded bytes; the adapter path completes the 128 MiB payload while ordinary HTTP tasks retain the global value of 10.
- The real-engine test skips if the bundled binary or loopback TCP binding is unavailable. The reporter's Windows environment and public swarm discovery were not reproduced; the increased magnet timeout provides a longer wait budget, without claiming to resolve every discovery failure.
- Focused unit/component tests verify the 600-second initial timeout, the existing 1,200-second retry timeout, and saving/reloading the 900-second setting.

- 定向 Vitest 单元/组件测试 **550 项通过**，覆盖 adapter 参数、会话恢复、设置迁移与持久化、magnet 计时器和设置表单。
- 真实引擎回归 **2 项通过**：在 macOS arm64、自带 aria2 `1.37.0-motrix.14` 上，原始 RPC 对照以错误码 4、零下载字节失败；adapter 路径完整下载 128 MiB，普通 HTTP 任务仍继承全局值 10。
- 缺少自带引擎或无法绑定 loopback TCP 时，该集成测试会跳过。未在报告者的 Windows 环境或公网 swarm 中复现；延长 magnet 超时提供更多等待时间，不代表解决所有 peer 发现失败。
- 定向单元/组件测试验证了首次等待 600 秒、重试等待 1,200 秒，以及 900 秒设置的保存与重新加载。

## Checklist / 检查清单

- [x] This pull request targets `main` and contains one focused change.
- [x] User-visible text is localized, and paired English/Chinese documentation stays aligned.
- [x] No credentials, private URLs, personal paths, or other sensitive information are included.
- [x] I have read and followed the [contribution guidelines](https://github.com/agalwood/Motrix/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/agalwood/Motrix/blob/main/CODE_OF_CONDUCT.md).
