### PR TITLE
fix(bridge): refresh the save directory for new submissions

### DIFF
--- a/src/core/bridge-receiver/bridge-receiver.test.ts
+++ b/src/core/bridge-receiver/bridge-receiver.test.ts
@@ -23,7 +23,7 @@ function fakeDeps(
   over: Partial<ConstructorParameters<typeof BridgeReceiver>[0]> = {}
 ) {
   return {
-    defaultSaveDir: '/tmp/save',
+    getDefaultSaveDir: () => '/tmp/save',
     pickName: async (_d: string, n: string) => n,
     createTask: vi.fn(async () => ({ gid: 'gid-1', taskId: 'task-abc' })),
     removeTask: vi.fn(async () => {}),

--- a/src/core/bridge-receiver/bridge-receiver.ts
+++ b/src/core/bridge-receiver/bridge-receiver.ts
@@ -53,7 +53,7 @@ export function serializeCookieHeader(
 }
 
 export interface BridgeReceiverDeps {
-  defaultSaveDir: string
+  getDefaultSaveDir: AdapterDeps['getDefaultSaveDir']
   pickName: AdapterDeps['pickName']
   createTask: ConstructorParameters<typeof DirectPipeline>[0]['createTask']
   removeTask: ConstructorParameters<typeof DirectPipeline>[0]['removeTask']
@@ -188,7 +188,7 @@ export class BridgeReceiver {
 
   constructor(private readonly deps: BridgeReceiverDeps) {
     this.adapter = new SubmitDownloadAdapter({
-      defaultSaveDir: deps.defaultSaveDir,
+      getDefaultSaveDir: deps.getDefaultSaveDir,
       pickName: deps.pickName,
       mintTaskId: newTaskId,
     })

--- a/src/core/bridge-receiver/default-save-dir.integration.test.ts
+++ b/src/core/bridge-receiver/default-save-dir.integration.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment node
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  writeFile,
+} from 'node:fs/promises'
+import { createServer, type Server } from 'node:http'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { AppliedDownloadProxyPolicy } from '@core/proxy/applied-download-proxy-policy'
+import { SettingsManager } from '@core/settings/settings-manager'
+import {
+  type CreateTaskDeps,
+  handleCreateTask,
+} from '@core/task/create-task-handler'
+import { FinalNamePickerImpl } from '@core/task/final-name-picker'
+import { TorrentMetaStoreImpl } from '@core/task/torrent-meta-store'
+import {
+  type Aria2Handle,
+  bundledAria2Exists,
+  canBindLoopbackTcp,
+  connectAdapter,
+  spawnAria2ForTest,
+} from '@test-utils/aria2'
+import {
+  makeBridgeReceiverDeps,
+  makeDirectSubmit,
+  makeExtensionContext,
+} from '@test-utils/bridge-receiver'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { BridgeReceiver } from './bridge-receiver'
+
+describe.skipIf(!bundledAria2Exists() || !canBindLoopbackTcp())(
+  'bridge save directories with the bundled engine',
+  () => {
+    let root: string
+    let server: Server
+    let baseUrl: string
+    let engine: Aria2Handle
+    let wired: Awaited<ReturnType<typeof connectAdapter>>
+
+    beforeAll(async () => {
+      root = await realpath(
+        await mkdtemp(path.join(tmpdir(), 'motrix-save-dir-engine-'))
+      )
+      server = createServer((request, response) => {
+        response.end(`fixture:${request.url}`)
+      })
+      await new Promise<void>((resolve) =>
+        server.listen(0, '127.0.0.1', resolve)
+      )
+      const address = server.address()
+      if (!address || typeof address === 'string')
+        throw new Error('missing HTTP address')
+      baseUrl = `http://127.0.0.1:${address.port}`
+      engine = await spawnAria2ForTest({ baseDir: root })
+      wired = await connectAdapter(engine)
+    }, 30_000)
+
+    afterAll(async () => {
+      wired?.disconnect()
+      await engine?.kill()
+      server?.closeAllConnections()
+      if (server)
+        await new Promise<void>((resolve) => server.close(() => resolve()))
+      if (root) await rm(root, { recursive: true, force: true })
+    })
+
+    it('writes new tasks to the committed directory and preserves existing task paths', async () => {
+      const oldDir = path.join(root, 'old')
+      const newDir = path.join(root, 'new 中文 directory')
+      await Promise.all([mkdir(oldDir), mkdir(newDir)])
+      const settings = new SettingsManager(path.join(root, 'settings.json'))
+      await settings.update({ app: { defaultSaveDir: oldDir } })
+      const picker = new FinalNamePickerImpl({
+        exists: async (candidate) => {
+          try {
+            await access(candidate)
+            return true
+          } catch {
+            return false
+          }
+        },
+      })
+      const deps = makeBridgeReceiverDeps({
+        getDefaultSaveDir: () => settings.getApp().defaultSaveDir,
+        pickName: (dir, name) => picker.pick(dir, name),
+      })
+      const createTaskDeps: CreateTaskDeps = {
+        adapter: wired.adapter,
+        settingsManager: settings,
+        finalNamePicker: picker,
+        torrentMetaStore: new TorrentMetaStoreImpl(root),
+        taskManager: deps.taskManager,
+        activityRecorder: deps.activityRecorder,
+        eventBus: { emit: () => {} },
+        directResourceProxyPolicy: new AppliedDownloadProxyPolicy({
+          noProxy: '',
+        }),
+        publishTaskUpdate: () => {},
+      }
+      const created = new Map<string, string>()
+      deps.createTask = async (request, _unused, options) => {
+        const result = await handleCreateTask(request, createTaskDeps, options)
+        created.set(result.taskId, result.gid)
+        return result
+      }
+      const receiver = new BridgeReceiver(deps)
+      const context = makeExtensionContext()
+      const submit = async (key: string, dir: string, filename: string) => {
+        const params = makeDirectSubmit(key)
+        if (params.selection.kind !== 'direct')
+          throw new Error('expected direct')
+        params.selection.primary.url = `${baseUrl}/${key}`
+        const { taskId } = await receiver.handle(params, context)
+        const gid = created.get(taskId)
+        if (!gid) throw new Error('missing engine id')
+        await vi.waitFor(
+          async () => {
+            const status = await wired.rpc.tellStatus(gid)
+            expect(status.status).toBe('complete')
+            expect(status.dir).toBe(dir)
+          },
+          { timeout: 10_000, interval: 50 }
+        )
+        const task = deps.taskManager.getById(taskId)
+        if (!task) throw new Error('missing task')
+        expect(task.saveDir).toBe(dir)
+        expect(task.finalPath).toBe(path.join(dir, filename))
+        // This fixture runs the engine, not the application poll/finalize loop.
+        expect(task.diskPath).toBe(path.join(dir, `${filename}.motrix`))
+        expect(await readFile(task.diskPath, 'utf8')).toBe(`fixture:/${key}`)
+        return task
+      }
+      const first = await submit('first-download', oldDir, 'file.zip')
+      await settings.update({ app: { defaultSaveDir: newDir } })
+      await wired.rpc.changeGlobalOption({ dir: newDir })
+      await writeFile(path.join(newDir, 'file.zip'), 'existing file')
+      await submit('second-download', newDir, 'file (1).zip')
+      expect(first.saveDir).toBe(oldDir)
+      expect(await readFile(first.diskPath, 'utf8')).toBe(
+        'fixture:/first-download'
+      )
+      expect(await readFile(path.join(newDir, 'file.zip'), 'utf8')).toBe(
+        'existing file'
+      )
+      await expect(
+        access(path.join(oldDir, 'file (1).zip.motrix'))
+      ).rejects.toThrow()
+    }, 25_000)
+  }
+)

--- a/src/core/bridge-receiver/default-save-dir.test.ts
+++ b/src/core/bridge-receiver/default-save-dir.test.ts
@@ -1,0 +1,301 @@
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { SettingsManager } from '@core/settings/settings-manager'
+import { FinalNamePickerImpl } from '@core/task/final-name-picker'
+import { MediaTaskCoordinator } from '@core/task/media-task-coordinator'
+import {
+  makeBridgeReceiverDeps,
+  makeDirectSubmit,
+  makeExtensionContext,
+} from '@test-utils/bridge-receiver'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { BridgeReceiver } from './bridge-receiver'
+
+describe('bridge default save directory', () => {
+  let root: string
+  let settings: SettingsManager
+  let oldDir: string
+  let newDir: string
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'motrix-save-dir-'))
+    oldDir = join(root, 'old')
+    newDir = join(root, 'new')
+    await Promise.all([mkdir(oldDir), mkdir(newDir)])
+    settings = new SettingsManager(join(root, 'settings.json'))
+    await settings.update({ app: { defaultSaveDir: oldDir } })
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await rm(root, { recursive: true, force: true })
+  })
+
+  it('uses a committed directory change without recreating the receiver', async () => {
+    const deps = makeBridgeReceiverDeps({
+      getDefaultSaveDir: () => settings.getApp().defaultSaveDir,
+    })
+    const createTask = vi.spyOn(deps, 'createTask')
+    const pickName = vi.spyOn(deps, 'pickName')
+    const receiver = new BridgeReceiver(deps)
+    const ctx = makeExtensionContext()
+    await receiver.handle(makeDirectSubmit('before-change'), ctx)
+    const update = await settings.update({ app: { defaultSaveDir: newDir } })
+    expect(update.saved).toBe(true)
+    expect(
+      JSON.parse(await readFile(join(root, 'settings.json'), 'utf8')).app
+        .defaultSaveDir
+    ).toBe(newDir)
+    await receiver.handle(makeDirectSubmit('after-change'), ctx)
+    expect(createTask.mock.calls[0]?.[0]).toMatchObject({ saveDir: oldDir })
+    expect(createTask.mock.calls[1]?.[0]).toMatchObject({ saveDir: newDir })
+    expect(pickName).toHaveBeenLastCalledWith(newDir, 'file.zip')
+  })
+
+  for (const suffix of ['', '.motrix']) {
+    it(`deduplicates against files in the newly selected directory (${suffix || 'final'})`, async () => {
+      const picker = new FinalNamePickerImpl({
+        exists: async (path) => {
+          try {
+            await access(path)
+            return true
+          } catch {
+            return false
+          }
+        },
+      })
+      const deps = makeBridgeReceiverDeps({
+        getDefaultSaveDir: () => settings.getApp().defaultSaveDir,
+        pickName: (dir, name) => picker.pick(dir, name),
+      })
+      const createTask = vi.spyOn(deps, 'createTask')
+      const receiver = new BridgeReceiver(deps)
+      await writeFile(join(newDir, `file.zip${suffix}`), 'keep')
+      await settings.update({ app: { defaultSaveDir: newDir } })
+      await receiver.handle(makeDirectSubmit(), makeExtensionContext())
+      expect(createTask.mock.calls[0]?.[0]).toMatchObject({
+        saveDir: newDir,
+        filename: 'file (1).zip',
+      })
+      expect(await readFile(join(newDir, `file.zip${suffix}`), 'utf8')).toBe(
+        'keep'
+      )
+    })
+  }
+
+  it('reads settings only after the startup gate resolves', async () => {
+    const gate = Promise.withResolvers<void>()
+    const getDefaultSaveDir = vi.fn(() => settings.getApp().defaultSaveDir)
+    const deps = makeBridgeReceiverDeps({
+      getDefaultSaveDir,
+      waitForReady: () => gate.promise,
+    })
+    const pickName = vi.spyOn(deps, 'pickName')
+    const createTask = vi.spyOn(deps, 'createTask')
+    const receiver = new BridgeReceiver(deps)
+    const pending = receiver.handle(makeDirectSubmit(), makeExtensionContext())
+    expect(getDefaultSaveDir).not.toHaveBeenCalled()
+    expect(pickName).not.toHaveBeenCalled()
+    expect(createTask).not.toHaveBeenCalled()
+    await settings.update({ app: { defaultSaveDir: newDir } })
+    gate.resolve()
+    await pending
+    expect(createTask.mock.calls[0]?.[0]).toMatchObject({ saveDir: newDir })
+    expect(getDefaultSaveDir).toHaveBeenCalledOnce()
+  })
+
+  it('does not select a directory when the startup gate fails', async () => {
+    const getDefaultSaveDir = vi.fn(() => newDir)
+    const receiver = new BridgeReceiver(
+      makeBridgeReceiverDeps({
+        getDefaultSaveDir,
+        waitForReady: async () => {
+          throw new Error('startup failed')
+        },
+      })
+    )
+    await expect(
+      receiver.handle(makeDirectSubmit(), makeExtensionContext())
+    ).rejects.toThrow('startup failed')
+    expect(getDefaultSaveDir).not.toHaveBeenCalled()
+  })
+
+  it('preserves a pending and cached task across setting changes, but uses the new directory for a new key', async () => {
+    const gate = Promise.withResolvers<string>()
+    const getDefaultSaveDir = vi.fn(() => settings.getApp().defaultSaveDir)
+    const pickName = vi
+      .fn(async (_dir: string, name: string) => name)
+      .mockImplementationOnce(() => gate.promise)
+    const deps = makeBridgeReceiverDeps({ getDefaultSaveDir, pickName })
+    const createTask = vi.spyOn(deps, 'createTask')
+    const receiver = new BridgeReceiver(deps)
+    const ctx = makeExtensionContext()
+    const pending = receiver.handle(makeDirectSubmit('same-logical-task'), ctx)
+    await settings.update({ app: { defaultSaveDir: newDir } })
+    const replay = receiver.handle(makeDirectSubmit('same-logical-task'), ctx)
+    gate.resolve('file.zip')
+    const [first, duplicate] = await Promise.all([pending, replay])
+    expect(duplicate).toEqual(first)
+    expect(
+      await receiver.handle(makeDirectSubmit('same-logical-task'), ctx)
+    ).toEqual(first)
+    expect(createTask).toHaveBeenCalledOnce()
+    expect(getDefaultSaveDir).toHaveBeenCalledOnce()
+    expect(createTask.mock.calls[0]?.[0]).toMatchObject({ saveDir: oldDir })
+    const next = await receiver.handle(
+      makeDirectSubmit('new-logical-task'),
+      ctx
+    )
+    expect(next.taskId).not.toBe(first.taskId)
+    expect(createTask.mock.calls[1]?.[0]).toMatchObject({ saveDir: newDir })
+    expect(getDefaultSaveDir).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses current settings when retrying a failed pre-creation attempt', async () => {
+    const pickName = vi
+      .fn(async (_dir: string, name: string) => name)
+      .mockRejectedValueOnce(new Error('pick failed'))
+    const deps = makeBridgeReceiverDeps({
+      getDefaultSaveDir: () => settings.getApp().defaultSaveDir,
+      pickName,
+    })
+    const createTask = vi.spyOn(deps, 'createTask')
+    const receiver = new BridgeReceiver(deps)
+    const ctx = makeExtensionContext()
+    await expect(
+      receiver.handle(makeDirectSubmit('retry-failed-key'), ctx)
+    ).rejects.toThrow('pick failed')
+    expect(createTask).not.toHaveBeenCalled()
+    await settings.update({ app: { defaultSaveDir: newDir } })
+    await receiver.handle(makeDirectSubmit('retry-failed-key'), ctx)
+    expect(createTask.mock.calls[0]?.[0]).toMatchObject({ saveDir: newDir })
+  })
+
+  it('keeps the committed directory when a settings write fails', async () => {
+    const receiverDeps = makeBridgeReceiverDeps({
+      getDefaultSaveDir: () => settings.getApp().defaultSaveDir,
+    })
+    const createTask = vi.spyOn(receiverDeps, 'createTask')
+    const receiver = new BridgeReceiver(receiverDeps)
+    // A directory at the destination deterministically prevents atomic replacement.
+    await rm(join(root, 'settings.json'))
+    await mkdir(join(root, 'settings.json'))
+    await expect(
+      settings.update({ app: { defaultSaveDir: newDir } })
+    ).rejects.toThrow()
+    expect(settings.getApp().defaultSaveDir).toBe(oldDir)
+    await receiver.handle(makeDirectSubmit(), makeExtensionContext())
+    expect(createTask.mock.calls[0]?.[0]).toMatchObject({ saveDir: oldDir })
+  })
+
+  for (const enabled of [false, true]) {
+    it(`passes the changed directory to magnets with file selection ${enabled}`, async () => {
+      const deps = makeBridgeReceiverDeps({
+        getDefaultSaveDir: () => settings.getApp().defaultSaveDir,
+        isMagnetFileSelectionEnabled: () => enabled,
+      })
+      const createTask = vi.spyOn(deps, 'createTask')
+      const selectFiles = vi.spyOn(deps, 'submitMagnetForFileSelection')
+      const receiver = new BridgeReceiver(deps)
+      await settings.update({ app: { defaultSaveDir: newDir } })
+      const params = makeDirectSubmit()
+      params.selection = {
+        kind: 'magnet',
+        uri: 'magnet:?xt=urn:btih:0123456789012345678901234567890123456789',
+      }
+      await receiver.handle(params, makeExtensionContext())
+      if (enabled) {
+        expect(selectFiles).toHaveBeenCalledWith(
+          params.selection.uri,
+          newDir,
+          expect.any(Object)
+        )
+        expect(createTask).not.toHaveBeenCalled()
+      } else {
+        expect(createTask.mock.calls[0]?.[0]).toMatchObject({ saveDir: newDir })
+        expect(selectFiles).not.toHaveBeenCalled()
+      }
+    })
+  }
+
+  it('retains the chosen directory when an async direct resolver reroutes to mux', async () => {
+    const resolveStarted = Promise.withResolvers<void>()
+    const releaseResolve = Promise.withResolvers<void>()
+    const submit = vi
+      .spyOn(MediaTaskCoordinator.prototype, 'submit')
+      .mockResolvedValue({ taskId: 'mux-task' })
+    const deps = makeBridgeReceiverDeps({
+      getDefaultSaveDir: () => settings.getApp().defaultSaveDir,
+      ffmpegBinaryPath: '/test/ffmpeg',
+      resolveToMux: async () => {
+        resolveStarted.resolve()
+        await releaseResolve.promise
+        return {
+          title: 'Resolved title',
+          videoUrl: 'https://example.com/video',
+          audioUrl: 'https://example.com/audio',
+          container: 'mp4',
+        }
+      },
+    })
+    const pickName = vi.spyOn(deps, 'pickName')
+    const receiver = new BridgeReceiver(deps)
+    const pending = receiver.handle(makeDirectSubmit(), makeExtensionContext())
+    await resolveStarted.promise
+    await settings.update({ app: { defaultSaveDir: newDir } })
+    releaseResolve.resolve()
+    await pending
+    expect(pickName).toHaveBeenLastCalledWith(oldDir, 'Resolved title.mp4')
+    expect(submit.mock.calls[0]?.[0]).toMatchObject({
+      saveDir: oldDir,
+      finalName: 'Resolved title.mp4',
+    })
+  })
+
+  for (const kind of ['hls', 'dash', 'mux'] as const) {
+    it(`passes a stable directory to the ${kind} media job`, async () => {
+      const fetchStarted = Promise.withResolvers<void>()
+      const manifest = Promise.withResolvers<string>()
+      const submit = vi
+        .spyOn(MediaTaskCoordinator.prototype, 'submit')
+        .mockResolvedValue({ taskId: 'media-task' })
+      const deps = makeBridgeReceiverDeps({
+        getDefaultSaveDir: () => settings.getApp().defaultSaveDir,
+        ffmpegBinaryPath: '/test/ffmpeg',
+        fetchManifest: () => {
+          fetchStarted.resolve()
+          return manifest.promise
+        },
+      })
+      const receiver = new BridgeReceiver(deps)
+      await settings.update({ app: { defaultSaveDir: newDir } })
+      const params = makeDirectSubmit()
+      if (params.selection.kind !== 'direct') throw new Error('expected direct')
+      const primary = params.selection.primary
+      params.selection =
+        kind === 'mux'
+          ? { kind, video: primary, audio: primary, container: 'mp4' }
+          : { kind, primary, container: 'mp4' }
+      const pending = receiver.handle(params, makeExtensionContext())
+      if (kind !== 'mux') {
+        await fetchStarted.promise
+        await settings.update({ app: { defaultSaveDir: oldDir } })
+        manifest.resolve(
+          kind === 'hls'
+            ? '#EXTM3U\n#EXTINF:2,\nsegment.ts\n#EXT-X-ENDLIST\n'
+            : '<MPD type="static" mediaPresentationDuration="PT2S"><Period duration="PT2S"><AdaptationSet mimeType="video/mp4"><SegmentTemplate timescale="1" duration="2" initialization="init.mp4" media="segment-$Number$.m4s"/><Representation id="v" bandwidth="1000"/></AdaptationSet></Period></MPD>'
+        )
+      }
+      await pending
+      expect(submit.mock.calls[0]?.[0]).toMatchObject({ kind, saveDir: newDir })
+    })
+  }
+})

