### PR TITLE
fix(tray): correct linux theme icons and refresh on changes

### DIFF
--- a/src/main/platform/tray-icon.test.ts
+++ b/src/main/platform/tray-icon.test.ts
@@ -1,8 +1,14 @@
-import { describe, expect, it, vi } from 'vitest'
+import path from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { nativeImageMock, nativeThemeMock } = vi.hoisted(() => ({
+  nativeImageMock: { createFromPath: vi.fn(), createFromBuffer: vi.fn() },
+  nativeThemeMock: { shouldUseDarkColors: false },
+}))
 
 vi.mock('electron', () => ({
-  nativeImage: { createFromPath: vi.fn(), createFromBuffer: vi.fn() },
-  nativeTheme: { shouldUseDarkColors: false },
+  nativeImage: nativeImageMock,
+  nativeTheme: nativeThemeMock,
 }))
 
 vi.mock('@resvg/resvg-wasm', () => ({
@@ -10,7 +16,57 @@ vi.mock('@resvg/resvg-wasm', () => ({
   Resvg: vi.fn(),
 }))
 
-import { formatSpeed } from './tray-icon'
+import { createLinuxIconProvider, formatSpeed } from './tray-icon'
+
+describe('createLinuxIconProvider', () => {
+  const assetDir = path.join(process.cwd(), 'extra', 'tray')
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    nativeThemeMock.shouldUseDarkColors = false
+    nativeImageMock.createFromPath.mockImplementation((filePath: string) => ({
+      filePath,
+    }))
+  })
+
+  it.each([
+    { dark: true, theme: 'dark', color: 'white' },
+    { dark: false, theme: 'light', color: 'dark blue' },
+  ])('uses $color icons for the $theme theme', async ({ dark, theme }) => {
+    nativeThemeMock.shouldUseDarkColors = dark
+    const provider = createLinuxIconProvider(assetDir)
+
+    await provider.init()
+
+    for (const active of [false, true]) {
+      expect(provider.getIcon(active)).toEqual({
+        filePath: path.join(
+          assetDir,
+          `mo-tray-${theme}-${active ? 'active' : 'normal'}.png`
+        ),
+      })
+    }
+  })
+
+  it('reloads both cached icons using the current theme', async () => {
+    const provider = createLinuxIconProvider(assetDir)
+    await provider.init()
+    const previousNormal = provider.getIcon(false)
+    const previousActive = provider.getIcon(true)
+
+    nativeThemeMock.shouldUseDarkColors = true
+    await provider.init()
+
+    expect(provider.getIcon(false)).not.toBe(previousNormal)
+    expect(provider.getIcon(true)).not.toBe(previousActive)
+    expect(provider.getIcon(false)).toEqual({
+      filePath: path.join(assetDir, 'mo-tray-dark-normal.png'),
+    })
+    expect(provider.getIcon(true)).toEqual({
+      filePath: path.join(assetDir, 'mo-tray-dark-active.png'),
+    })
+  })
+})
 
 describe('formatSpeed', () => {
   it('formats zero as 0 KB/s', () => {

--- a/src/main/platform/tray-icon.ts
+++ b/src/main/platform/tray-icon.ts
@@ -31,8 +31,8 @@ export interface TrayIconProvider {
 
 // ─── macOS: static PNG template icon ────────────────────────
 // Uses a pre-rendered PNG instead of runtime SVG→WASM→PNG rendering.
-// The dark variant (black on transparent) works as a macOS template image —
-// the system tints it automatically for light/dark mode.
+// The dark-background variant's alpha mask works as a macOS template image —
+// the system supplies the tint automatically for light/dark mode.
 // WASM is only loaded later if the speedometer is enabled.
 
 export function createMacOSIconProvider(
@@ -103,7 +103,8 @@ export function createLinuxIconProvider(
   let activeIcon: NativeImage | null = null
 
   function getThemePrefix(): string {
-    return nativeTheme.shouldUseDarkColors ? 'light' : 'dark'
+    // Asset names describe the background: dark uses white artwork and vice versa.
+    return nativeTheme.shouldUseDarkColors ? 'dark' : 'light'
   }
 
   return {

--- a/src/main/platform/tray.test.ts
+++ b/src/main/platform/tray.test.ts
@@ -5,6 +5,7 @@ const {
   appDock,
   icon,
   iconProvider,
+  nativeThemeMock,
   speedometer,
   trayConstructor,
   trayInstance,
@@ -27,6 +28,7 @@ const {
       getIcon: vi.fn(),
       init: vi.fn(),
     },
+    nativeThemeMock: { on: vi.fn(), off: vi.fn() },
     speedometer: {
       destroy: vi.fn(),
       onSpeedChange: vi.fn(),
@@ -39,6 +41,7 @@ const {
 
 vi.mock('electron', () => ({
   app: { dock: appDock },
+  nativeTheme: nativeThemeMock,
   Tray: class {
     destroy = trayInstance.destroy
     on = trayInstance.on
@@ -114,9 +117,17 @@ function getTrayHandler(eventName: string): () => void {
   return handler as () => void
 }
 
+function getThemeUpdatedHandler(): () => Promise<void> {
+  const handler = nativeThemeMock.on.mock.calls.find(
+    ([event]) => event === 'updated'
+  )?.[1]
+  expect(handler).toBeTypeOf('function')
+  return handler as () => Promise<void>
+}
+
 describe('setupTray', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.resetAllMocks()
     iconProvider.getIcon.mockReturnValue(icon)
     iconProvider.init.mockResolvedValue(undefined)
   })
@@ -149,6 +160,89 @@ describe('setupTray', () => {
       expect(trayConstructor).toHaveBeenCalledWith(icon)
     })
 
+    handle.destroy()
+  })
+
+  it.each([false, true])(
+    'refreshes Linux icons on theme changes and preserves active=%s',
+    async (active) => {
+      Object.defineProperty(process, 'platform', { value: 'linux' })
+      const deps = createDeps()
+      const handle = setupTray(deps)
+      await vi.waitFor(() => expect(trayConstructor).toHaveBeenCalledOnce())
+
+      const activeChanged = vi
+        .mocked(deps.eventBus.on)
+        .mock.calls.find(([event]) => event === Events.EngineActiveChanged)?.[1]
+      expect(activeChanged).toBeTypeOf('function')
+      activeChanged?.(active)
+      trayInstance.setImage.mockClear()
+
+      const updatedIcon = { kind: 'updated-theme-icon' }
+      iconProvider.getIcon.mockReturnValue(updatedIcon)
+      await getThemeUpdatedHandler()()
+
+      expect(iconProvider.init).toHaveBeenCalledTimes(2)
+      expect(iconProvider.getIcon).toHaveBeenLastCalledWith(active)
+      expect(trayInstance.setImage).toHaveBeenCalledExactlyOnceWith(updatedIcon)
+      expect(trayConstructor).toHaveBeenCalledOnce()
+      handle.destroy()
+    }
+  )
+
+  it.each(['darwin', 'win32'])(
+    'does not reload native tray icons for theme changes on %s',
+    async (platform) => {
+      Object.defineProperty(process, 'platform', { value: platform })
+      const handle = setupTray(createDeps())
+      await vi.waitFor(() => expect(trayConstructor).toHaveBeenCalledOnce())
+
+      expect(nativeThemeMock.on).not.toHaveBeenCalled()
+      handle.destroy()
+      expect(nativeThemeMock.off).not.toHaveBeenCalled()
+    }
+  )
+
+  it('unsubscribes from theme updates when the Linux tray is destroyed', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+    const handle = setupTray(createDeps())
+    await vi.waitFor(() => expect(trayConstructor).toHaveBeenCalledOnce())
+    const onUpdated = getThemeUpdatedHandler()
+
+    handle.destroy()
+    expect(nativeThemeMock.off).toHaveBeenCalledExactlyOnceWith(
+      'updated',
+      onUpdated
+    )
+    await onUpdated()
+    expect(iconProvider.init).toHaveBeenCalledOnce()
+    expect(trayInstance.setImage).not.toHaveBeenCalled()
+  })
+
+  it('does not apply a pending theme refresh to a destroyed tray', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+    const handle = setupTray(createDeps())
+    await vi.waitFor(() => expect(trayConstructor).toHaveBeenCalledOnce())
+    const pending = Promise.withResolvers<void>()
+    iconProvider.init.mockReturnValueOnce(pending.promise)
+
+    const refresh = getThemeUpdatedHandler()()
+    handle.destroy()
+    pending.resolve()
+    await refresh
+
+    expect(trayInstance.setImage).not.toHaveBeenCalled()
+  })
+
+  it('keeps the existing icon if a Linux theme refresh fails', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+    const handle = setupTray(createDeps())
+    await vi.waitFor(() => expect(trayConstructor).toHaveBeenCalledOnce())
+    iconProvider.init.mockRejectedValueOnce(new Error('Image loading failed'))
+
+    await expect(getThemeUpdatedHandler()()).resolves.toBeUndefined()
+
+    expect(trayInstance.setImage).not.toHaveBeenCalled()
     handle.destroy()
   })
 

--- a/src/main/platform/tray.ts
+++ b/src/main/platform/tray.ts
@@ -6,7 +6,7 @@ import type { SettingsManager } from '@core/settings/settings-manager'
 import { RunMode } from '@shared/constants'
 import { Events } from '@shared/protocol/events'
 import type { AppSettings } from '@shared/types/settings'
-import { app, type Menu, Tray } from 'electron'
+import { app, type Menu, nativeTheme, Tray } from 'electron'
 import type { MenuManager } from '../menu/menu-manager'
 import { resolveDesktopBackgroundPolicy } from './desktop-background-policy'
 import type { createProtocolManager } from './protocol-manager'
@@ -178,6 +178,21 @@ export function setupTray(deps: TrayDeps): TrayHandle {
 
   // ─── EventBus Listeners ─────────────────────────────────
 
+  async function onNativeThemeUpdated() {
+    const currentTray = tray
+    const currentProvider = iconProvider
+    if (!currentTray || !currentProvider) return
+
+    try {
+      // Reload both states without clearing icons that other events may still use.
+      await currentProvider.init()
+      if (tray !== currentTray || iconProvider !== currentProvider) return
+      currentTray.setImage(currentProvider.getIcon(isActive))
+    } catch (err) {
+      log.error({ err }, 'tray theme refresh failed')
+    }
+  }
+
   function onSettingsChanged(payload: unknown) {
     const { old: oldSettings, updated } = payload as {
       old: AppSettings
@@ -259,6 +274,9 @@ export function setupTray(deps: TrayDeps): TrayHandle {
   eventBus.on(Events.SettingsChanged, onSettingsChanged)
   eventBus.on(Events.EngineActiveChanged, onEngineActiveChanged)
   eventBus.on(Events.StatsUpdated, onStatsUpdated)
+  if (process.platform === 'linux') {
+    nativeTheme.on('updated', onNativeThemeUpdated)
+  }
 
   log.info({ keepTray: policy.keepTray, runMode }, 'tray setup complete')
 
@@ -269,6 +287,9 @@ export function setupTray(deps: TrayDeps): TrayHandle {
       eventBus.off(Events.SettingsChanged, onSettingsChanged)
       eventBus.off(Events.EngineActiveChanged, onEngineActiveChanged)
       eventBus.off(Events.StatsUpdated, onStatsUpdated)
+      if (process.platform === 'linux') {
+        nativeTheme.off('updated', onNativeThemeUpdated)
+      }
       destroyTray()
       log.info('tray destroyed')
     },


### PR DESCRIPTION
## Summary / 概述

Linux dark mode selected the near-black tray artwork intended for light panels, making Motrix nearly invisible on dark panels. Select the white artwork for dark mode and the dark artwork for light mode, and refresh the tray when Electron reports a native theme change.

## Related issue / 相关 Issue

Closes #2108

Refs #2107, the English duplicate that its author closed in favor of #2108. Both reports describe the same inverted Linux tray artwork selection.

## Changes / 改动

- Correct the Linux asset mapping for both normal and active icons; document that asset names describe the background theme.
- Reload both icons on `nativeTheme.updated`, preserve the current download activity state, and remove the listener during teardown.
- Ignore refresh results after the tray is destroyed and catch refresh failures without replacing the displayed icon.
- Add regression coverage for theme selection, cache reloads, activity state, teardown, failures, and platform-specific subscriptions.

## Validation / 验证

- [x] `pnpm run check:boundaries`
- [x] `pnpm run lint`
- [x] `pnpm exec tsc --noEmit`
- [x] Relevant automated tests / 相关自动化测试
- [ ] Manual verification, if applicable / 必要的手动验证

On macOS, `pnpm exec vitest run src/main/platform/tray-icon.test.ts src/main/platform/tray.test.ts src/main/platform/native-theme-sync.test.ts` passed all 29 tests. The new regression tests exposed the reversed mapping and missing theme subscription before the fix. Electron APIs are mocked in these tests.

Pixel inspection of all eight source PNGs confirmed that the normal dark-background artwork is white (`#FFFFFF`) and the normal light-background artwork is near-black (`#00010D`). Native Linux niri/DankMaterialShell verification remains pending. Independently configured panel and application themes remain a limitation of using `nativeTheme.shouldUseDarkColors`.

## Screenshots or recordings / 截图或录屏

A Linux panel screenshot has not been captured; niri/DankMaterialShell is unavailable in the validation environment.

## Checklist / 检查清单

- [x] This pull request targets `main` and contains one focused change.
- [x] User-visible text is localized, and paired English/Chinese documentation stays aligned. No user-visible strings or documentation pairs changed.
- [x] No credentials, private URLs, personal paths, or other sensitive information are included.
- [x] I have read the [contribution guidelines](https://github.com/agalwood/Motrix/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/agalwood/Motrix/blob/main/CODE_OF_CONDUCT.md); the outstanding manual verification is documented above.
