### PR TITLE
feat(settings): add login startup window preference

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1626,6 +1626,7 @@ async function initializeMainProcess(): Promise<void> {
     })
     const mainWindowPlan = resolveMainWindowStartupPlan({
       openedAtLogin: launcher.wasOpenedAtLogin,
+      showMainWindowAtLogin: settingsManager.getApp().showMainWindowAtLogin,
       runMode,
       releaseWhenHidden: backgroundPolicy.releaseMainWindowWhenHidden,
     })

--- a/src/main/window/window-startup-plan.test.ts
+++ b/src/main/window/window-startup-plan.test.ts
@@ -49,3 +49,20 @@ describe('resolveMainWindowStartupPlan', () => {
     ).toEqual({ create: false, show: false })
   })
 })
+
+it.each([RunMode.Standard, RunMode.HideTray, RunMode.TrayOnly])(
+  'honors the login window preference in %s mode',
+  (runMode) => {
+    expect(
+      resolveMainWindowStartupPlan({
+        openedAtLogin: true,
+        showMainWindowAtLogin: true,
+        runMode,
+        releaseWhenHidden: true,
+      })
+    ).toEqual({
+      create: runMode !== RunMode.TrayOnly,
+      show: runMode !== RunMode.TrayOnly,
+    })
+  }
+)

--- a/src/main/window/window-startup-plan.ts
+++ b/src/main/window/window-startup-plan.ts
@@ -2,6 +2,7 @@ import { RunMode } from '@shared/constants'
 
 export interface MainWindowStartupPlanInput {
   openedAtLogin: boolean
+  showMainWindowAtLogin?: boolean
   runMode: RunMode
   releaseWhenHidden: boolean
 }
