### PR TITLE
chore(release): prepare 2.0.0-beta.34

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. After its remaining release gates pass,
-download [v2.0.0-beta.33 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.33)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.33.md) before
+download [v2.0.0-beta.34 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.34)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.34.md) before
 installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -174,7 +174,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.33'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.34'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。剩余发布门禁通过后，请从 GitHub Releases
-下载 [v2.0.0-beta.33](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.33)，
-并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.33.zh-CN.md)。
+下载 [v2.0.0-beta.34](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.34)，
+并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.34.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -165,7 +165,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.33'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.34'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.34.md
+++ b/docs/release-notes/2.0.0-beta.34.md
@@ -1,0 +1,93 @@
+# Motrix 2.0.0-beta.34
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.34/docs/release-notes/2.0.0-beta.34.zh-CN.md)
+
+Motrix 2.0.0-beta.34 makes BitTorrent and magnet downloads more resilient when
+Web Seeds fail, peer discovery is slow, or a WebUI misses the file-selection
+event. It also adds an optional timeout that can start all files when a magnet
+selection remains unconfirmed. It is intended for public distribution only
+after every protected release gate passes.
+
+## Highlights
+
+- A failed HTTP Web Seed no longer stops an entire BitTorrent task through
+  aria2's file-not-found limit. The BT-specific policy covers torrent and
+  magnet submission, metadata retry and recovery, and torrent re-add paths,
+  while ordinary HTTP downloads keep their configured policy
+  ([#2088](https://github.com/agalwood/Motrix/pull/2088)).
+- Magnet metadata discovery now waits 600 seconds by default, with a configurable
+  maximum of 900 seconds. Existing settings using the former 120-second default
+  are migrated once; other saved values and later user edits are preserved
+  ([#2088](https://github.com/agalwood/Motrix/pull/2088)).
+- Pending magnet file selections recover after refresh or reconnect, multiple
+  pending tasks queue behind the active form, and the task inspector provides a
+  manual selection action with pending and failure feedback. Direct WebUI
+  responses and dialog revisions prevent stale forms from replacing or closing
+  newer selections ([#2089](https://github.com/agalwood/Motrix/pull/2089)).
+- **Settings → BitTorrent** has an opt-in automatic selection timeout. When
+  enabled, a magnet task that remains unconfirmed after metadata is ready starts
+  all files after 60 seconds by default, configurable from 10 to 3,600 seconds.
+  The host-owned timer survives renderer closure and preserves elapsed selection
+  time across restarts ([#2089](https://github.com/agalwood/Motrix/pull/2089)).
+- Builtin plugin downloads retry transient failures with bounded exponential
+  backoff while retaining digest and signature verification. License checks are
+  isolated from application setup so they no longer fetch builtin plugins
+  ([#2089](https://github.com/agalwood/Motrix/pull/2089)).
+
+## Before testing
+
+This is prerelease software. Back up existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Test torrents containing unavailable Web Seeds, slow
+magnet metadata discovery, selection recovery after refreshing or reconnecting
+the WebUI, manual selection from the task inspector, and the optional automatic
+selection timeout across an application restart.
+
+After the protected release completes, Snap testers can install the strictly
+confined build with `sudo snap install motrix --edge`. Existing installations
+tracking `latest/edge` should upgrade to the same beta.34 revision set.
+
+## Planned downloads after release gates pass
+
+| Distribution | Architectures | Planned output |
+|--------------|---------------|----------------|
+| macOS 13 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | AppImage, DEB, and RPM |
+| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.34-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.34` tag in both registries |
+| Snap Store | `amd64`, `arm64` | Verified build set on `latest/edge` |
+
+After every container gate passes, the versioned image references will be
+`docker.io/motrixapp/motrix-server:2.0.0-beta.34` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.34`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.34/docs/docker-server.md)
+for storage, networking, remote Extension pairing, and upgrade guidance.
+
+## Distribution notes
+
+- AppImage desktop integration is opt-in and confined to the current user's
+  XDG data directory. Browser-extension hand-off is not yet available from the
+  AppImage package because its Native Messaging host does not have a stable
+  path outside the mounted image.
+- Flatpak is validated separately and is not published by the release tag; the
+  GitHub prerelease includes its Native Host companion archives.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
+  Download them only from the official GitHub prerelease after it is published.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+- The Snap package is strictly confined. Its approved `personal-files`
+  interface is limited to registering Native Messaging host manifests for
+  supported browsers. Beta publication updates `latest/edge` only; it does not
+  promote the build to `candidate` or `stable`.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.34.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.34.zh-CN.md
@@ -1,0 +1,80 @@
+# Motrix 2.0.0-beta.34
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.34/docs/release-notes/2.0.0-beta.34.md) | 简体中文
+
+Motrix 2.0.0-beta.34 提升了 BitTorrent 与磁力下载在 Web Seed 失效、peer 发现
+缓慢或 WebUI 错过文件选择事件时的可靠性，并新增可选的超时兜底，在磁力文件
+选择一直未确认时自动开始下载全部文件。只有在所有受保护发布门禁通过后，本版本
+才适合公开分发。
+
+## 主要改进
+
+- HTTP Web Seed 失效时，不再因 aria2 的文件未找到次数上限而中止整个 BitTorrent
+  任务。BT 专用策略覆盖 torrent 与 magnet 提交、元数据重试与恢复，以及 torrent
+  重新添加入口；普通 HTTP 下载仍保留用户配置的策略
+  （[#2088](https://github.com/agalwood/Motrix/pull/2088)）。
+- magnet 元数据发现的默认等待时间延长至 600 秒，设置上限为 900 秒。使用旧版
+  默认值 120 秒的存量设置会一次性迁移，其他已保存值和后续用户修改均会保留
+  （[#2088](https://github.com/agalwood/Motrix/pull/2088)）。
+- 刷新或重新连接后，尚未处理的 magnet 文件选择可从任务快照恢复；多个待处理
+  任务会排在当前表单之后，任务详情检查器也提供带等待与失败反馈的手动选择入口。
+  WebUI 可直接接收响应，弹窗 revision 会阻止旧表单替换或关闭较新的选择
+  （[#2089](https://github.com/agalwood/Motrix/pull/2089)）。
+- **设置 → BitTorrent** 新增可选的自动选择超时。启用后，如果 magnet 元数据
+  就绪后仍未确认文件选择，默认 60 秒后开始下载全部文件；可配置范围为 10 至
+  3,600 秒。计时由 host 持有，关闭 renderer 后仍会继续，并能跨重启保留已经
+  等待的时间（[#2089](https://github.com/agalwood/Motrix/pull/2089)）。
+- 内置插件下载遇到瞬时故障时，会使用有上限的指数退避重试，同时保留摘要与签名
+  验证。许可证检查与应用全局初始化隔离，不再触发内置插件下载
+  （[#2089](https://github.com/agalwood/Motrix/pull/2089)）。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1 数据的
+迁移路径尚未经过验证，请勿让本 beta 使用您唯一的一份 v1 数据。
+
+条件允许时，请使用独立的操作系统账号、设备或 Docker 数据目录并行测试 v2。
+请重点检查包含不可用 Web Seed 的 torrent、较慢的 magnet 元数据发现、刷新或
+重新连接 WebUI 后的文件选择恢复、任务详情检查器中的手动选择，以及跨应用重启
+后的可选自动选择超时。
+
+受保护发布完成后，Snap 测试者可使用
+`sudo snap install motrix --edge` 安装严格限制的构建。已跟踪
+`latest/edge` 的安装应升级到同一组 beta.34 revision。
+
+## 发布门禁通过后计划提供的下载
+
+| 分发方式 | 架构 | 计划产物 |
+|---------|------|---------|
+| macOS 13 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
+| Windows | `x64` | 未签名 NSIS 安装程序（`.exe`）和 ZIP |
+| Linux | `x64`、`arm64` | AppImage、DEB 和 RPM |
+| Flatpak Native Host companion | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.34-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个仓库中的不可变 `2.0.0-beta.34` 标签 |
+| Snap Store | `amd64`、`arm64` | `latest/edge` 上的已验证构建集 |
+
+所有容器门禁通过后，可使用以下带版本镜像：
+`docker.io/motrixapp/motrix-server:2.0.0-beta.34` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.34`。存储、网络、远程 Extension
+配对与升级说明请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.34/docs/docker-server.zh-CN.md)。
+
+## 分发说明
+
+- AppImage 桌面集成需要用户主动启用，且只会写入当前用户的 XDG 数据目录。由于
+  Native Messaging host 在挂载镜像之外没有稳定路径，浏览器扩展暂时无法向
+  AppImage 安装包转交下载任务。
+- Flatpak 单独验证，不由 release tag 发布；GitHub 预发布版会包含它的 Native
+  Host companion 压缩包。
+- 不提供 Windows `arm64` 和所有 32 位安装包。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅从已发布的
+  官方 GitHub 预发布版下载。
+- Beta 容器标签不可变，也不会更新 `latest`、`stable` 或其他稳定通道浮动标签。
+- Snap 安装包使用严格限制。已批准的 `personal-files` interface 仅用于为支持的
+  浏览器注册 Native Messaging host manifest。Beta 发布只会更新
+  `latest/edge`，不会把构建晋级到 `candidate` 或 `stable`。
+
+## 反馈
+
+如遇到可复现问题，请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues)
+反馈，并附上操作系统、架构、安装包类型和复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -74,6 +74,16 @@
   </screenshots>
 
   <releases>
+    <release version="2.0.0-beta.34" date="2026-09-08">
+      <description>
+        <p>
+          Improves BitTorrent resilience when HTTP Web Seeds fail, gives slow
+          magnet metadata discovery more time, restores missed file-selection
+          prompts, and adds an optional automatic download fallback for
+          unconfirmed magnet selections.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.33" date="2026-09-07">
       <description>
         <p>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.33",
+  "version": "2.0.0-beta.34",
   "packageManager": "pnpm@11.25.0+sha512.5cde925b4f075f725eb71fbae18a42ffe784524789f19b61c731cb8721ec28aaee160e01a8d5af4fedb2a42cdbf300efe23db356b0d4a17b4d63e11f8ab7c956",
   "description": "A full-featured download manager",
   "keywords": [],


### PR DESCRIPTION
## Summary / 概述

Prepare Motrix 2.0.0-beta.34 for the protected beta release workflow.

准备 Motrix 2.0.0-beta.34，并交由受保护的 beta 发布工作流构建与发布。

## Changes / 改动

- Bump the application, README download links, and immutable Server image examples to 2.0.0-beta.34.
- Add aligned English and Simplified Chinese release notes based on merged PRs #2088 and #2089.
- Add the matching Flatpak metainfo release entry dated 2026-09-08.

- 将应用版本、README 下载链接与不可变 Server 镜像示例更新至 2.0.0-beta.34。
- 根据已合并的 #2088 与 #2089 添加对齐的英文和简体中文发布说明。
- 添加日期为 2026-09-08 的 Flatpak metainfo 发布记录。

## Validation / 验证

- [x] Boundary checks
- [x] Biome lint
- [x] TypeScript typecheck
- [x] Flatpak packaging verification
- [x] File-name verification
- [x] Full Vitest suite: 9,185 passed, 4 skipped
- [x] git diff --check

The first sandboxed test attempt could not bind loopback sockets and reported environment-level EPERM failures. The identical full suite passed outside the sandbox.