### PR TITLE
chore(release): prepare 2.0.0-beta.35

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. After its remaining release gates pass,
-download [v2.0.0-beta.34 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.34)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.34.md) before
+download [v2.0.0-beta.35 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.35)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.35.md) before
 installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -176,7 +176,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.34'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.35'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。剩余发布门禁通过后，请从 GitHub Releases
-下载 [v2.0.0-beta.34](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.34)，
-并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.34.zh-CN.md)。
+下载 [v2.0.0-beta.35](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.35)，
+并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.35.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -167,7 +167,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.34'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.35'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.35.md
+++ b/docs/release-notes/2.0.0-beta.35.md
@@ -1,0 +1,81 @@
+# Motrix 2.0.0-beta.35
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.35/docs/release-notes/2.0.0-beta.35.zh-CN.md)
+
+Motrix 2.0.0-beta.35 improves download task controls and completion display,
+adds native Arch Linux packages, and links the published Firefox extension.
+It is intended for public distribution only after every protected release gate passes.
+
+## Highlights
+
+- Pause state remains consistent across aria2 RPC polling. HTTP/FTP tasks publish
+  their finalizing state before file processing, clear stale transfer metrics,
+  and keep incomplete transfers below 100 percent
+  ([#2100](https://github.com/agalwood/Motrix/pull/2100)).
+- Selected tasks remain visible beside the inspector, including after filtering
+  or resizing. Task details show creation and completion times, and opening the
+  destination folder works before the output file is ready
+  ([#2100](https://github.com/agalwood/Motrix/pull/2100)).
+- Native Arch Linux `.pacman` packages are built and verified for `x64` and
+  `arm64`, with an additional x64 installation smoke test. See the
+  [Arch Linux guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.35/docs/arch-linux.md)
+  for installation and updates
+  ([#2099](https://github.com/agalwood/Motrix/pull/2099)).
+- Browser integration links now point to the published Firefox Add-ons listing.
+
+## Before testing
+
+This is prerelease software. Back up existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Check pause/resume, completion progress, destination-folder
+actions before files exist, and selected-row visibility with the inspector open.
+Arch Linux testers should check installation and updates using the native package.
+
+After the protected release completes, Snap testers can install the strictly
+confined build with `sudo snap install motrix --edge`. Existing installations
+tracking `latest/edge` should upgrade to the same beta.35 revision set.
+
+## Planned downloads after release gates pass
+
+| Distribution | Architectures | Planned output |
+|--------------|---------------|----------------|
+| macOS 13 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | AppImage, DEB, RPM, and pacman |
+| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.35-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.35` tag in both registries |
+| Snap Store | `amd64`, `arm64` | Verified build set on `latest/edge` |
+
+After every container gate passes, the versioned image references will be
+`docker.io/motrixapp/motrix-server:2.0.0-beta.35` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.35`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.35/docs/docker-server.md)
+for storage, networking, remote Extension pairing, and upgrade guidance.
+
+## Distribution notes
+
+- AppImage desktop integration is opt-in and confined to the current user's
+  XDG data directory. Browser-extension hand-off is not yet available from the
+  AppImage package because its Native Messaging host does not have a stable
+  path outside the mounted image.
+- Flatpak is validated separately and is not published by the release tag; the
+  GitHub prerelease includes its Native Host companion archives.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
+  Download them only from the official GitHub prerelease after it is published.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+- The Snap package is strictly confined. Its approved `personal-files`
+  interface is limited to registering Native Messaging host manifests for
+  supported browsers. Beta publication updates `latest/edge` only; it does not
+  promote the build to `candidate` or `stable`.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.35.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.35.zh-CN.md
@@ -1,0 +1,71 @@
+# Motrix 2.0.0-beta.35
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.35/docs/release-notes/2.0.0-beta.35.md) | 简体中文
+
+Motrix 2.0.0-beta.35 改进下载任务控制与完成状态显示，新增 Arch Linux 原生
+安装包，并更新已发布 Firefox 扩展的入口。只有在所有受保护发布门禁通过后，
+本版本才适合公开分发。
+
+## 主要改进
+
+- 暂停状态在 aria2 RPC 轮询期间保持一致。HTTP/FTP 任务会在文件处理前发布
+  finalizing 状态，清除过时的传输指标，并使未完成下载的进度保持在 100% 以下
+  （[#2100](https://github.com/agalwood/Motrix/pull/2100)）。
+- 打开任务详情检查器后，选中的任务保持可见，包括筛选或调整窗口大小之后。
+  任务详情展示创建与完成时间，输出文件尚未就绪时也能打开目标目录
+  （[#2100](https://github.com/agalwood/Motrix/pull/2100)）。
+- 为 `x64` 和 `arm64` 构建并验证 Arch Linux 原生 `.pacman` 安装包，另有
+  x64 安装冒烟测试。安装与更新方式见
+  [Arch Linux 指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.35/docs/arch-linux.zh-CN.md)
+  （[#2099](https://github.com/agalwood/Motrix/pull/2099)）。
+- 浏览器集成入口现已指向发布在 Firefox Add-ons 的扩展。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1 数据的
+迁移路径尚未经过验证，请勿让本 beta 使用您唯一的一份 v1 数据。
+
+条件允许时，请使用独立的操作系统账号、设备或 Docker 数据目录并行测试 v2。
+请重点检查暂停与恢复、完成进度、文件尚不存在时的目标目录操作，以及打开任务
+详情检查器时选中行的可见性。Arch Linux 测试者请检查原生安装包的安装与更新。
+
+受保护发布完成后，Snap 测试者可使用
+`sudo snap install motrix --edge` 安装严格限制的构建。已跟踪
+`latest/edge` 的安装应升级到同一组 beta.35 revision。
+
+## 发布门禁通过后计划提供的下载
+
+| 分发方式 | 架构 | 计划产物 |
+|---------|------|---------|
+| macOS 13 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
+| Windows | `x64` | 未签名 NSIS 安装程序（`.exe`）和 ZIP |
+| Linux | `x64`、`arm64` | AppImage、DEB、RPM 和 pacman |
+| Flatpak Native Host companion | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.35-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个仓库中的不可变 `2.0.0-beta.35` 标签 |
+| Snap Store | `amd64`、`arm64` | `latest/edge` 上的已验证构建集 |
+
+所有容器门禁通过后，可使用以下带版本镜像：
+`docker.io/motrixapp/motrix-server:2.0.0-beta.35` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.35`。存储、网络、远程 Extension
+配对与升级说明请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.35/docs/docker-server.zh-CN.md)。
+
+## 分发说明
+
+- AppImage 桌面集成需要用户主动启用，且只会写入当前用户的 XDG 数据目录。由于
+  Native Messaging host 在挂载镜像之外没有稳定路径，浏览器扩展暂时无法向
+  AppImage 安装包转交下载任务。
+- Flatpak 单独验证，不由 release tag 发布；GitHub 预发布版会包含它的 Native
+  Host companion 压缩包。
+- 不提供 Windows `arm64` 和所有 32 位安装包。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅从已发布的
+  官方 GitHub 预发布版下载。
+- Beta 容器标签不可变，也不会更新 `latest`、`stable` 或其他稳定通道浮动标签。
+- Snap 安装包使用严格限制。已批准的 `personal-files` interface 仅用于为支持的
+  浏览器注册 Native Messaging host manifest。Beta 发布只会更新
+  `latest/edge`，不会把构建晋级到 `candidate` 或 `stable`。
+
+## 反馈
+
+如遇到可复现问题，请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues)
+反馈，并附上操作系统、架构、安装包类型和复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -74,6 +74,15 @@
   </screenshots>
 
   <releases>
+    <release version="2.0.0-beta.35" date="2026-09-08">
+      <description>
+        <p>
+          Improves download task controls, completion progress, and inspector
+          visibility, adds native Arch Linux packages, and links the published
+          Firefox extension.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.34" date="2026-09-08">
       <description>
         <p>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.34",
+  "version": "2.0.0-beta.35",
   "packageManager": "pnpm@11.25.0+sha512.5cde925b4f075f725eb71fbae18a42ffe784524789f19b61c731cb8721ec28aaee160e01a8d5af4fedb2a42cdbf300efe23db356b0d4a17b4d63e11f8ab7c956",
   "description": "A full-featured download manager",
   "keywords": [],


### PR DESCRIPTION
## Summary / 概述

Prepare 2.0.0-beta.35 from `v2.0.0-beta.34..bd2ee38b`: download task controls and completion display (#2100), native Arch Linux packages (#2099), and the published Firefox extension link. Align package metadata, both READMEs, paired release notes, and Flatpak metadata.

## Release outputs / 发布产物

macOS arm64/x64 DMG and ZIP with required signing and notarization; unsigned Windows x64 installer and ZIP; Linux x64/arm64 AppImage, DEB, RPM, and pacman; Flatpak Native Host archives; beta update manifests; immutable amd64/arm64 Server images; verified Snap latest/edge build set. Windows remains unsigned and this is disclosed in both release notes.

## Validation / 验证

- [x] `pnpm run check:boundaries`
- [x] `pnpm run lint`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm run check:flatpak`
- [x] `pnpm run check:file-names`
- [x] Focused Vitest: release-version-contract, release-metadata, assemble-release-artifacts, workflow-release-matrix, verify-pacman-artifact, verify-update-artifacts — 6 files, 152 tests passed.
- [x] Staged diff whitespace and bilingual/version references reviewed. Remaining beta.34 references are release history and a pacman test fixture.

The complete protected PR matrix must pass before squash merge; the formal tagged release must pass before the website deployment.