@@ -15,10 +16,12 @@ export interface MainWindowStartupPlan {
  * creates one; background launches may stay headless when release is safe. */
 export function resolveMainWindowStartupPlan({
   openedAtLogin,
+  showMainWindowAtLogin = false,
   runMode,
   releaseWhenHidden,
 }: MainWindowStartupPlanInput): MainWindowStartupPlan {
-  const show = !openedAtLogin && runMode !== RunMode.TrayOnly
+  const show =
+    (!openedAtLogin || showMainWindowAtLogin) && runMode !== RunMode.TrayOnly
   return {
     create: show || !releaseWhenHidden,
     show,

--- a/src/renderer/routes/settings/cards/general-dialog.test.tsx
+++ b/src/renderer/routes/settings/cards/general-dialog.test.tsx
@@ -34,6 +34,7 @@ class MockResizeObserver {
 const SETTINGS_FIXTURE = {
   app: {
     launchAtStartup: false,
+    showMainWindowAtLogin: false,
     defaultSaveDir: '/Users/me/Downloads',
     notifyOnComplete: true,
     notifyOnError: true,
@@ -101,7 +102,10 @@ describe('<GeneralDialog>', () => {
       ).toBeInTheDocument()
     )
     expect(
-      screen.queryByRole('switch', { name: /launch at startup/i })
+      screen.queryByRole('switch', { name: /open at login/i })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('switch', { name: /show main window at login/i })
     ).not.toBeInTheDocument()
     expect(
       screen.queryByRole('switch', { name: /confirm before quitting/i })
@@ -159,5 +163,22 @@ describe('<GeneralDialog>', () => {
       app: { launchAtStartup: true },
     })
     expect(onClose).toHaveBeenCalled()
+  })
+})
+
+it('enables the login window preference with auto-launch and saves both dirty fields', async () => {
+  render(<GeneralDialog open onClose={() => {}} labelKey="" descKey="" />)
+  await waitFor(() => screen.getByDisplayValue('/Users/me/Downloads'))
+  const toggle = screen.getByRole('switch', {
+    name: /show main window at login/i,
+  })
+  expect(toggle).toHaveAttribute('aria-disabled', 'true')
+  expect(toggle).not.toBeChecked()
+  await userEvent.click(screen.getByRole('switch', { name: /open at login/i }))
+  expect(toggle).not.toHaveAttribute('aria-disabled', 'true')
+  await userEvent.click(toggle)
+  await userEvent.click(screen.getByRole('button', { name: /save/i }))
+  expect(transport.invoke).toHaveBeenCalledWith(Commands.UpdateSettings, {
+    app: { launchAtStartup: true, showMainWindowAtLogin: true },
   })
 })

--- a/src/renderer/routes/settings/cards/general-dialog.test.tsx
+++ b/src/renderer/routes/settings/cards/general-dialog.test.tsx
@@ -105,7 +105,7 @@ describe('<GeneralDialog>', () => {
       screen.queryByRole('switch', { name: /open at login/i })
     ).not.toBeInTheDocument()
     expect(
-      screen.queryByRole('switch', { name: /show main window at login/i })
+      screen.queryByRole('switch', { name: /show window at login/i })
     ).not.toBeInTheDocument()
     expect(
       screen.queryByRole('switch', { name: /confirm before quitting/i })
@@ -170,7 +170,7 @@ it('enables the login window preference with auto-launch and saves both dirty fi
   render(<GeneralDialog open onClose={() => {}} labelKey="" descKey="" />)
   await waitFor(() => screen.getByDisplayValue('/Users/me/Downloads'))
   const toggle = screen.getByRole('switch', {
-    name: /show main window at login/i,
+    name: /show window at login/i,
   })
   expect(toggle).toHaveAttribute('aria-disabled', 'true')
   expect(toggle).not.toBeChecked()

--- a/src/renderer/routes/settings/cards/general-dialog.tsx
+++ b/src/renderer/routes/settings/cards/general-dialog.tsx
@@ -151,7 +151,13 @@ export function GeneralDialog({
                           {t('settings.general.showMainWindowAtLogin')}
                         </FormLabel>
                         <FormDescription className="text-xs">
-                          {t('settings.general.showMainWindowAtLoginDesc')}
+                          {t('settings.general.showMainWindowAtLoginDesc', {
+                            mode: t(
+                              transport.platform === 'darwin'
+                                ? 'settings.appearance.runModeTray'
+                                : 'settings.appearance.runModeTrayDesktop'
+                            ),
+                          })}
                         </FormDescription>
                       </div>
                       <FormControl>

--- a/src/renderer/routes/settings/cards/general-dialog.tsx
+++ b/src/renderer/routes/settings/cards/general-dialog.tsx
@@ -31,6 +31,7 @@ import type { SettingsCardDialogProps } from './card-types'
 type GeneralFields = Pick<
   MotrixAppSettings,
   | 'launchAtStartup'
+  | 'showMainWindowAtLogin'
   | 'defaultSaveDir'
   | 'notifyOnComplete'
   | 'notifyOnError'
@@ -43,6 +44,7 @@ type GeneralFields = Pick<
 // fields it edits. Keep this Pick<> in sync if the schema fields change.
 const DEFAULTS: GeneralFields = {
   launchAtStartup: DEFAULT_APP_SETTINGS.launchAtStartup,
+  showMainWindowAtLogin: DEFAULT_APP_SETTINGS.showMainWindowAtLogin,
   defaultSaveDir: DEFAULT_APP_SETTINGS.defaultSaveDir,
   notifyOnComplete: DEFAULT_APP_SETTINGS.notifyOnComplete,
   notifyOnError: DEFAULT_APP_SETTINGS.notifyOnError,
@@ -71,6 +73,7 @@ export function GeneralDialog({
         if (all?.app) {
           form.reset({
             launchAtStartup: all.app.launchAtStartup,
+            showMainWindowAtLogin: all.app.showMainWindowAtLogin,
             defaultSaveDir: all.app.defaultSaveDir,
             notifyOnComplete: all.app.notifyOnComplete,
             notifyOnError: all.app.notifyOnError,
@@ -128,6 +131,32 @@ export function GeneralDialog({
                       </div>
                       <FormControl>
                         <Switch
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                        />
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
+              )}
+
+              {!isWeb && (
+                <FormField
+                  control={form.control}
+                  name="showMainWindowAtLogin"
+                  render={({ field }) => (
+                    <FormItem className="flex items-start justify-between gap-4">
+                      <div className="space-y-1">
+                        <FormLabel>
+                          {t('settings.general.showMainWindowAtLogin')}
+                        </FormLabel>
+                        <FormDescription className="text-xs">
+                          {t('settings.general.showMainWindowAtLoginDesc')}
+                        </FormDescription>
+                      </div>
+                      <FormControl>
+                        <Switch
+                          disabled={!form.watch('launchAtStartup')}
                           checked={field.value}
                           onCheckedChange={field.onChange}
                         />

--- a/src/shared/locales/en-US.json
+++ b/src/shared/locales/en-US.json
@@ -968,6 +968,8 @@
     "general": {
       "launchAtStartup": "Open at login",
       "launchAtStartupDesc": "Start Motrix automatically when you log in.",
+      "showMainWindowAtLogin": "Show main window at login",
+      "showMainWindowAtLoginDesc": "Show the main window when Motrix starts automatically at login. Tray-only mode keeps it hidden.",
       "defaultSaveDir": "Default download folder",
       "defaultSaveDirDesc": "New downloads land here unless overridden per-task.",
       "notifyOnComplete": "Notify when download completes",

--- a/src/shared/locales/en-US.json
+++ b/src/shared/locales/en-US.json
@@ -968,8 +968,8 @@
     "general": {
       "launchAtStartup": "Open at login",
       "launchAtStartupDesc": "Start Motrix automatically when you log in.",
-      "showMainWindowAtLogin": "Show main window at login",
-      "showMainWindowAtLoginDesc": "Show the main window when Motrix starts automatically at login. Tray-only mode keeps it hidden.",
+      "showMainWindowAtLogin": "Show window at login",
+      "showMainWindowAtLoginDesc": "Hidden with “{{mode}}”.",
       "defaultSaveDir": "Default download folder",
       "defaultSaveDirDesc": "New downloads land here unless overridden per-task.",
       "notifyOnComplete": "Notify when download completes",

--- a/src/shared/locales/zh-CN.json
+++ b/src/shared/locales/zh-CN.json
@@ -955,6 +955,8 @@
     "general": {
       "launchAtStartup": "登录时自动启动",
       "launchAtStartupDesc": "登录时自动启动 Motrix。",
+      "showMainWindowAtLogin": "登录自启动时显示主窗口",
+      "showMainWindowAtLoginDesc": "登录后自动启动 Motrix 时显示主窗口；“仅托盘”模式下仍保持隐藏。",
       "defaultSaveDir": "默认下载目录",
       "defaultSaveDirDesc": "新建下载默认保存到此目录，可按任务覆盖。",
       "notifyOnComplete": "下载完成通知",

--- a/src/shared/locales/zh-CN.json
+++ b/src/shared/locales/zh-CN.json
@@ -955,8 +955,8 @@
     "general": {
       "launchAtStartup": "登录时自动启动",
       "launchAtStartupDesc": "登录时自动启动 Motrix。",
-      "showMainWindowAtLogin": "登录自启动时显示主窗口",
-      "showMainWindowAtLoginDesc": "登录后自动启动 Motrix 时显示主窗口；“仅托盘”模式下仍保持隐藏。",
+      "showMainWindowAtLogin": "登录时显示窗口",
+      "showMainWindowAtLoginDesc": "选择“{{mode}}”时不显示。",
       "defaultSaveDir": "默认下载目录",
       "defaultSaveDirDesc": "新建下载默认保存到此目录，可按任务覆盖。",
       "notifyOnComplete": "下载完成通知",

--- a/src/shared/locales/zh-TW.json
+++ b/src/shared/locales/zh-TW.json
@@ -955,6 +955,8 @@
     "general": {
       "launchAtStartup": "登入時開啟",
       "launchAtStartupDesc": "登入時自動啟動 Motrix。",
+      "showMainWindowAtLogin": "登入自啟動時顯示主視窗",
+      "showMainWindowAtLoginDesc": "登入後自動啟動 Motrix 時顯示主視窗；「僅系統匣」模式下仍保持隱藏。",
       "defaultSaveDir": "預設下載資料夾",
       "defaultSaveDirDesc": "除非個別任務另有指定，新的下載會儲存在這裡。",
       "notifyOnComplete": "下載完成時通知",

--- a/src/shared/locales/zh-TW.json
+++ b/src/shared/locales/zh-TW.json
@@ -955,8 +955,8 @@
     "general": {
       "launchAtStartup": "登入時開啟",
       "launchAtStartupDesc": "登入時自動啟動 Motrix。",
-      "showMainWindowAtLogin": "登入自啟動時顯示主視窗",
-      "showMainWindowAtLoginDesc": "登入後自動啟動 Motrix 時顯示主視窗；「僅系統匣」模式下仍保持隱藏。",
+      "showMainWindowAtLogin": "登入時顯示視窗",
+      "showMainWindowAtLoginDesc": "選擇「{{mode}}」時不顯示。",
       "defaultSaveDir": "預設下載資料夾",
       "defaultSaveDirDesc": "除非個別任務另有指定，新的下載會儲存在這裡。",
       "notifyOnComplete": "下載完成時通知",

--- a/src/shared/schemas/app-settings.test.ts
+++ b/src/shared/schemas/app-settings.test.ts
@@ -70,3 +70,16 @@ describe('appSettingsSchema', () => {
     ).toBe(true)
   })
 })
+
+it('keeps login launches hidden for existing and invalid settings', () => {
+  for (const value of [undefined, null, 'true', false]) {
+    expect(
+      appSettingsSchema.parse({ showMainWindowAtLogin: value })
+        .showMainWindowAtLogin
+    ).toBe(false)
+  }
+  expect(
+    appSettingsSchema.parse({ showMainWindowAtLogin: true })
+      .showMainWindowAtLogin
+  ).toBe(true)
+})

--- a/src/shared/schemas/app-settings.ts
+++ b/src/shared/schemas/app-settings.ts
@@ -16,6 +16,7 @@ export const magnetFileSelectionTimeoutSecondsSchema = z
 
 export const appSettingsSchema = z.object({
   launchAtStartup: z.boolean().catch(false),
+  showMainWindowAtLogin: z.boolean().catch(false),
   theme: z.enum(['system', 'light', 'dark']).catch('system'),
   reduceMotion: z.boolean().catch(false),
   language: supportedLocaleSchema.catch(DEFAULT_LOCALE),

--- a/src/shared/types/settings.ts
+++ b/src/shared/types/settings.ts
@@ -214,6 +214,7 @@ export interface EngineSettings {
 
 export interface MotrixAppSettings {
   launchAtStartup: boolean
+  showMainWindowAtLogin: boolean
   theme: 'system' | 'light' | 'dark'
   reduceMotion: boolean
   language: SupportedLocale


### PR DESCRIPTION
## Summary / 概述

Add “Show window at login” directly below “Open at login” so users can explicitly choose whether automatic login launches display the main window. The preference defaults to off and is disabled until auto-launch is enabled.

## Related issue / 相关 Issue

Related to #2102. Windows login launch detection still needs real-device verification; this PR exposes the existing background-launch policy as a preference.

## Changes / 改动

- Persist `app.showMainWindowAtLogin` with a safe false default for existing or invalid settings.
- Apply the preference to startup window creation, including lightweight mode; preserve interactive launch behavior and tray-only precedence.
- Add concise English, Simplified Chinese, and Traditional Chinese labels; reuse the existing platform-specific Menu Bar Only / Start in System Tray option names in the description. Include schema, startup-policy, and settings-form regression coverage.

## Validation / 验证

- [x] `pnpm run check:boundaries`
- [x] `pnpm run lint`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm run check:i18n`
- [x] Relevant automated tests / 相关自动化测试
- [ ] Windows login startup manual verification

Validation details / 验证详情：

- `pnpm exec vitest run src/main/window/window-startup-plan.test.ts src/main/platform/auto-launch.test.ts src/main/launcher.test.ts src/shared/schemas/app-settings.test.ts src/renderer/routes/settings/cards/general-dialog.test.tsx` — 48 passed.
- `MOTRIX_E2E_FORCE_BUILD=1 pnpm test:e2e e2e/settings-persistence.spec.ts` — production desktop build succeeded; 3 existing settings-persistence tests passed on macOS. These tests do not simulate Windows login.

## Screenshots or recordings / 截图或录屏

Not attached. The added switch appears immediately below “Open at login” in General settings.

## Checklist / 检查清单

- [x] This pull request targets `main` and contains one focused change.
- [x] User-visible text is localized.
- [x] No credentials, private URLs, personal paths, or other sensitive information are included.