--- a/src/core/bridge-receiver/submit-download-adapter.test.ts
+++ b/src/core/bridge-receiver/submit-download-adapter.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, readdir, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { DownloadSubmitParams } from '@motrix/mdxp'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { SubmitDownloadAdapter } from './submit-download-adapter'
 
 describe('SubmitDownloadAdapter.adapt', () => {
@@ -49,7 +49,7 @@ describe('SubmitDownloadAdapter.adapt', () => {
 
   const adapter = (overrides: Partial<{ defaultSaveDir: string }> = {}) =>
     new SubmitDownloadAdapter({
-      defaultSaveDir: overrides.defaultSaveDir ?? '/tmp/save',
+      getDefaultSaveDir: () => overrides.defaultSaveDir ?? '/tmp/save',
       pickName: async (_dir, n) => n,
       mintTaskId: () => 'task-1',
     })
@@ -160,7 +160,7 @@ describe('SubmitDownloadAdapter.adapt', () => {
 
   it('adapts an hls selection (was unsupported-kind)', async () => {
     const a = new SubmitDownloadAdapter({
-      defaultSaveDir: '/tmp/save',
+      getDefaultSaveDir: () => '/tmp/save',
       pickName: async (_d, n) => n,
       mintTaskId: () => 't1',
     })
@@ -195,7 +195,7 @@ describe('SubmitDownloadAdapter.adapt', () => {
 
   it('adapts a dash selection', async () => {
     const a = new SubmitDownloadAdapter({
-      defaultSaveDir: '/tmp/save',
+      getDefaultSaveDir: () => '/tmp/save',
       pickName: async (_d, n) => n,
       mintTaskId: () => 't1',
     })
@@ -230,7 +230,7 @@ describe('SubmitDownloadAdapter.adapt', () => {
 
   it('adapts a mux selection into video/audio urls', async () => {
     const a = new SubmitDownloadAdapter({
-      defaultSaveDir: '/tmp/save',
+      getDefaultSaveDir: () => '/tmp/save',
       pickName: async (_d, n) => n,
       mintTaskId: () => 't1',
     })
@@ -265,7 +265,7 @@ describe('SubmitDownloadAdapter.adapt', () => {
   it('hls: appends the container extension BEFORE the dedup pick', async () => {
     const picked: string[] = []
     const a = new SubmitDownloadAdapter({
-      defaultSaveDir: '/tmp/save',
+      getDefaultSaveDir: () => '/tmp/save',
       pickName: async (_d, n) => {
         picked.push(n)
         return n
@@ -296,7 +296,7 @@ describe('SubmitDownloadAdapter.adapt', () => {
   it('mux: appends the container extension BEFORE the dedup pick (mkv)', async () => {
     const picked: string[] = []
     const a = new SubmitDownloadAdapter({
-      defaultSaveDir: '/tmp/save',
+      getDefaultSaveDir: () => '/tmp/save',
       pickName: async (_d, n) => {
         picked.push(n)
         return n
@@ -328,7 +328,7 @@ describe('SubmitDownloadAdapter.adapt', () => {
   it('mux: trusts an existing known media extension rather than double-appending', async () => {
     const picked: string[] = []
     const a = new SubmitDownloadAdapter({
-      defaultSaveDir: '/tmp/save',
+      getDefaultSaveDir: () => '/tmp/save',
       pickName: async (_d, n) => {
         picked.push(n)
         return n
@@ -402,4 +402,89 @@ describe('SubmitDownloadAdapter.adapt', () => {
       durationSec: 360,
     })
   })
+})
+
+describe('per-submission directory snapshots', () => {
+  const primary = {
+    url: 'https://example.com/media',
+    headers: {},
+    cookies: [],
+    refererPolicy: 'strict-origin-when-cross-origin',
+  }
+  const selections: DownloadSubmitParams['selection'][] = [
+    { kind: 'direct', primary },
+    {
+      kind: 'magnet',
+      uri: 'magnet:?xt=urn:btih:0123456789012345678901234567890123456789',
+    },
+    { kind: 'hls', primary, container: 'mp4' },
+    { kind: 'dash', primary, container: 'mp4' },
+    { kind: 'mux', video: primary, audio: primary, container: 'mp4' },
+  ]
+  const params = (
+    selection: DownloadSubmitParams['selection']
+  ): DownloadSubmitParams => ({
+    source: {
+      pageUrl: 'https://example.com/',
+      pageTitle: 'Fixture',
+      detectedAt: 1,
+    },
+    meta: { suggestedFilename: 'media', qualityLabel: 'source' },
+    selection,
+  })
+  const input = { extensionId: 'test', browser: 'chromium' as const }
+
+  for (const selection of selections) {
+    it(`reads current settings for each ${selection.kind} submission`, async () => {
+      let currentDir = '/old'
+      const getDefaultSaveDir = vi.fn(() => currentDir)
+      const pickName = vi.fn(async (_dir: string, name: string) => name)
+      const adapter = new SubmitDownloadAdapter({
+        getDefaultSaveDir,
+        pickName,
+        mintTaskId: () => 'task',
+      })
+      expect(getDefaultSaveDir).not.toHaveBeenCalled()
+      for (const dir of ['/old', '/new', '/third']) {
+        currentDir = dir
+        const adapted = await adapter.adapt(params(selection), input)
+        expect(adapted.saveDir).toBe(dir)
+        if (selection.kind !== 'magnet') {
+          expect(pickName).toHaveBeenLastCalledWith(
+            dir,
+            selection.kind === 'direct' ? 'media' : 'media.mp4'
+          )
+        }
+      }
+      expect(getDefaultSaveDir).toHaveBeenCalledTimes(3)
+    })
+
+    if (selection.kind === 'magnet') continue
+    it(`keeps the ${selection.kind} directory stable while name selection is pending`, async () => {
+      let currentDir = '/old'
+      const getDefaultSaveDir = vi.fn(() => currentDir)
+      const gate = Promise.withResolvers<string>()
+      const pickName = vi
+        .fn(async (_dir: string, name: string) => name)
+        .mockImplementationOnce(() => gate.promise)
+      const adapter = new SubmitDownloadAdapter({
+        getDefaultSaveDir,
+        pickName,
+        mintTaskId: () => 'task',
+      })
+      const pending = adapter.adapt(params(selection), input)
+      expect(pickName).toHaveBeenCalledOnce()
+      currentDir = '/new'
+      gate.resolve('chosen.mp4')
+      expect(await pending).toMatchObject({
+        saveDir: '/old',
+        finalName: 'chosen.mp4',
+      })
+      expect(getDefaultSaveDir).toHaveBeenCalledOnce()
+      expect(await adapter.adapt(params(selection), input)).toMatchObject({
+        saveDir: '/new',
+      })
+      expect(getDefaultSaveDir).toHaveBeenCalledTimes(2)
+    })
+  }
 })

--- a/src/core/bridge-receiver/submit-download-adapter.ts
+++ b/src/core/bridge-receiver/submit-download-adapter.ts
@@ -7,8 +7,8 @@ import { stripHopByHopHeaders } from './header-replay'
 import { ensureMediaExtension } from './pipelines/media-final-name'
 
 export interface AdapterDeps {
-  /** appSettings.defaultSaveDir; used when client did not specify saveDir. */
-  defaultSaveDir: string
+  /** Read the current receiver-side default directory for each submission. */
+  getDefaultSaveDir: () => string
   /** FinalNamePicker shim — wraps existing picker so tests can stub. */
   pickName: (saveDir: string, desired: string) => Promise<string>
   /** newTaskId injection — defaults to a uuid mint in production wiring. */
@@ -112,11 +112,13 @@ export class SubmitDownloadAdapter {
     }
 
     const { selection, source, meta } = params
+    // Keep name selection and every async pipeline step in the same directory.
+    const saveDir = this.deps.getDefaultSaveDir()
 
     if (selection.kind === 'magnet') {
       return {
         kind: 'magnet',
-        saveDir: this.deps.defaultSaveDir,
+        saveDir,
         uri: selection.uri,
         sourceMeta: this.makeSourceMeta('magnet', input, source, meta),
       }
@@ -128,7 +130,7 @@ export class SubmitDownloadAdapter {
       // name must be the name that lands on disk, or the collision counter
       // is computed against a string that never exists.
       const finalName = await this.deps.pickName(
-        this.deps.defaultSaveDir,
+        saveDir,
         ensureMediaExtension(
           sanitizeFilename(meta.suggestedFilename),
           selection.container
@@ -137,7 +139,7 @@ export class SubmitDownloadAdapter {
       const sanitizedHeaders = stripHopByHopHeaders(selection.primary.headers)
       const base = {
         taskId,
-        saveDir: this.deps.defaultSaveDir,
+        saveDir,
         finalName,
         manifestUrl: selection.primary.url,
         sanitizedHeaders,
@@ -162,7 +164,7 @@ export class SubmitDownloadAdapter {
       const taskId = this.deps.mintTaskId()
       // Same as hls/dash: extension first, then the dedup pick.
       const finalName = await this.deps.pickName(
-        this.deps.defaultSaveDir,
+        saveDir,
         ensureMediaExtension(
           sanitizeFilename(meta.suggestedFilename),
           selection.container
@@ -171,7 +173,7 @@ export class SubmitDownloadAdapter {
       return {
         kind: 'mux',
         taskId,
-        saveDir: this.deps.defaultSaveDir,
+        saveDir,
         finalName,
         videoUrl: selection.video.url,
         audioUrl: selection.audio.url,
@@ -186,7 +188,6 @@ export class SubmitDownloadAdapter {
     const primaryUrl = selection.primary.url
     const sanitized = sanitizeFilename(meta.suggestedFilename)
     const taskId = this.deps.mintTaskId()
-    const saveDir = this.deps.defaultSaveDir
     const finalName = await this.deps.pickName(saveDir, sanitized)
     const sanitizedHeaders = stripHopByHopHeaders(selection.primary.headers)
 

--- a/src/core/bridge-receiver/task-cookies.integration.test.ts
+++ b/src/core/bridge-receiver/task-cookies.integration.test.ts
@@ -89,7 +89,7 @@ describe.skipIf(!bundledAria2Exists() || !canBindLoopbackTcp())(
       })
       let serial = 0
       const adapter = new SubmitDownloadAdapter({
-        defaultSaveDir: root,
+        getDefaultSaveDir: () => root,
         pickName: async (_dir, name) => name,
         mintTaskId: () => `browser-cookie-${++serial}`,
       })

--- a/src/main/bridge/bootstrap-lifecycle.test.ts
+++ b/src/main/bridge/bootstrap-lifecycle.test.ts
@@ -18,8 +18,13 @@ import { PairingService } from '@core/bridge/pairing-service'
 import { WebSocketBridgeServer } from '@core/bridge/web-socket-bridge-server'
 import { BridgeReceiver } from '@core/bridge-receiver/bridge-receiver'
 import { BridgeStreamSource } from '@core/bridge-receiver/bridge-stream-source'
+import * as taskCreation from '@core/task/create-task-handler'
 import type { BridgeStatusInfo } from '@shared/protocol/bridge'
 import { EngineState } from '@shared/types/engine'
+import {
+  makeDirectSubmit,
+  makeExtensionContext,
+} from '@test-utils/bridge-receiver'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NativeMessagingInstaller } from './native-messaging-installer'
 
@@ -93,7 +98,7 @@ function args(): Parameters<typeof bootstrapBridge>[0] {
     submitMagnetForFileSelection: vi.fn(async () => 'magnet'),
     isMagnetFileSelectionEnabled: vi.fn(() => false),
     finalNamePicker: { pick: vi.fn(async (_dir, desired) => desired) },
-    defaultSaveDir: '/downloads',
+    getDefaultSaveDir: () => '/downloads',
     readHandlerDeps: {
       taskManager: { getAll: () => [], getById: () => undefined },
       statsAggregator: {
@@ -184,6 +189,41 @@ describe('desktop bridge bootstrap ownership', () => {
   afterEach(async () => {
     vi.restoreAllMocks()
     await rm(userDataDir, { recursive: true, force: true })
+  })
+
+  it('uses the current directory through the registered submit handler without restarting', async () => {
+    let directory = '/downloads/old'
+    const getDefaultSaveDir = vi.fn(() => directory)
+    const createTask = vi
+      .spyOn(taskCreation, 'handleCreateTask')
+      .mockResolvedValue({ outcome: 'created', gid: 'gid', taskId: 'task' })
+    const registration = vi.spyOn(
+      WebSocketBridgeServer.prototype,
+      'setHandlers'
+    )
+    const runtime = await bootstrapBridge({ ...args(), getDefaultSaveDir })
+    if (!runtime) throw new Error('bridge did not start')
+    try {
+      const submit = registration.mock.calls[0]?.[0].submitDownload
+      if (!submit) throw new Error('submit handler missing')
+      expect(getDefaultSaveDir).not.toHaveBeenCalled()
+      await submit(makeDirectSubmit('before-change'), makeExtensionContext())
+      directory = '/downloads/new'
+      await submit(makeDirectSubmit('after-change'), makeExtensionContext())
+      expect(createTask.mock.calls[0]?.[0]).toMatchObject({
+        saveDir: '/downloads/old',
+      })
+      expect(createTask.mock.calls[1]?.[0]).toMatchObject({
+        saveDir: '/downloads/new',
+      })
+      expect(getDefaultSaveDir).toHaveBeenCalledTimes(2)
+      expect(
+        WebSocketBridgeServer.prototype.startOnFirstFree
+      ).toHaveBeenCalledOnce()
+      expect(WebSocketBridgeServer.prototype.stop).not.toHaveBeenCalled()
+    } finally {
+      await runtime.shutdown()
+    }
   })
 
   it('acquires the data-root lock before the first bridge store load', async () => {

--- a/src/main/bridge/index.ts
+++ b/src/main/bridge/index.ts
@@ -383,7 +383,7 @@ export async function bootstrapBridge(args: {
     typeof BridgeReceiver
   >[0]['isMagnetFileSelectionEnabled']
   finalNamePicker: { pick(saveDir: string, desired: string): Promise<string> }
-  defaultSaveDir: string
+  getDefaultSaveDir: BridgeReceiverDeps['getDefaultSaveDir']
   // Spec 3 — v1 READ methods over the unary POST /mdxp transport.
   readHandlerDeps: ReadHandlerDeps
   // Spec 4 — v1 WRITE methods (pause/resume/remove/add).
@@ -550,7 +550,7 @@ export async function bootstrapBridge(args: {
       args.pluginHost
     )
     const receiver = new BridgeReceiver({
-      defaultSaveDir: args.defaultSaveDir,
+      getDefaultSaveDir: args.getDefaultSaveDir,
       pickName: (saveDir, desired) =>
         args.finalNamePicker.pick(saveDir, desired),
       createTask: (req, _deps, options) =>

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2427,7 +2427,7 @@ async function initializeMainProcess(): Promise<void> {
       isMagnetFileSelectionEnabled: () =>
         settingsManager.getApp().magnetFileSelection,
       finalNamePicker,
-      defaultSaveDir: settingsManager.getApp().defaultSaveDir,
+      getDefaultSaveDir: () => settingsManager.getApp().defaultSaveDir,
       readHandlerDeps: {
         taskManager,
         statsAggregator,

--- a/src/main/ipc/commands.test.ts
+++ b/src/main/ipc/commands.test.ts
@@ -1705,6 +1705,8 @@ describe('Commands.UpdateSettings', () => {
     expect(ctx.supervisor.applyDefaultSaveDir).toHaveBeenCalledExactlyOnceWith(
       '/downloads/new'
     )
+    expect(ctx.bridgeManager.restart).not.toHaveBeenCalled()
+    expect(ctx.bridgeManager.setEnabled).not.toHaveBeenCalled()
   })
 
   it('saves restart-required settings and publishes a reminder without restarting', async () => {

--- a/src/server/bridge/bootstrap.test.ts
+++ b/src/server/bridge/bootstrap.test.ts
@@ -20,13 +20,19 @@ import type { ReadHandlerDeps } from '@core/bridge/handlers/read-handlers'
 import type { WriteHandlerDeps } from '@core/bridge/handlers/write-handlers'
 import { PairingService } from '@core/bridge/pairing-service'
 import { WebSocketBridgeServer } from '@core/bridge/web-socket-bridge-server'
+import { BridgeReceiver } from '@core/bridge-receiver/bridge-receiver'
 import { BridgeStreamSource } from '@core/bridge-receiver/bridge-stream-source'
 import { EventBus } from '@core/events/event-bus'
-import { Notifications } from '@motrix/mdxp'
+import { SettingsManager } from '@core/settings/settings-manager'
+import { Methods, Notifications } from '@motrix/mdxp'
 import { BridgeEvents, BridgeQueries } from '@shared/protocol/bridge'
 import { Events } from '@shared/protocol/events'
 import { EngineState } from '@shared/types/engine'
 import { TaskStatus } from '@shared/types/task'
+import {
+  makeBridgeReceiverDeps,
+  makeDirectSubmit,
+} from '@test-utils/bridge-receiver'
 import { makeDownloadTask } from '@test-utils/task'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
@@ -310,6 +316,80 @@ describe('bootstrapBridgeForServer', () => {
     await processLock.release()
     const reacquired = await acquireBridgeDataDirLock(bridgeDir)
     await reacquired.release()
+  })
+
+  it('applies changed settings through the same authenticated extension connection', async () => {
+    const oldDir = join(userDataDir, 'old')
+    const newDir = join(userDataDir, 'new')
+    const settings = new SettingsManager(join(userDataDir, 'settings.json'))
+    await settings.update({ app: { defaultSaveDir: oldDir } })
+    const eventBus = new EventBus()
+    const deps = makeBridgeReceiverDeps({
+      eventBus,
+      getDefaultSaveDir: () => settings.getApp().defaultSaveDir,
+    })
+    const createTask = vi.spyOn(deps, 'createTask')
+    const createExtensionReceiver = vi.fn(
+      ({ bridgeBus }: { bridgeBus: BridgeEventBus }) =>
+        new BridgeReceiver({ ...deps, bridgeBus })
+    )
+    runtime = await bootstrapBridgeForServer({
+      userDataDir,
+      host: '0.0.0.0',
+      port: 0,
+      motrixVersion: '2.0',
+      eventBus,
+      readHandlerDeps: readDeps(),
+      writeHandlerDeps: writeDeps(),
+      remoteExtensionConfig: parseRemoteExtensionConfig({
+        MOTRIX_REMOTE_EXTENSION_ENABLED: 'true',
+        MOTRIX_REMOTE_EXTENSION_PUBLIC_URL: 'ws://motrix.example/bridge',
+        MOTRIX_PUBLIC_URL: 'https://motrix.example',
+      }),
+      createExtensionReceiver,
+    })
+    const extensionId = 'a'.repeat(32)
+    const handshake = await startPair({
+      port: runtime.port,
+      origin: `chrome-extension://${extensionId}`,
+      browser: 'chromium',
+      claimedExtensionId: extensionId,
+      routePrefix: '/bridge',
+      hostHeader: 'motrix.example',
+    })
+    const pending = (await runtime.bridgeQueryHandlers[
+      BridgeQueries.ListPendingPairRequests
+    ]()) as Array<{ code?: string }>
+    const code = pending[0]?.code
+    if (!code) throw new Error('pairing code missing')
+    const { channel } = await runPake(handshake, code)
+    await exchangeCredential(handshake, channel)
+    const connection = mdxpOverChannel(handshake.wire, channel)
+    try {
+      await connection.sendRequest(
+        Methods.MotrixInitialize,
+        initializeParams(extensionId)
+      )
+      await connection.sendNotification(
+        Notifications.MotrixInitialized,
+        undefined
+      )
+      await connection.sendRequest(
+        Methods.DownloadSubmit,
+        makeDirectSubmit('before-change')
+      )
+      await settings.update({ app: { defaultSaveDir: newDir } })
+      await connection.sendRequest(
+        Methods.DownloadSubmit,
+        makeDirectSubmit('after-change')
+      )
+      expect(createTask.mock.calls[0]?.[0]).toMatchObject({ saveDir: oldDir })
+      expect(createTask.mock.calls[1]?.[0]).toMatchObject({ saveDir: newDir })
+      expect(createExtensionReceiver).toHaveBeenCalledOnce()
+    } finally {
+      connection.dispose()
+      handshake.wire.ws.close()
+    }
   })
 
   it('serves the direct-LAN Extension routes across a persistent restart', async () => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1871,7 +1871,7 @@ async function main() {
         trustedExtensionRegistry,
         createExtensionReceiver: ({ bridgeBus }) =>
           new BridgeReceiver({
-            defaultSaveDir: settingsManager.getApp().defaultSaveDir,
+            getDefaultSaveDir: () => settingsManager.getApp().defaultSaveDir,
             pickName: (saveDir, desired) =>
               finalNamePicker.pick(saveDir, desired),
             createTask: (request, _deps, options) =>

--- a/src/server/ipc/commands.test.ts
+++ b/src/server/ipc/commands.test.ts
@@ -14,7 +14,7 @@ import type { RegistryClient } from '@core/plugin/registry/registry-client'
 import type { PluginStateStore } from '@core/plugin/state/plugin-state-store'
 import { AppliedDownloadProxyPolicy } from '@core/proxy/applied-download-proxy-policy'
 import { MotrixDatabase } from '@core/session/motrix-database'
-import type { SettingsManager } from '@core/settings/settings-manager'
+import { SettingsManager } from '@core/settings/settings-manager'
 import type { FileCleanupService } from '@core/task/file-cleanup-service'
 import type { FinalNamePicker } from '@core/task/final-name-picker'
 import type { TaskManager } from '@core/task/task-manager'
@@ -430,6 +430,8 @@ describe('server Commands.UpdateSettings', () => {
     expect(ctx.supervisor.applyDefaultSaveDir).toHaveBeenCalledExactlyOnceWith(
       '/downloads/new'
     )
+    expect(ctx.bridgeControl.restart).not.toHaveBeenCalled()
+    expect(ctx.bridgeControl.setEnabled).not.toHaveBeenCalled()
   })
 
   it('hot-applies the browser bridge master switch', async () => {
@@ -679,6 +681,29 @@ describe('server Commands.UpdateSettings', () => {
     })
 
     expect(ctx.trackerManager.applySyncScheduleChange).toHaveBeenCalledOnce()
+  })
+
+  it('rejects a disallowed save directory before committing or changing the bridge', async () => {
+    const ctx = makeFakeCtx()
+    const oldSettings = new SettingsManager('/unused-settings.json').get()
+    oldSettings.app.defaultSaveDir = '/downloads/old'
+    vi.mocked(ctx.settingsManager.get).mockReturnValue(oldSettings)
+    vi.mocked(ctx.downloadPathPolicy.prepareSaveDir).mockRejectedValue(
+      new Error('outside allowed roots')
+    )
+    const handlers = buildServerCommandHandlers(
+      ctx as Parameters<typeof buildServerCommandHandlers>[0]
+    )
+    await expect(
+      handlers[Commands.UpdateSettings]?.({
+        app: { defaultSaveDir: '/outside' },
+      })
+    ).rejects.toThrow('outside allowed roots')
+    expect(ctx.settingsManager.update).not.toHaveBeenCalled()
+    expect(ctx.settingsManager.get().app.defaultSaveDir).toBe('/downloads/old')
+    expect(ctx.supervisor.applyDefaultSaveDir).not.toHaveBeenCalled()
+    expect(ctx.bridgeControl.restart).not.toHaveBeenCalled()
+    expect(ctx.bridgeControl.setEnabled).not.toHaveBeenCalled()
   })
 
   it('validates a default save directory before persisting settings', async () => {

--- a/src/test-utils/bridge-receiver.ts
+++ b/src/test-utils/bridge-receiver.ts
@@ -1,0 +1,80 @@
+import { EventEmitter } from 'node:events'
+import { NOOP_TASK_ACTIVITY_RECORDER } from '@core/activity'
+import { BridgeEventBus } from '@core/bridge/bridge-event-bus'
+import type { MdxpSessionContext } from '@core/bridge/mdxp-session-context'
+import type { BridgeReceiverDeps } from '@core/bridge-receiver/bridge-receiver'
+import { TaskManager } from '@core/task/task-manager'
+import type { DownloadSubmitParams } from '@motrix/mdxp'
+import { vi } from 'vitest'
+
+/** Typed receiver dependencies with inert IO; each call owns independent state. */
+export function makeBridgeReceiverDeps(
+  overrides: Partial<BridgeReceiverDeps> = {}
+): BridgeReceiverDeps {
+  let serial = 0
+  return {
+    getDefaultSaveDir: () => '/downloads',
+    pickName: vi.fn(async (_dir, name) => name),
+    createTask: vi.fn(async () => ({
+      gid: `gid-${++serial}`,
+      taskId: `task-${serial}`,
+    })),
+    removeTask: vi.fn(async () => {}),
+    submitMagnetForFileSelection: vi.fn(async () => 'magnet-task'),
+    isMagnetFileSelectionEnabled: () => false,
+    eventBus: new EventEmitter(),
+    bridgeBus: new BridgeEventBus(),
+    localize: (code) => code,
+    ffmpegBinaryPath: null,
+    taskManager: new TaskManager(),
+    activityRecorder: NOOP_TASK_ACTIVITY_RECORDER,
+    publishTaskUpdate: vi.fn(),
+    publishTaskUpdateNow: vi.fn(),
+    segmentAria2: {
+      addUri: vi.fn(async () => 'segment'),
+      forceRemove: vi.fn(async () => {}),
+      removeDownloadResult: vi.fn(async () => {}),
+      tellStatus: vi.fn(async () => null),
+      onComplete: vi.fn(),
+      onError: vi.fn(),
+    },
+    tmpRoot: '/tmp/motrix-test',
+    persistTask: vi.fn(async () => {}),
+    ...overrides,
+  }
+}
+
+export function makeDirectSubmit(
+  idempotencyKey?: string
+): DownloadSubmitParams {
+  return {
+    source: {
+      pageUrl: 'https://example.com/',
+      pageTitle: 'Fixture',
+      detectedAt: 1,
+    },
+    selection: {
+      kind: 'direct',
+      primary: {
+        url: 'https://example.com/file.zip',
+        headers: {},
+        cookies: [],
+        refererPolicy: 'strict-origin-when-cross-origin',
+      },
+    },
+    meta: { suggestedFilename: 'file.zip', qualityLabel: 'source' },
+    ...(idempotencyKey ? { idempotencyKey } : {}),
+  }
+}
+
+export function makeExtensionContext(): MdxpSessionContext {
+  return {
+    identity: { kind: 'extension', browser: 'chromium', extensionId: 'test' },
+    startedAt: 0,
+    isReady: () => true,
+    markReady: () => {},
+    isAuthorized: () => true,
+    markAuthorized: () => {},
+    pendingPair: null,
+  }
+}


### PR DESCRIPTION
## Summary / 概述

Changing Motrix's default save directory while the browser bridge was running left new extension downloads using the directory captured at startup. Read the current setting when adapting each new submission, then retain that directory throughout its asynchronous processing. This applies to both Electron and Server.

## Related issue / 相关 Issue

Closes #2112

## Changes / 改动

- Pass a `getDefaultSaveDir` dependency through both hosts and the bridge receiver. Snapshot it once per submission for direct, magnet, HLS, DASH, and mux downloads.
- Cover directory changes on an existing receiver and authenticated Server connection, asynchronous name selection and media resolution, filename collisions, readiness, idempotent replays, and failed setting updates.
- Verify that directory changes do not restart the bridge, Server path restrictions remain enforced, and the bundled engine writes new tasks to the updated directory while preserving existing task paths.

## Validation / 验证

- [x] `pnpm run check:boundaries`
- [x] `pnpm run lint`
- [x] `pnpm exec tsc --noEmit`
- [x] Relevant automated tests / 相关自动化测试
- [ ] Manual verification, if applicable / 必要的手动验证

Validation details / 验证详情 (macOS):

- Confirmed the regression test fails with the original startup snapshot and passes after the fix.
- `node scripts/ensure-native-abi.mjs node`
- `pnpm exec vitest run src/core/bridge/ src/core/bridge-receiver/ src/main/bridge/ src/server/bridge/ src/main/ipc/commands.test.ts src/server/ipc/commands.test.ts src/server/download-path-policy.test.ts src/core/settings/settings-manager.test.ts`: 94 files passed; 1638 tests passed, 1 skipped. The existing legacy aria2 cookie compatibility test requires `MOTRIX_LEGACY_ARIA2_TEST_BIN`, which was not configured.
- The new bundled-engine integration test ran successfully, including a directory containing Chinese characters and spaces, collision handling, task paths, engine directory, and downloaded bytes. It verifies `.motrix` staging files; it does not run the application's final rename loop.
- `pnpm exec biome check src/core/bridge/ src/core/bridge-receiver/ src/main/bridge/ src/server/bridge/`
- `pnpm run check:file-names`
- `pnpm build` and `pnpm build:server`: passed.
- `pnpm test:e2e e2e/settings-persistence.spec.ts`: 3 passed. This checks settings UI compatibility, not the full extension download flow.
- Windows 11 + Chrome same-session downloads across drives and official-extension downloads against a running Server remain pending manual verification. This PR remains a draft for that acceptance work.

## Checklist / 检查清单

- [x] This pull request targets `main` and contains one focused change.
- [x] User-visible text is localized, and paired English/Chinese documentation stays aligned (no text or documentation changes).
- [x] No credentials, private URLs, personal paths, or other sensitive information are included.
- [x] I have read and followed the [contribution guidelines](https://github.com/agalwood/Motrix/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/agalwood/Motrix/blob/main/CODE_OF_CONDUCT.md).
