### PR TITLE
feat(ui): follow system defaults for size and speed units

### DIFF
--- a/src/core/engine/aria2/aria2-adapter.test.ts
+++ b/src/core/engine/aria2/aria2-adapter.test.ts
@@ -1708,7 +1708,7 @@ describe('Aria2Adapter', () => {
       ).rejects.toThrow('rpc down')
     })
 
-    it('addTorrent maps dlLimit/ulLimit with K suffix and merges extraEngineOptions', async () => {
+    it('addTorrent maps byte-per-second limits without suffixes and merges extraEngineOptions', async () => {
       const rpc = createMockRpc()
       vi.mocked(rpc.addTorrent).mockResolvedValue('gid')
       const adapter = new Aria2Adapter(rpc)
@@ -1723,8 +1723,8 @@ describe('Aria2Adapter', () => {
         expect.any(String),
         [],
         expect.objectContaining({
-          'max-download-limit': '100K',
-          'max-upload-limit': '50K',
+          'max-download-limit': '100',
+          'max-upload-limit': '50',
           'bt-max-peers': '60',
         })
       )

--- a/src/core/engine/aria2/aria2-adapter.ts
+++ b/src/core/engine/aria2/aria2-adapter.ts
@@ -747,10 +747,10 @@ export class Aria2Adapter implements EngineAdapter {
       opts['bt-prioritize-piece'] = 'head=10M,tail=10M'
     }
     if (params.dlLimit !== undefined) {
-      opts['max-download-limit'] = `${params.dlLimit}K`
+      opts['max-download-limit'] = String(params.dlLimit)
     }
     if (params.ulLimit !== undefined) {
-      opts['max-upload-limit'] = `${params.ulLimit}K`
+      opts['max-upload-limit'] = String(params.ulLimit)
     }
     if (params.extraEngineOptions) {
       for (const [k, v] of Object.entries(params.extraEngineOptions)) {

--- a/src/core/engine/engine-adapter.ts
+++ b/src/core/engine/engine-adapter.ts
@@ -70,6 +70,7 @@ export interface AddTorrentParams {
    * torrent. Concrete adapters translate this product policy. */
   prioritizePreviewPieces?: boolean
   // ── create-path additions ──
+  /** Per-task limits in bytes per second; zero means unlimited. */
   dlLimit?: number
   ulLimit?: number
   /** Engine-agnostic passthrough for shell-supplied options. The adapter
@@ -119,6 +120,7 @@ export interface CreateDownloadParams {
   extraEngineOptions?: Record<string, string | string[]>
   priority?: number
   category?: string
+  /** Per-task limits in bytes per second; zero means unlimited. */
   dlLimit?: number
   ulLimit?: number
   pause?: boolean

--- a/src/core/task/create-task-handler.test.ts
+++ b/src/core/task/create-task-handler.test.ts
@@ -996,6 +996,8 @@ describe('handleCreateTask', () => {
       {
         type: 'bt',
         payload: { kind: 'magnet', uri: 'magnet:?xt=urn:btih:x' },
+        dlLimit: 1_000_000,
+        ulLimit: 512_000,
         selectedFiles: [0],
         saveDir: '/d',
         displayName: 'mag-name',
@@ -1009,6 +1011,10 @@ describe('handleCreateTask', () => {
       expect.any(Object)
     )
     const [, options] = deps.addUri.mock.calls[0]
+    expect(options).toMatchObject({
+      'max-download-limit': '1000000',
+      'max-upload-limit': '512000',
+    })
     expect(options).not.toHaveProperty('bt-prioritize-piece')
   })
 })

--- a/src/core/task/create-task-handler.ts
+++ b/src/core/task/create-task-handler.ts
@@ -850,10 +850,10 @@ async function handleCreateTaskUnderAdmission(
         .join(',')
     }
     if (req.dlLimit !== undefined) {
-      magnetEngineOpts['max-download-limit'] = `${req.dlLimit}K`
+      magnetEngineOpts['max-download-limit'] = String(req.dlLimit)
     }
     if (req.ulLimit !== undefined) {
-      magnetEngineOpts['max-upload-limit'] = `${req.ulLimit}K`
+      magnetEngineOpts['max-upload-limit'] = String(req.ulLimit)
     }
     if (req.seedRatio !== undefined) {
       magnetEngineOpts['seed-ratio'] = String(req.seedRatio)
@@ -866,7 +866,7 @@ async function handleCreateTaskUnderAdmission(
       // merged LAST in the old code and could override). createDownload then
       // merges extraEngineOptions after `dir`, so the final aria2 map is
       // { dir: diskPath, ...magnetEngineOpts, ...opts.extraEngineOptions } —
-      // byte-identical to the old toBt + applyPathOverrides + opts merge.
+      // explicit shell overrides keep their existing precedence.
       extraEngineOptions: {
         ...magnetEngineOpts,
         ...(opts.extraEngineOptions ?? {}),

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -330,6 +330,11 @@ const settingsManager = new SettingsManager(settingsPath, {
   ...defaultSaveDirOptions,
   onChange: (old, updated) => {
     eventBus.emit(Events.SettingsChanged, { old, updated })
+    if (old.app.byteUnitSystem !== updated.app.byteUnitSystem) {
+      eventBus.emit(Events.ByteUnitSystemChanged, {
+        byteUnitSystem: updated.app.byteUnitSystem,
+      })
+    }
     if (old.app.reduceMotion !== updated.app.reduceMotion) {
       eventBus.emit(Events.ReducedMotionChanged, {
         reduceMotion: updated.app.reduceMotion,

--- a/src/main/ipc/commands.test.ts
+++ b/src/main/ipc/commands.test.ts
@@ -897,8 +897,8 @@ describe('buildCommandHandlers', () => {
       [],
       expect.objectContaining({
         'select-file': '2',
-        'max-download-limit': '2048K',
-        'max-upload-limit': '1024K',
+        'max-download-limit': '2048',
+        'max-upload-limit': '1024',
         'seed-ratio': '1.5',
       })
     )
@@ -908,8 +908,8 @@ describe('buildCommandHandlers', () => {
       [],
       expect.objectContaining({
         'select-file': '1,2',
-        'max-download-limit': '2048K',
-        'max-upload-limit': '1024K',
+        'max-download-limit': '2048',
+        'max-upload-limit': '1024',
         'seed-ratio': '1.5',
       })
     )

--- a/src/main/platform/tray-icon.test.ts
+++ b/src/main/platform/tray-icon.test.ts
@@ -69,29 +69,14 @@ describe('createLinuxIconProvider', () => {
 })
 
 describe('formatSpeed', () => {
-  it('formats zero as 0 KB/s', () => {
-    expect(formatSpeed(0)).toBe('0 KB/s')
+  it('matches renderer decimal speed units', () => {
+    expect(formatSpeed(0)).toBe('0 B/s')
+    expect(formatSpeed(512)).toBe('512 B/s')
+    expect(formatSpeed(50_000)).toBe('50.0 KB/s')
+    expect(formatSpeed(16_500_000)).toBe('16.5 MB/s')
   })
-
-  it('formats bytes as KB/s (minimum unit, no decimal)', () => {
-    expect(formatSpeed(512)).toBe('1 KB/s')
-    expect(formatSpeed(100)).toBe('0 KB/s')
-  })
-
-  it('formats kilobytes without decimal', () => {
-    expect(formatSpeed(1024)).toBe('1 KB/s')
-    expect(formatSpeed(50 * 1024)).toBe('50 KB/s')
-    expect(formatSpeed(200 * 1024)).toBe('200 KB/s')
-  })
-
-  it('formats megabytes with one decimal', () => {
-    expect(formatSpeed(1048576)).toBe('1.0 MB/s')
-    expect(formatSpeed(1.5 * 1024 ** 2)).toBe('1.5 MB/s')
-    expect(formatSpeed(88 * 1024 ** 2)).toBe('88.0 MB/s')
-  })
-
-  it('formats gigabytes with one decimal', () => {
-    expect(formatSpeed(1073741824)).toBe('1.0 GB/s')
-    expect(formatSpeed(1.2 * 1024 ** 3)).toBe('1.2 GB/s')
+  it('matches the selected binary speed units', () => {
+    expect(formatSpeed(1_048_576, 'binary')).toBe('1.0 MiB/s')
+    expect(formatSpeed(1_073_741_824, 'binary')).toBe('1.0 GiB/s')
   })
 })

--- a/src/main/platform/tray-icon.test.ts
+++ b/src/main/platform/tray-icon.test.ts
@@ -69,14 +69,24 @@ describe('createLinuxIconProvider', () => {
 })
 
 describe('formatSpeed', () => {
-  it('matches renderer decimal speed units', () => {
-    expect(formatSpeed(0)).toBe('0 B/s')
-    expect(formatSpeed(512)).toBe('512 B/s')
-    expect(formatSpeed(50_000)).toBe('50.0 KB/s')
-    expect(formatSpeed(16_500_000)).toBe('16.5 MB/s')
+  it('keeps integer kilobytes as the minimum unit in decimal mode', () => {
+    expect(formatSpeed(0)).toBe('0 KB/s')
+    expect(formatSpeed(512)).toBe('1 KB/s')
+    expect(formatSpeed(50_000)).toBe('50 KB/s')
+    expect(formatSpeed(999_999)).toBe('1000 KB/s')
   })
-  it('matches the selected binary speed units', () => {
+  it('keeps one decimal place for megabytes and above in decimal mode', () => {
+    expect(formatSpeed(16_500_000)).toBe('16.5 MB/s')
+    expect(formatSpeed(125_000_000)).toBe('125.0 MB/s')
+    expect(formatSpeed(1_500_000_000)).toBe('1.5 GB/s')
+  })
+  it('preserves the original binary rounding with IEC labels', () => {
+    expect(formatSpeed(0, 'binary')).toBe('0 KiB/s')
+    expect(formatSpeed(512, 'binary')).toBe('1 KiB/s')
+    expect(formatSpeed(50 * 1024, 'binary')).toBe('50 KiB/s')
+    expect(formatSpeed(1_048_575, 'binary')).toBe('1024 KiB/s')
     expect(formatSpeed(1_048_576, 'binary')).toBe('1.0 MiB/s')
+    expect(formatSpeed(125 * 1_048_576, 'binary')).toBe('125.0 MiB/s')
     expect(formatSpeed(1_073_741_824, 'binary')).toBe('1.0 GiB/s')
   })
 })

--- a/src/main/platform/tray-icon.ts
+++ b/src/main/platform/tray-icon.ts
@@ -1,10 +1,37 @@
 import path from 'node:path'
+import {
+  type ByteUnitSystem,
+  DEFAULT_BYTE_UNIT_SYSTEM,
+} from '@shared/schemas/byte-unit-system'
 import type { NativeImage } from 'electron'
 import { nativeImage, nativeTheme } from 'electron'
 
 // ─── formatSpeed (exported for testing) ─────────────────────
 
-export { formatSpeed } from '@shared/utils/format-bytes'
+const UNITS = {
+  decimal: ['KB/s', 'MB/s', 'GB/s', 'TB/s'],
+  binary: ['KiB/s', 'MiB/s', 'GiB/s', 'TiB/s'],
+} as const
+
+export function formatSpeed(
+  bytes: number,
+  unitSystem: ByteUnitSystem = DEFAULT_BYTE_UNIT_SYSTEM
+): string {
+  const base = unitSystem === 'binary' ? 1024 : 1000
+  const units = UNITS[unitSystem]
+  // The tray keeps its compact presentation: minimum KB/s or KiB/s.
+  let value = bytes / base
+  let unitIndex = 0
+
+  while (value >= base && unitIndex < units.length - 1) {
+    value /= base
+    unitIndex++
+  }
+
+  // KB/s or KiB/s: no decimal; MB/s or MiB/s and above: one decimal.
+  if (unitIndex === 0) return `${Math.round(value)} ${units[unitIndex]}`
+  return `${value.toFixed(1)} ${units[unitIndex]}`
+}
 
 // ─── TrayIconProvider interface ─────────────────────────────
 

--- a/src/main/platform/tray-icon.ts
+++ b/src/main/platform/tray-icon.ts
@@ -4,22 +4,7 @@ import { nativeImage, nativeTheme } from 'electron'
 
 // ─── formatSpeed (exported for testing) ─────────────────────
 
-const UNITS = ['KB/s', 'MB/s', 'GB/s', 'TB/s']
-
-export function formatSpeed(bytes: number): string {
-  // Always show at least KB/s (minimum unit)
-  let value = bytes / 1024
-  let unitIndex = 0
-
-  while (value >= 1024 && unitIndex < UNITS.length - 1) {
-    value /= 1024
-    unitIndex++
-  }
-
-  // KB/s: no decimal; MB/s and above: one decimal
-  if (unitIndex === 0) return `${Math.round(value)} ${UNITS[unitIndex]}`
-  return `${value.toFixed(1)} ${UNITS[unitIndex]}`
-}
+export { formatSpeed } from '@shared/utils/format-bytes'
 
 // ─── TrayIconProvider interface ─────────────────────────────
 

--- a/src/main/platform/tray-speedometer.test.ts
+++ b/src/main/platform/tray-speedometer.test.ts
@@ -17,17 +17,28 @@ describe('buildSpeedometerSvg', () => {
   it('produces valid SVG with speed text', () => {
     const svg = buildSpeedometerSvg(MOCK_ICON_SVG, 1024, 1048576)
     expect(svg).toContain('<svg')
-    expect(svg).toContain('1 KB/s')
+    expect(svg).toContain('1.0 KB/s')
     expect(svg).toContain('1.0 MB/s')
   })
 
   it('shows zero speeds', () => {
     const svg = buildSpeedometerSvg(MOCK_ICON_SVG, 0, 0)
-    expect(svg).toContain('0 KB/s')
+    expect(svg).toContain('0 B/s')
   })
 
   it('embeds icon SVG content', () => {
     const svg = buildSpeedometerSvg(MOCK_ICON_SVG, 0, 0)
     expect(svg).toContain(MOCK_ICON_SVG)
   })
+})
+
+it('uses IEC units in the speedometer when selected', () => {
+  const svg = buildSpeedometerSvg(
+    MOCK_ICON_SVG,
+    1_048_576,
+    1_073_741_824,
+    'binary'
+  )
+  expect(svg).toContain('1.0 MiB/s')
+  expect(svg).toContain('1.0 GiB/s')
 })

--- a/src/main/platform/tray-speedometer.test.ts
+++ b/src/main/platform/tray-speedometer.test.ts
@@ -17,13 +17,13 @@ describe('buildSpeedometerSvg', () => {
   it('produces valid SVG with speed text', () => {
     const svg = buildSpeedometerSvg(MOCK_ICON_SVG, 1024, 1048576)
     expect(svg).toContain('<svg')
-    expect(svg).toContain('1.0 KB/s')
+    expect(svg).toContain('1 KB/s')
     expect(svg).toContain('1.0 MB/s')
   })
 
   it('shows zero speeds', () => {
     const svg = buildSpeedometerSvg(MOCK_ICON_SVG, 0, 0)
-    expect(svg).toContain('0 B/s')
+    expect(svg).toContain('0 KB/s')
   })
 
   it('embeds icon SVG content', () => {

--- a/src/main/platform/tray-speedometer.ts
+++ b/src/main/platform/tray-speedometer.ts
@@ -1,10 +1,14 @@
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
+import {
+  type ByteUnitSystem,
+  DEFAULT_BYTE_UNIT_SYSTEM,
+} from '@shared/schemas/byte-unit-system'
 import type { NativeImage, Tray } from 'electron'
 import { nativeImage } from 'electron'
 import { formatSpeed } from './tray-icon'
 
-// ─── SVG Layout (@2x pixels, scaleFactor 2 → 68×22 pt) ─────
+// ─── SVG Layout (@2x pixels, scaleFactor 2 → 79×22 pt) ─────
 //
 //  ┌─────────────────────────────────┐
 //  │  ┌──────┐          1.2 MB/s    │
@@ -12,9 +16,9 @@ import { formatSpeed } from './tray-icon'
 //  │  │36×36 │     (right-aligned)  │
 //  │  └──────┘                      │
 //  └─────────────────────────────────┘
-//    0    40  46                  134
+//    0    40  46                  158
 
-const SVG_WIDTH = 134
+const SVG_WIDTH = 158
 const SVG_HEIGHT = 44
 const ICON_SIZE = 32
 const ICON_SCALE = ICON_SIZE / 32 // tray.svg is 32×32
@@ -30,10 +34,11 @@ const DOWNLOAD_Y = UPLOAD_Y + LINE_HEIGHT - 2 // baseline of second line
 export function buildSpeedometerSvg(
   iconSvg: string,
   uploadSpeed: number,
-  downloadSpeed: number
+  downloadSpeed: number,
+  unitSystem: ByteUnitSystem = DEFAULT_BYTE_UNIT_SYSTEM
 ): string {
-  const upload = formatSpeed(uploadSpeed)
-  const download = formatSpeed(downloadSpeed)
+  const upload = formatSpeed(uploadSpeed, unitSystem)
+  const download = formatSpeed(downloadSpeed, unitSystem)
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${SVG_WIDTH}" height="${SVG_HEIGHT}">
   <g transform="translate(0,${ICON_Y}) scale(${ICON_SCALE})">${iconSvg}</g>
@@ -47,6 +52,7 @@ export function buildSpeedometerSvg(
 export interface SpeedometerHandle {
   onSpeedChange(uploadSpeed: number, downloadSpeed: number): void
   setEnabled(enabled: boolean): void
+  setUnitSystem(unitSystem: ByteUnitSystem): void
   destroy(): void
 }
 
@@ -69,6 +75,7 @@ export function createSpeedometer(
   iconSvg: string,
   trayAssetDir: string
 ): SpeedometerHandle {
+  let unitSystem = DEFAULT_BYTE_UNIT_SYSTEM
   let enabled = false
   let lastUpload = -1
   let lastDownload = -1
@@ -100,7 +107,7 @@ export function createSpeedometer(
     const tray = trayRef()
     if (!tray) return
 
-    const svg = buildSpeedometerSvg(iconSvg, upload, download)
+    const svg = buildSpeedometerSvg(iconSvg, upload, download, unitSystem)
     const { Resvg } = await ensureResvg()
     // Load fonts once — resvg-wasm can't access filesystem for fonts
     if (!fontBuffers) {
@@ -144,6 +151,14 @@ export function createSpeedometer(
       pendingUpload = uploadSpeed
       pendingDownload = downloadSpeed
       scheduleRender()
+    },
+
+    setUnitSystem(value: ByteUnitSystem) {
+      if (unitSystem === value) return
+      unitSystem = value
+      lastUpload = -1
+      lastDownload = -1
+      if (enabled) scheduleRender()
     },
 
     setEnabled(value: boolean) {

--- a/src/main/platform/tray-speedometer.ts
+++ b/src/main/platform/tray-speedometer.ts
@@ -8,7 +8,7 @@ import type { NativeImage, Tray } from 'electron'
 import { nativeImage } from 'electron'
 import { formatSpeed } from './tray-icon'
 
-// ─── SVG Layout (@2x pixels, scaleFactor 2 → 79×22 pt) ─────
+// ─── SVG Layout (@2x pixels, scaleFactor 2 → 71×22 pt) ─────
 //
 //  ┌─────────────────────────────────┐
 //  │  ┌──────┐          1.2 MB/s    │
@@ -16,9 +16,9 @@ import { formatSpeed } from './tray-icon'
 //  │  │36×36 │     (right-aligned)  │
 //  │  └──────┘                      │
 //  └─────────────────────────────────┘
-//    0    40  46                  158
+//    0    40  46                  142
 
-const SVG_WIDTH = 158
+const SVG_WIDTH = 142 // 4pt wider than the original to fit IEC unit labels
 const SVG_HEIGHT = 44
 const ICON_SIZE = 32
 const ICON_SCALE = ICON_SIZE / 32 // tray.svg is 32×32

--- a/src/main/platform/tray.test.ts
+++ b/src/main/platform/tray.test.ts
@@ -33,6 +33,7 @@ const {
       destroy: vi.fn(),
       onSpeedChange: vi.fn(),
       setEnabled: vi.fn(),
+      setUnitSystem: vi.fn(),
     },
     trayConstructor: vi.fn(),
     trayInstance,

--- a/src/main/platform/tray.ts
+++ b/src/main/platform/tray.ts
@@ -5,6 +5,7 @@ import { getLogger } from '@core/logger'
 import type { SettingsManager } from '@core/settings/settings-manager'
 import { RunMode } from '@shared/constants'
 import { Events } from '@shared/protocol/events'
+import { resolveByteUnitSystem } from '@shared/schemas/byte-unit-system'
 import type { AppSettings } from '@shared/types/settings'
 import { app, type Menu, nativeTheme, Tray } from 'electron'
 import type { MenuManager } from '../menu/menu-manager'
@@ -98,6 +99,12 @@ export function setupTray(deps: TrayDeps): TrayHandle {
     // macOS: speedometer
     if (process.platform === 'darwin') {
       speedometer = createSpeedometer(() => tray, getIconSvg(), trayAssetDir)
+      speedometer.setUnitSystem(
+        resolveByteUnitSystem(
+          settingsManager.getApp().byteUnitSystem,
+          process.platform
+        )
+      )
       speedometer.setEnabled(settingsManager.getApp().traySpeedometer)
     }
 
@@ -228,6 +235,12 @@ export function setupTray(deps: TrayDeps): TrayHandle {
       if (oldSettings.app.runMode !== newMode) {
         syncDockVisibility(newMode)
       }
+    }
+
+    if (oldSettings.app.byteUnitSystem !== updated.app.byteUnitSystem) {
+      speedometer?.setUnitSystem(
+        resolveByteUnitSystem(updated.app.byteUnitSystem, process.platform)
+      )
     }
 
     // Speedometer toggled

--- a/src/renderer/components/add-task/advanced-panel.test.tsx
+++ b/src/renderer/components/add-task/advanced-panel.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from '@testing-library/react'
+import { setByteUnitSystem } from '@renderer/hooks/use-byte-format'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { FormProvider, useForm } from 'react-hook-form'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 import '@renderer/lib/i18n'
 import { AddTaskLayoutProvider } from './add-task-layout-context'
@@ -10,9 +11,11 @@ import { AdvancedPanel } from './advanced-panel'
 function Wrapper({
   tab,
   onAdvancedOpenChange,
+  onSubmit,
 }: {
   tab: 'links' | 'torrent'
   onAdvancedOpenChange?: (expanded: boolean) => void
+  onSubmit?: (values: unknown) => void
 }) {
   const form = useForm({
     defaultValues:
@@ -36,10 +39,20 @@ function Wrapper({
     <AddTaskLayoutProvider onAdvancedOpenChange={onAdvancedOpenChange}>
       <FormProvider {...form}>
         <AdvancedPanel />
+        {onSubmit && (
+          <button type="button" onClick={() => onSubmit(form.getValues())}>
+            Submit
+          </button>
+        )}
       </FormProvider>
     </AddTaskLayoutProvider>
   )
 }
+
+afterEach(() => {
+  cleanup()
+  setByteUnitSystem('decimal')
+})
 
 describe('AdvancedPanel', () => {
   it('renders Links-flavored fields when tab=links', async () => {
@@ -73,3 +86,46 @@ describe('AdvancedPanel', () => {
     expect(onAdvancedOpenChange).toHaveBeenLastCalledWith(false)
   })
 })
+
+it.each(['decimal', 'binary'] as const)(
+  'submits %s torrent limits in bytes per second and preserves them across unit changes',
+  async (unitSystem) => {
+    setByteUnitSystem(unitSystem)
+    const onSubmit = vi.fn()
+    const user = userEvent.setup()
+    render(<Wrapper tab="torrent" onSubmit={onSubmit} />)
+    await user.click(screen.getByRole('button', { name: /advanced/i }))
+    const input = screen.getByLabelText(/dl limit/i)
+    fireEvent.change(input, { target: { value: '1000' } })
+    act(() =>
+      setByteUnitSystem(unitSystem === 'decimal' ? 'binary' : 'decimal')
+    )
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dlLimit: unitSystem === 'decimal' ? 1_000_000 : 1_024_000,
+      })
+    )
+  }
+)
+
+it.each(['decimal', 'binary'] as const)(
+  'allows fractional %s torrent limits without disrupting typing',
+  async (unitSystem) => {
+    setByteUnitSystem(unitSystem)
+    const onSubmit = vi.fn()
+    const user = userEvent.setup()
+    render(<Wrapper tab="torrent" onSubmit={onSubmit} />)
+    await user.click(screen.getByRole('button', { name: /advanced/i }))
+    const input = screen.getByLabelText(/dl limit/i)
+    await user.clear(input)
+    await user.type(input, '1.1')
+    expect(input).toHaveValue(1.1)
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dlLimit: unitSystem === 'binary' ? 1126 : 1100,
+      })
+    )
+  }
+)

--- a/src/renderer/components/add-task/advanced-panel.tsx
+++ b/src/renderer/components/add-task/advanced-panel.tsx
@@ -12,6 +12,7 @@ import {
 } from '@renderer/components/ui/form'
 import { Input } from '@renderer/components/ui/input'
 import { Textarea } from '@renderer/components/ui/textarea'
+import { useByteFormat } from '@renderer/hooks/use-byte-format'
 import { cn } from '@renderer/lib/utils'
 import { EXTERNAL_URLS } from '@shared/external-urls'
 import type { AddTaskFormValues } from '@shared/schemas/add-task'
@@ -122,6 +123,9 @@ function LinksAdvancedFields() {
 }
 
 function TorrentAdvancedFields() {
+  const { unitSystem } = useByteFormat()
+  const scale = unitSystem === 'binary' ? 1024 : 1000
+  const unit = unitSystem === 'binary' ? 'KiB/s' : 'KB/s'
   const { t } = useTranslation()
   const { control } = useFormContext<AddTaskFormValues>()
   return (
@@ -129,18 +133,30 @@ function TorrentAdvancedFields() {
       <DenseField
         control={control}
         name="dlLimit"
-        label={t('task.add.dlLimit')}
+        label={
+          <>
+            {t('task.add.dlLimit')} ({unit})
+          </>
+        }
         type="number"
         min={0}
-        placeholder="KB/s"
+        scale={scale}
+        step="any"
+        placeholder={t('task.add.unlimited')}
       />
       <DenseField
         control={control}
         name="ulLimit"
-        label={t('task.add.ulLimit')}
+        label={
+          <>
+            {t('task.add.ulLimit')} ({unit})
+          </>
+        }
         type="number"
         min={0}
-        placeholder="KB/s"
+        scale={scale}
+        step="any"
+        placeholder={t('task.add.unlimited')}
       />
       <DenseField
         control={control}
@@ -169,6 +185,7 @@ interface DenseFieldProps {
   max?: number
   step?: string
   multiline?: boolean
+  scale?: number
 }
 
 function DenseField({
@@ -181,7 +198,11 @@ function DenseField({
   max,
   step,
   multiline,
+  scale = 1,
 }: DenseFieldProps) {
+  const [draft, setDraft] = useState<{ text: string; scale: number } | null>(
+    null
+  )
   return (
     <FormField
       control={control}
@@ -220,18 +241,32 @@ function DenseField({
                 step={step}
                 placeholder={placeholder}
                 value={
-                  typeof field.value === 'number' ||
-                  typeof field.value === 'string'
-                    ? field.value
-                    : ''
+                  draft?.scale === scale
+                    ? draft.text
+                    : typeof field.value === 'number'
+                      ? field.value / scale
+                      : typeof field.value === 'string'
+                        ? field.value
+                        : ''
                 }
                 onChange={(e) => {
                   if (type === 'number') {
                     const v = e.target.value
-                    field.onChange(v === '' ? undefined : Number(v))
+                    if (scale !== 1) setDraft({ text: v, scale })
+                    field.onChange(
+                      v === ''
+                        ? undefined
+                        : scale === 1
+                          ? Number(v)
+                          : Math.round(Number(v) * scale)
+                    )
                   } else {
                     field.onChange(e.target.value)
                   }
+                }}
+                onBlur={() => {
+                  setDraft(null)
+                  field.onBlur()
                 }}
                 className="h-8 text-xs"
               />

--- a/src/renderer/components/add-task/torrent-info-header.tsx
+++ b/src/renderer/components/add-task/torrent-info-header.tsx
@@ -1,27 +1,17 @@
 import { Button } from '@renderer/components/ui/button'
+import { useByteFormat } from '@renderer/hooks/use-byte-format'
 import type { AddTaskFormValues } from '@shared/schemas/add-task'
 import { X } from 'lucide-react'
 import { useWatch } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-
-function formatBytes(n: number): string {
-  if (n < 1024) return `${n} B`
-  const k = 1024
-  const units = ['KB', 'MB', 'GB', 'TB']
-  let i = -1
-  let v = n
-  do {
-    v /= k
-    i++
-  } while (v >= k && i < units.length - 1)
-  return `${v.toFixed(1)} ${units[i]}`
-}
 
 interface TorrentInfoHeaderProps {
   onClear: () => void
 }
 
 export function TorrentInfoHeader({ onClear }: TorrentInfoHeaderProps) {
+  const { formatBytes } = useByteFormat()
+
   const { t } = useTranslation()
   const meta = useWatch<AddTaskFormValues, 'torrentMeta'>({
     name: 'torrentMeta',

--- a/src/renderer/components/add-task/torrent-summary-controls.test.tsx
+++ b/src/renderer/components/add-task/torrent-summary-controls.test.tsx
@@ -52,7 +52,7 @@ describe('torrent summary controls', () => {
     render(<TorrentControls onClear={onClear} />)
 
     expect(screen.getByTitle('Example bundle')).toBeInTheDocument()
-    expect(screen.getByText('1.5 KB')).toBeInTheDocument()
+    expect(screen.getByText('1.54 KB')).toBeInTheDocument()
     await user.click(screen.getByRole('button', { name: 'Clear selection' }))
     expect(onClear).toHaveBeenCalledOnce()
   })

--- a/src/renderer/components/byte-unit-sync.test.tsx
+++ b/src/renderer/components/byte-unit-sync.test.tsx
@@ -1,0 +1,149 @@
+import {
+  setByteUnitSystem,
+  useByteFormat,
+} from '@renderer/hooks/use-byte-format'
+import { transport } from '@renderer/lib/transport'
+import type {
+  EventListener,
+  TransportConnectionListener,
+} from '@renderer/lib/transport/types'
+import { Events } from '@shared/protocol/events'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { ByteUnitSync } from './byte-unit-sync'
+
+vi.mock('@renderer/lib/transport', () => ({
+  transport: {
+    invoke: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+    onConnectionChange: vi.fn(),
+    platform: 'darwin',
+  },
+}))
+
+let onChange: EventListener
+let onConnectionChange: TransportConnectionListener
+const stopConnectionSync = vi.fn()
+
+function Values() {
+  const { formatBytes, formatSpeed } = useByteFormat()
+  return (
+    <output>
+      {formatBytes(1_048_576)} · {formatSpeed(1_048_576)}
+    </output>
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  setByteUnitSystem('decimal')
+  vi.stubGlobal('navigator', { platform: 'MacIntel' })
+  Object.defineProperty(transport, 'platform', {
+    value: 'darwin',
+    configurable: true,
+  })
+  vi.mocked(transport.invoke).mockResolvedValue({
+    app: { byteUnitSystem: 'binary' },
+  })
+  vi.mocked(transport.on).mockImplementation((event, listener) => {
+    if (event === Events.ByteUnitSystemChanged) onChange = listener
+  })
+  vi.mocked(transport.onConnectionChange!).mockImplementation((listener) => {
+    onConnectionChange = listener
+    return stopConnectionSync
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  setByteUnitSystem('decimal')
+})
+
+it('hydrates and updates mounted size and speed displays without a reload', async () => {
+  render(
+    <>
+      <ByteUnitSync />
+      <Values />
+    </>
+  )
+  await waitFor(() =>
+    expect(screen.getByRole('status').textContent).toBe('1.00 MiB · 1.0 MiB/s')
+  )
+  act(() => onChange({ byteUnitSystem: 'decimal' }))
+  expect(screen.getByRole('status').textContent).toBe('1.05 MB · 1.0 MB/s')
+  act(() => onChange({ byteUnitSystem: 'invalid' }))
+  expect(screen.getByRole('status').textContent).toBe('1.05 MB · 1.0 MB/s')
+})
+
+it('subscribes first and ignores snapshots older than a live update', async () => {
+  let resolveSnapshot!: (value: unknown) => void
+  vi.mocked(transport.invoke).mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        resolveSnapshot = resolve
+      })
+  )
+  render(
+    <>
+      <ByteUnitSync />
+      <Values />
+    </>
+  )
+  expect(vi.mocked(transport.on).mock.invocationCallOrder[0]).toBeLessThan(
+    vi.mocked(transport.invoke).mock.invocationCallOrder[0]!
+  )
+  act(() => onChange({ byteUnitSystem: 'binary' }))
+  await act(async () => resolveSnapshot({ app: { byteUnitSystem: 'decimal' } }))
+  expect(screen.getByRole('status').textContent).toBe('1.00 MiB · 1.0 MiB/s')
+})
+
+it('refreshes after reconnect and removes subscriptions on unmount', async () => {
+  const { unmount } = render(
+    <>
+      <ByteUnitSync />
+      <Values />
+    </>
+  )
+  await waitFor(() =>
+    expect(screen.getByRole('status').textContent).toBe('1.00 MiB · 1.0 MiB/s')
+  )
+  vi.mocked(transport.invoke).mockResolvedValue({
+    app: { byteUnitSystem: 'decimal' },
+  })
+  act(() => onConnectionChange({ state: 'connected' }))
+  await waitFor(() =>
+    expect(screen.getByRole('status').textContent).toBe('1.05 MB · 1.0 MB/s')
+  )
+  unmount()
+  expect(transport.off).toHaveBeenCalledWith(
+    Events.ByteUnitSystemChanged,
+    onChange
+  )
+  expect(stopConnectionSync).toHaveBeenCalledOnce()
+})
+
+it.each([
+  ['darwin', '1.05 MB · 1.0 MB/s'],
+  ['win32', '1.00 MiB · 1.0 MiB/s'],
+  ['linux', '1.00 MiB · 1.0 MiB/s'],
+  ['web', '1.05 MB · 1.0 MB/s'],
+] as const)('hydrates system defaults on %s', async (platform, expected) => {
+  Object.defineProperty(transport, 'platform', {
+    value: platform,
+    configurable: true,
+  })
+  vi.mocked(transport.invoke).mockResolvedValue({
+    app: { byteUnitSystem: 'system' },
+  })
+  render(
+    <>
+      <ByteUnitSync />
+      <Values />
+    </>
+  )
+  await waitFor(() =>
+    expect(screen.getByRole('status').textContent).toBe(expected)
+  )
+})

--- a/src/renderer/components/byte-unit-sync.tsx
+++ b/src/renderer/components/byte-unit-sync.tsx
@@ -1,0 +1,58 @@
+import { setByteUnitSystem } from '@renderer/hooks/use-byte-format'
+import { transport } from '@renderer/lib/transport'
+import { Events } from '@shared/protocol/events'
+import { Queries } from '@shared/protocol/queries'
+import {
+  byteUnitSystemSchema,
+  DEFAULT_BYTE_UNIT_PREFERENCE,
+} from '@shared/schemas/byte-unit-system'
+import type { AppSettings } from '@shared/types/settings'
+import { useEffect } from 'react'
+
+export function ByteUnitSync() {
+  useEffect(() => {
+    const platform =
+      transport.platform === 'web'
+        ? (globalThis.navigator?.platform ?? '')
+        : (transport.platform ?? '')
+    let active = true
+    let generation = 0
+    const reconcile = () => {
+      const requestGeneration = ++generation
+      void transport
+        .invoke(Queries.GetSettings)
+        .then((data) => {
+          if (!active || requestGeneration !== generation) return
+          const settings = data as AppSettings | undefined
+          const parsed = byteUnitSystemSchema.safeParse(
+            settings?.app?.byteUnitSystem
+          )
+          setByteUnitSystem(
+            parsed.success ? parsed.data : DEFAULT_BYTE_UNIT_PREFERENCE,
+            platform
+          )
+        })
+        .catch(() => {})
+    }
+    const onChange = (payload: unknown) => {
+      const parsed = byteUnitSystemSchema.safeParse(
+        (payload as { byteUnitSystem?: unknown } | null)?.byteUnitSystem
+      )
+      if (!parsed.success) return
+      generation += 1
+      setByteUnitSystem(parsed.data, platform)
+    }
+    transport.on(Events.ByteUnitSystemChanged, onChange)
+    const stopConnectionSync = transport.onConnectionChange?.((event) => {
+      if (event.state === 'connected') reconcile()
+    })
+    reconcile()
+    return () => {
+      active = false
+      generation += 1
+      transport.off(Events.ByteUnitSystemChanged, onChange)
+      stopConnectionSync?.()
+    }
+  }, [])
+  return null
+}

--- a/src/renderer/components/file-list/file-list.test.tsx
+++ b/src/renderer/components/file-list/file-list.test.tsx
@@ -156,9 +156,9 @@ describe('FileList', () => {
 
   it('formats file sizes correctly', () => {
     const files: TorrentFileInfo[] = [
-      { index: 0, path: 'big.mkv', size: 1_073_741_824, extension: '.mkv' }, // 1.0 GB
-      { index: 1, path: 'mid.mp3', size: 5_242_880, extension: '.mp3' }, // 5.0 MB
-      { index: 2, path: 'small.txt', size: 1_024, extension: '.txt' }, // 1.0 KB
+      { index: 0, path: 'big.mkv', size: 1_073_741_824, extension: '.mkv' }, // 1.07 GB
+      { index: 1, path: 'mid.mp3', size: 5_242_880, extension: '.mp3' }, // 5.24 MB
+      { index: 2, path: 'small.txt', size: 1_024, extension: '.txt' }, // 1.02 KB
     ]
     render(
       <FileList<TorrentFileInfo>
@@ -167,9 +167,9 @@ describe('FileList', () => {
         onSelectionChange={vi.fn()}
       />
     )
-    expect(screen.getByText('1.0 GB')).toBeDefined()
-    expect(screen.getByText('5.0 MB')).toBeDefined()
-    expect(screen.getByText('1.0 KB')).toBeDefined()
+    expect(screen.getByText('1.07 GB')).toBeDefined()
+    expect(screen.getByText('5.24 MB')).toBeDefined()
+    expect(screen.getByText('1.02 KB')).toBeDefined()
   })
 
   it('disables checkboxes in readOnly mode', () => {

--- a/src/renderer/components/file-list/file-list.tsx
+++ b/src/renderer/components/file-list/file-list.tsx
@@ -1,22 +1,10 @@
 import { VirtualList } from '@renderer/components/desktop-kit/virtual-list/virtual-list'
 import { Checkbox } from '@renderer/components/ui/checkbox'
+import { useByteFormat } from '@renderer/hooks/use-byte-format'
 import { cn } from '@renderer/lib/utils'
 import type { BaseFileRow } from '@shared/types/file-row'
 import { type ReactNode, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-
-function formatSize(bytes: number): string {
-  if (bytes >= 1_073_741_824) {
-    return `${(bytes / 1_073_741_824).toFixed(1)} GB`
-  }
-  if (bytes >= 1_048_576) {
-    return `${(bytes / 1_048_576).toFixed(1)} MB`
-  }
-  if (bytes >= 1_024) {
-    return `${(bytes / 1_024).toFixed(1)} KB`
-  }
-  return `${bytes} B`
-}
 
 interface FileListProps<T extends BaseFileRow = BaseFileRow> {
   files: T[]
@@ -39,6 +27,8 @@ export function FileList<T extends BaseFileRow = BaseFileRow>({
   headerClassName,
   renderRowTrailing,
 }: FileListProps<T>) {
+  const { formatBytes } = useByteFormat()
+
   const { t } = useTranslation()
 
   const selectedSet = useMemo(() => new Set(selectedIndices), [selectedIndices])
@@ -56,7 +46,7 @@ export function FileList<T extends BaseFileRow = BaseFileRow>({
 
   const summary = `${t('task.torrent.fileSelected', {
     count: selectedIndices.length,
-  })} · ${formatSize(totalSelectedSize)}`
+  })} · ${formatBytes(totalSelectedSize)}`
 
   function toggleSelectAll() {
     if (readOnly || !onSelectionChange) return
@@ -127,7 +117,7 @@ export function FileList<T extends BaseFileRow = BaseFileRow>({
               {file.path}
             </span>
             <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
-              {formatSize(file.size)}
+              {formatBytes(file.size)}
             </span>
             {renderRowTrailing?.(file)}
           </div>

--- a/src/renderer/hooks/use-byte-format.ts
+++ b/src/renderer/hooks/use-byte-format.ts
@@ -1,0 +1,53 @@
+import {
+  type ByteUnitPreference,
+  type ByteUnitSystem,
+  DEFAULT_BYTE_UNIT_PREFERENCE,
+  resolveByteUnitSystem,
+} from '@shared/schemas/byte-unit-system'
+import {
+  type ByteValue,
+  formatBytes,
+  formatSpeed,
+} from '@shared/utils/format-bytes'
+import { useSyncExternalStore } from 'react'
+
+function createFormatters(unitSystem: ByteUnitSystem) {
+  return {
+    unitSystem,
+    formatBytes: (bytes: ByteValue) => formatBytes(bytes, { unitSystem }),
+    formatSpeed: (bytes: ByteValue) => formatSpeed(bytes, unitSystem),
+  }
+}
+
+const formatters = {
+  decimal: createFormatters('decimal'),
+  binary: createFormatters('binary'),
+}
+const listeners = new Set<() => void>()
+const devicePlatform = () => globalThis.navigator?.platform ?? ''
+let current =
+  formatters[
+    resolveByteUnitSystem(DEFAULT_BYTE_UNIT_PREFERENCE, devicePlatform())
+  ]
+const getSnapshot = () => current
+const subscribe = (listener: () => void) => {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+// A cache of the host setting; persistence belongs to UpdateSettings.
+export function setByteUnitSystem(
+  preference: ByteUnitPreference,
+  platform = devicePlatform()
+): void {
+  const value = resolveByteUnitSystem(preference, platform)
+  if (current === formatters[value]) return
+  current = formatters[value]
+  for (const listener of listeners) listener()
+}
+
+export function useByteFormat() {
+  return useSyncExternalStore(subscribe, getSnapshot)
+}

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -1,3 +1,4 @@
+import { ByteUnitSync } from '@renderer/components/byte-unit-sync'
 import { LanguageSync } from '@renderer/components/language-sync'
 import { LocaleDirectionProvider } from '@renderer/components/locale-direction-provider'
 import { OperatorUnlockGate } from '@renderer/components/operator-unlock-gate'
@@ -66,6 +67,7 @@ function Root({
     >
       <LocaleDirectionProvider>
         {syncSettings && <ThemeSync />}
+        {syncSettings && <ByteUnitSync />}
         <ReducedMotionSync syncSettings={syncSettings} />
         <LanguageSync windowId={windowId} />
         {children}

--- a/src/renderer/lib/format.test.ts
+++ b/src/renderer/lib/format.test.ts
@@ -1,27 +1,56 @@
 import { SUPPORTED_LOCALE_CODES } from '@shared/constants/locales'
+import { resolveByteUnitSystem } from '@shared/schemas/byte-unit-system'
 import { describe, expect, it } from 'vitest'
 import {
   formatByteParts,
   formatBytes,
   formatProgressPercent,
+  formatSpeed,
   formatTime24Hour,
 } from './format'
 
 describe('formatBytes', () => {
-  it('preserves the existing number formatting contract', () => {
+  it('uses decimal units and two decimal places for sizes', () => {
     expect(formatBytes(0)).toBe('0 B')
     expect(formatBytes(Number.NaN)).toBe('0 B')
-    expect(formatBytes(16_500_000)).toBe('15.7 MB')
-    expect(formatBytes(4_700_000_000)).toBe('4.4 GB')
+    expect(formatBytes(16_500_000)).toBe('16.50 MB')
+    expect(formatBytes(4_700_000_000)).toBe('4.70 GB')
   })
 
   it('formats decimal strings and bigint values without Number conversion', () => {
-    expect(formatBytes('9007199254740992')).toBe('8.0 PB')
-    expect(formatBytes(9_223_372_036_854_775_807n)).toBe('8.0 EB')
+    expect(formatBytes('9007199254740992')).toBe('9.01 PB')
+    expect(formatBytes(9_223_372_036_854_775_807n)).toBe('9.22 EB')
     expect(formatByteParts('9223372036854775807')).toEqual({
-      number: '8.0',
+      number: '9.22',
       unit: 'EB',
     })
+  })
+
+  it('keeps binary values paired with IEC units', () => {
+    expect(formatBytes(1_048_576, { unitSystem: 'binary' })).toBe('1.00 MiB')
+    expect(formatBytes(1_073_741_824, { unitSystem: 'binary' })).toBe(
+      '1.00 GiB'
+    )
+    expect(formatBytes(1_048_576)).toBe('1.05 MB')
+    expect(
+      formatBytes(9_223_372_036_854_775_807n, { unitSystem: 'binary' })
+    ).toBe('8.00 EiB')
+  })
+
+  it('retains precision above 100 units and promotes rounded boundaries', () => {
+    expect(formatBytes(123_456_789)).toBe('123.46 MB')
+    expect(formatBytes(999_994)).toBe('999.99 KB')
+    expect(formatBytes(999_995)).toBe('1.00 MB')
+    expect(formatBytes(1_048_571, { unitSystem: 'binary' })).toBe('1.00 MiB')
+    expect(formatBytes(999)).toBe('999 B')
+  })
+
+  it('uses one decimal place for speeds in the selected system', () => {
+    expect(formatSpeed(16_500_000)).toBe('16.5 MB/s')
+    expect(formatSpeed(16_500_000, 'binary')).toBe('15.7 MiB/s')
+    expect(formatSpeed(999_950)).toBe('1.0 MB/s')
+    expect(formatSpeed(0)).toBe('0 B/s')
+    expect(formatSpeed(Infinity)).toBe('0 B/s')
   })
 
   it('treats invalid and negative values as zero', () => {
@@ -65,5 +94,20 @@ describe('formatProgressPercent', () => {
       expect(formatProgressPercent(value)).toBe(0)
     }
     expect(formatProgressPercent(0.426)).toBe(43)
+  })
+})
+
+describe('system byte units', () => {
+  it.each([
+    ['darwin', 'decimal'],
+    ['MacIntel', 'decimal'],
+    ['win32', 'binary'],
+    ['Win32', 'binary'],
+    ['linux', 'binary'],
+    ['Linux x86_64', 'binary'],
+  ] as const)('uses %s platform defaults', (platform, expected) => {
+    expect(resolveByteUnitSystem('system', platform)).toBe(expected)
+    expect(resolveByteUnitSystem('decimal', platform)).toBe('decimal')
+    expect(resolveByteUnitSystem('binary', platform)).toBe('binary')
   })
 })

--- a/src/renderer/lib/format.ts
+++ b/src/renderer/lib/format.ts
@@ -1,60 +1,9 @@
-const BYTE_UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB'] as const
-const BYTE_BASE = 1024n
-
-export type ByteValue = number | bigint | string
-
-export interface FormattedByteParts {
-  number: string
-  unit: (typeof BYTE_UNITS)[number]
-}
-
-function toByteCount(value: ByteValue): bigint {
-  if (typeof value === 'bigint') return value > 0n ? value : 0n
-  if (typeof value === 'number') {
-    if (!Number.isFinite(value) || value <= 0) return 0n
-    return BigInt(Math.floor(value))
-  }
-  if (!/^\d+$/.test(value)) return 0n
-  try {
-    return BigInt(value)
-  } catch {
-    return 0n
-  }
-}
-
-export function formatByteParts(bytes: ByteValue): FormattedByteParts {
-  const value = toByteCount(bytes)
-  if (value === 0n) return { number: '0', unit: 'B' }
-
-  let unitIndex = 0
-  let unitSize = 1n
-  while (unitIndex < BYTE_UNITS.length - 1 && value >= unitSize * BYTE_BASE) {
-    unitIndex += 1
-    unitSize *= BYTE_BASE
-  }
-
-  if (unitIndex === 0) {
-    return { number: value.toString(), unit: BYTE_UNITS[unitIndex] }
-  }
-
-  if (value >= unitSize * 100n) {
-    return {
-      number: ((value + unitSize / 2n) / unitSize).toString(),
-      unit: BYTE_UNITS[unitIndex],
-    }
-  }
-
-  const tenths = (value * 10n + unitSize / 2n) / unitSize
-  return {
-    number: `${tenths / 10n}.${tenths % 10n}`,
-    unit: BYTE_UNITS[unitIndex],
-  }
-}
-
-export function formatBytes(bytes: ByteValue): string {
-  const parts = formatByteParts(bytes)
-  return `${parts.number} ${parts.unit}`
-}
+export type { ByteValue, FormattedByteParts } from '@shared/utils/format-bytes'
+export {
+  formatByteParts,
+  formatBytes,
+  formatSpeed,
+} from '@shared/utils/format-bytes'
 
 const dateTimeFormatters = new Map<string, Intl.DateTimeFormat>()
 const time24HourFormatters = new Map<string, Intl.DateTimeFormat>()

--- a/src/renderer/lib/speed-chart.ts
+++ b/src/renderer/lib/speed-chart.ts
@@ -1,5 +1,6 @@
 import type { SpeedPoint } from '@shared/types/stats'
-import { formatBytes } from './format'
+
+export { formatSpeed } from '@shared/utils/format-bytes'
 
 export const SPEED_CHART_MIN_POINTS = 24
 const DEFAULT_STEP_MS = 1_000
@@ -58,9 +59,4 @@ export function chartCeiling(value: number): number {
   const normalized = value / power
   const step = normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10
   return step * power
-}
-
-export function formatSpeed(bytesPerSecond: number): string {
-  if (!Number.isFinite(bytesPerSecond) || bytesPerSecond < 1) return '0 B/s'
-  return `${formatBytes(bytesPerSecond)}/s`
 }

--- a/src/renderer/routes/dashboard/tiles/speed-limit-tile.tsx
+++ b/src/renderer/routes/dashboard/tiles/speed-limit-tile.tsx
@@ -1,3 +1,4 @@
+import { useByteFormat } from '@renderer/hooks/use-byte-format'
 // src/renderer/routes/dashboard/tiles/speed-limit-tile.tsx
 
 import { Button } from '@renderer/components/ui/button'
@@ -8,7 +9,7 @@ import {
   TooltipTrigger,
 } from '@renderer/components/ui/tooltip'
 import type { SpeedLimitStateView } from '@renderer/hooks/use-speed-limit-state'
-import { formatBytes } from '@renderer/lib/format'
+
 import { cn } from '@renderer/lib/utils'
 import { Bolt, InfinityIcon, Rabbit, Squirrel, Turtle } from 'lucide-react'
 import type { ComponentType, ReactElement } from 'react'
@@ -28,10 +29,6 @@ const TURTLES: {
   { id: 'auto', Icon: Squirrel },
 ]
 
-function fmt(v: number): string | ReactElement {
-  return v <= 0 ? <InfinityIcon className="size-4" /> : `${formatBytes(v)}/s`
-}
-
 export interface SpeedLimitTileProps {
   state: SpeedLimitStateView
   viewport: DashboardTileViewport
@@ -45,6 +42,11 @@ export function SpeedLimitTile({
   onSelectTurtle,
   className,
 }: SpeedLimitTileProps) {
+  const { formatSpeed } = useByteFormat()
+
+  function fmt(v: number): string | ReactElement {
+    return v <= 0 ? <InfinityIcon className="size-4" /> : formatSpeed(v)
+  }
   const { t } = useTranslation()
   const compact = viewport.contentLevel === 'compact'
   const detailed =

--- a/src/renderer/routes/dashboard/tiles/speed-tile.tsx
+++ b/src/renderer/routes/dashboard/tiles/speed-tile.tsx
@@ -1,10 +1,7 @@
 // src/renderer/routes/dashboard/tiles/speed-tile.tsx
 import { type ChartConfig, ChartContainer } from '@renderer/components/ui/chart'
-import {
-  chartCeiling,
-  formatSpeed,
-  normalizeSpeedHistory,
-} from '@renderer/lib/speed-chart'
+import { useByteFormat } from '@renderer/hooks/use-byte-format'
+import { chartCeiling, normalizeSpeedHistory } from '@renderer/lib/speed-chart'
 import { cn } from '@renderer/lib/utils'
 import type { SpeedPoint } from '@shared/types/stats'
 import { useTranslation } from 'react-i18next'
@@ -31,6 +28,8 @@ export function SpeedTile({
   viewport,
   className,
 }: SpeedTileProps) {
+  const { formatSpeed } = useByteFormat()
+
   const { t } = useTranslation()
   const dataKey = kind
   const current = history.at(-1)?.[dataKey] ?? 0

--- a/src/renderer/routes/dashboard/tiles/tasks-tile.test.tsx
+++ b/src/renderer/routes/dashboard/tiles/tasks-tile.test.tsx
@@ -359,7 +359,7 @@ describe('TasksTile', () => {
 
     await user.click(screen.getByRole('radio', { name: 'Recent' }))
     expect(screen.getAllByTestId('tasks-row')).toHaveLength(1)
-    expect(screen.getByText('2.0 KB')).toBeInTheDocument()
+    expect(screen.getByText('2.05 KB')).toBeInTheDocument()
     expect(screen.getAllByText(/Completed/)).toHaveLength(2)
     expect(screen.queryByText('Connection refused')).toBeNull()
   })
@@ -471,7 +471,9 @@ describe('TasksTile', () => {
     expect(button).toHaveAccessibleName(
       'A very long accessible task name, Downloading'
     )
-    expect(button).toHaveAccessibleDescription('9.8 KB/s. Downloading · ETA 2m')
+    expect(button).toHaveAccessibleDescription(
+      '10.0 KB/s. Downloading · ETA 2m'
+    )
     expect(button.getAttribute('aria-label')).not.toMatch(/B\/s|9999/)
     expect(button.closest('li')).not.toBeNull()
   })

--- a/src/renderer/routes/dashboard/tiles/tasks-tile.tsx
+++ b/src/renderer/routes/dashboard/tiles/tasks-tile.tsx
@@ -1,10 +1,11 @@
 import { Button } from '@renderer/components/ui/button'
 import { Progress } from '@renderer/components/ui/progress'
 import { Skeleton } from '@renderer/components/ui/skeleton'
+import { useByteFormat } from '@renderer/hooks/use-byte-format'
 import { useMinuteClock } from '@renderer/hooks/use-minute-clock'
 import { useTaskList } from '@renderer/hooks/use-task-list'
 import { resolveFailureReason } from '@renderer/lib/failure-reason'
-import { formatBytes } from '@renderer/lib/format'
+
 import { openAddTaskDialog } from '@renderer/lib/open-add-task-dialog'
 import { formatRelativeTime } from '@renderer/lib/relative-time'
 import { TASK_TYPE_META } from '@renderer/lib/task-type-meta'
@@ -162,6 +163,8 @@ function TaskRow({
   onOpen(task: DownloadTask): void
   onFocusedRowRemoved(): void
 }) {
+  const { formatBytes, formatSpeed } = useByteFormat()
+
   const { t, i18n } = useTranslation()
   const descriptionId = useId()
   const buttonRef = useRef<HTMLButtonElement | null>(null)
@@ -205,7 +208,7 @@ function TaskRow({
     switch (task.status) {
       case TaskStatus.Downloading:
         presentation = {
-          primary: engineOnline ? `${formatBytes(task.downloadSpeed)}/s` : '—',
+          primary: engineOnline ? formatSpeed(task.downloadSpeed) : '—',
           secondary: engineOnline
             ? `${statusLabel} · ${t('panel.dashboard.tasks.secondary.eta', {
                 time: formatEta(task.etaSeconds, i18n.language),
@@ -243,7 +246,7 @@ function TaskRow({
         break
       case TaskStatus.Seeding:
         presentation = {
-          primary: engineOnline ? `${formatBytes(task.uploadSpeed)}/s` : '—',
+          primary: engineOnline ? formatSpeed(task.uploadSpeed) : '—',
           secondary: engineOnline
             ? task.bt
               ? `${statusLabel} · ${t('panel.dashboard.tasks.secondary.ratio', {

--- a/src/renderer/routes/dashboard/tiles/transfer-tile.test.tsx
+++ b/src/renderer/routes/dashboard/tiles/transfer-tile.test.tsx
@@ -70,7 +70,7 @@ describe('TransferTile', () => {
       'aria-checked',
       'true'
     )
-    expect(screen.getByTestId('transfer-total')).toHaveTextContent('960 MB')
+    expect(screen.getByTestId('transfer-total')).toHaveTextContent('1.01 GB')
     expect(screen.getByTestId('transfer-total').firstElementChild).toHaveClass(
       'h-8',
       'text-[32px]',
@@ -96,7 +96,7 @@ describe('TransferTile', () => {
       'aria-checked',
       'true'
     )
-    expect(screen.getByTestId('transfer-total')).toHaveTextContent('3.0 GB')
+    expect(screen.getByTestId('transfer-total')).toHaveTextContent('3.22 GB')
   })
 
   it('uses shared roving radio keyboard behavior outside width 1', async () => {
@@ -115,7 +115,7 @@ describe('TransferTile', () => {
     expect(allTime).toHaveAttribute('aria-checked', 'true')
     expect(allTime).toHaveAttribute('tabindex', '0')
     expect(today).toHaveAttribute('tabindex', '-1')
-    expect(screen.getByTestId('transfer-total')).toHaveTextContent('3.0 GB')
+    expect(screen.getByTestId('transfer-total')).toHaveTextContent('3.22 GB')
   })
 
   it('uses a complete-label body dropdown at width 1 and no color bar', async () => {
@@ -131,7 +131,7 @@ describe('TransferTile', () => {
     expect(screen.queryByTestId('transfer-proportion-bar')).toBeNull()
     expect(
       screen.getByRole('region', {
-        name: 'Today transfer total: 960 MB',
+        name: 'Today transfer total: 1.01 GB',
       })
     ).toBeInTheDocument()
 
@@ -143,7 +143,7 @@ describe('TransferTile', () => {
     expect(
       screen.getByRole('button', { name: 'Transfer range: All Time' })
     ).toHaveTextContent('All Time')
-    expect(screen.getByTestId('transfer-total')).toHaveTextContent('3.0 GB')
+    expect(screen.getByTestId('transfer-total')).toHaveTextContent('3.22 GB')
   })
 
   it('renders ordered transfer endpoints with proportional segments', () => {
@@ -195,10 +195,10 @@ describe('TransferTile', () => {
     const [uploadValue, downloadValue] = Array.from(values.children)
 
     expect(labels).toHaveTextContent('UpDown')
-    expect(labels).not.toHaveTextContent(/0 B|53\.3 MB/)
+    expect(labels).not.toHaveTextContent(/0 B|55\.89 MB/)
     expect(values).not.toHaveTextContent(/Up|Down/)
     expect(uploadValue).toHaveTextContent('0 B')
-    expect(downloadValue).toHaveTextContent('53.3 MB')
+    expect(downloadValue).toHaveTextContent('55.89 MB')
     expect(screen.queryByTestId('transfer-upload-segment')).toBeNull()
     expect(screen.getByTestId('transfer-download-segment')).toHaveStyle({
       width: '100%',
@@ -272,7 +272,7 @@ describe('TransferTile', () => {
     expect(
       screen.getByRole('button', { name: 'Transfer range: All Time' })
     ).toBeInTheDocument()
-    expect(screen.getByTestId('transfer-total')).toHaveTextContent('3.0 GB')
+    expect(screen.getByTestId('transfer-total')).toHaveTextContent('3.22 GB')
     expect(screen.getByText(/Since 1\/2\/26/i)).toBeInTheDocument()
   })
 
@@ -370,7 +370,7 @@ describe('TransferTile', () => {
       />
     )
 
-    expect(screen.getByTestId('transfer-total')).toHaveTextContent('960 MB')
+    expect(screen.getByTestId('transfer-total')).toHaveTextContent('1.01 GB')
     expect(screen.getByText(/Updated 10:30 AM/i)).toBeInTheDocument()
 
     rerender(

--- a/src/renderer/routes/dashboard/tiles/transfer-tile.tsx
+++ b/src/renderer/routes/dashboard/tiles/transfer-tile.tsx
@@ -7,8 +7,9 @@ import {
   DropdownMenuTrigger,
 } from '@renderer/components/ui/dropdown-menu'
 import { Skeleton } from '@renderer/components/ui/skeleton'
+import { useByteFormat } from '@renderer/hooks/use-byte-format'
 import type { TransferStatsState } from '@renderer/hooks/use-transfer-stats'
-import { formatBytes } from '@renderer/lib/format'
+
 import { cn } from '@renderer/lib/utils'
 import type { TransferRangeStats } from '@shared/types/stats'
 import { ChevronDown } from 'lucide-react'
@@ -132,6 +133,8 @@ function DirectionMetric({
   align?: 'left' | 'right'
   inline?: boolean
 }) {
+  const { formatBytes } = useByteFormat()
+
   return (
     <div
       className={cn(
@@ -160,6 +163,8 @@ function DirectionBreakdown({
   range: TransferRangeStats
   viewport: DashboardTileViewport
 }) {
+  const { formatBytes } = useByteFormat()
+
   const { t } = useTranslation()
   const tall = viewport.span.w === 1
 
@@ -277,6 +282,8 @@ export function TransferTile({
   viewport,
   className,
 }: TransferTileProps) {
+  const { formatBytes } = useByteFormat()
+
   const { t, i18n } = useTranslation()
   const [scope, setScope] = useState<TransferScope>('today')
   const widthOne = viewport.span.w === 1

--- a/src/renderer/routes/downloads/filter-search-panel.tsx
+++ b/src/renderer/routes/downloads/filter-search-panel.tsx
@@ -5,7 +5,8 @@ import {
   CommandItem,
   CommandList,
 } from '@renderer/components/ui/command'
-import { formatBytes, formatProgressPercent } from '@renderer/lib/format'
+import { useByteFormat } from '@renderer/hooks/use-byte-format'
+import { formatProgressPercent } from '@renderer/lib/format'
 import { TASK_TYPE_META, TASK_TYPE_ORDER } from '@renderer/lib/task-type-meta'
 import { cn } from '@renderer/lib/utils'
 import type { DownloadTask } from '@shared/types/task'
@@ -53,6 +54,8 @@ export function FilterSearchPanel({
   typeCounts,
   onOpenTask,
 }: FilterSearchPanelProps) {
+  const { formatBytes } = useByteFormat()
+
   const { t } = useTranslation()
   const [query, setQuery] = useState('')
 

--- a/src/renderer/routes/downloads/global-stats-bar.test.tsx
+++ b/src/renderer/routes/downloads/global-stats-bar.test.tsx
@@ -67,8 +67,7 @@ describe('GlobalStatsBar', () => {
         <GlobalStatsBar counts={motrixCounts} />
       </PlatformServicesProvider>
     )
-    // formatBytes(16_500_000) = "15.7 MB" (1024-base, value.toFixed(1))
-    expect(screen.getByText(/15\.7 MB\/s/)).toBeInTheDocument()
+    expect(screen.getByText(/16\.5 MB\/s/)).toBeInTheDocument()
     expect(await screen.findByText(/Engine ready/)).toBeInTheDocument()
     expect(await screen.findByText(/NAT active/)).toBeInTheDocument()
   })

--- a/src/renderer/routes/downloads/global-stats-bar.tsx
+++ b/src/renderer/routes/downloads/global-stats-bar.tsx
@@ -1,5 +1,6 @@
+import { useByteFormat } from '@renderer/hooks/use-byte-format'
 import { useGlobalStats } from '@renderer/hooks/use-global-stats'
-import { formatBytes } from '@renderer/lib/format'
+
 import { useTranslation } from 'react-i18next'
 import { EngineBadge } from './engine-badge'
 import type { DownloadsTab } from './filter'
@@ -10,6 +11,8 @@ interface GlobalStatsBarProps {
 }
 
 export function GlobalStatsBar({ counts }: GlobalStatsBarProps) {
+  const { formatSpeed } = useByteFormat()
+
   const { t } = useTranslation()
   const { stats } = useGlobalStats()
 
@@ -19,13 +22,13 @@ export function GlobalStatsBar({ counts }: GlobalStatsBarProps) {
         <span className="tabular-nums">
           {t('panel.downloads.stats.downSpeed')}{' '}
           <span className="text-foreground">
-            {stats ? `${formatBytes(stats.totalDownloadSpeed)}/s` : '—'}
+            {stats ? formatSpeed(stats.totalDownloadSpeed) : '—'}
           </span>
         </span>
         <span className="tabular-nums">
           {t('panel.downloads.stats.upSpeed')}{' '}
           <span className="text-foreground">
-            {stats ? `${formatBytes(stats.totalUploadSpeed)}/s` : '—'}
+            {stats ? formatSpeed(stats.totalUploadSpeed) : '—'}
           </span>
         </span>
         <span className="tabular-nums">

--- a/src/renderer/routes/downloads/inspector/activity-tab.test.tsx
+++ b/src/renderer/routes/downloads/inspector/activity-tab.test.tsx
@@ -337,8 +337,8 @@ describe('ActivityTab', () => {
         screen.getByTestId('task-inspector-activity-summary-card')
       ).getAllByText('0 B/s')
     ).toHaveLength(2)
-    expect(screen.getByText('3.0 KB/s')).toBeInTheDocument()
-    expect(screen.getByText('4.0 KB/s')).toBeInTheDocument()
+    expect(screen.getByText('3.1 KB/s')).toBeInTheDocument()
+    expect(screen.getByText('4.1 KB/s')).toBeInTheDocument()
   })
 
   it('does not render Failed timeline details while Task history is hidden', () => {

--- a/src/renderer/routes/downloads/inspector/current-summary-card.test.tsx
+++ b/src/renderer/routes/downloads/inspector/current-summary-card.test.tsx
@@ -27,8 +27,8 @@ describe('CurrentSummaryCard', () => {
 
     expect(screen.getByText('2.0 KB/s')).toBeInTheDocument()
     expect(screen.getByText('1.0 KB/s')).toBeInTheDocument()
-    expect(screen.getByText('3.0 KB/s')).toBeInTheDocument()
-    expect(screen.getByText('4.0 KB/s')).toBeInTheDocument()
+    expect(screen.getByText('3.1 KB/s')).toBeInTheDocument()
+    expect(screen.getByText('4.1 KB/s')).toBeInTheDocument()
     expect(screen.getByText('00:42')).toBeInTheDocument()
     expect(screen.queryByText(/Progress/i)).toBeNull()
     expect(screen.queryByText(/ETA/i)).toBeNull()

--- a/src/renderer/routes/downloads/inspector/current-summary-card.tsx
+++ b/src/renderer/routes/downloads/inspector/current-summary-card.tsx
@@ -1,5 +1,6 @@
+import { useByteFormat } from '@renderer/hooks/use-byte-format'
 import { formatDurationHMS } from '@renderer/lib/format'
-import { formatSpeed } from '@renderer/lib/speed-chart'
+
 import type { DownloadTask } from '@shared/types/task'
 import { TaskStatus } from '@shared/types/task'
 import type { TaskInspectorActivitySnapshot } from '@shared/types/task-inspector-activity'
@@ -32,6 +33,8 @@ function LiveMetric({
   value: number
   label: string
 }) {
+  const { formatSpeed } = useByteFormat()
+
   const Icon = direction === 'download' ? ArrowDown : ArrowUp
   const color =
     direction === 'download'
@@ -87,6 +90,8 @@ export function CurrentSummaryCard({
   task,
   lifetime,
 }: CurrentSummaryCardProps) {
+  const { formatSpeed } = useByteFormat()
+
   const { t } = useTranslation()
   const unavailable = t('panel.downloads.inspector.activity.notAvailable')
   const live = LIVE_STATUSES.has(task.status)

--- a/src/renderer/routes/downloads/inspector/lifetime-transfer-card.test.tsx
+++ b/src/renderer/routes/downloads/inspector/lifetime-transfer-card.test.tsx
@@ -213,9 +213,9 @@ describe('LifetimeTransferCard', () => {
     )
 
     const scale = screen.getByTestId('activity-transfer-speed-scale')
-    expect(scale).toHaveTextContent('13.6 MB/s')
-    expect(scale).toHaveTextContent('6.8 MB/s')
-    expect(scale).not.toHaveTextContent('19.1 MB/s')
+    expect(scale).toHaveTextContent('14.3 MB/s')
+    expect(scale).toHaveTextContent('7.1 MB/s')
+    expect(scale).not.toHaveTextContent('20.0 MB/s')
   })
 
   it('formats X-axis labels as HH:mm:ss without AM or PM', () => {

--- a/src/renderer/routes/downloads/inspector/lifetime-transfer-card.tsx
+++ b/src/renderer/routes/downloads/inspector/lifetime-transfer-card.tsx
@@ -4,8 +4,9 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from '@renderer/components/ui/chart'
+import { useByteFormat } from '@renderer/hooks/use-byte-format'
 import { formatTime24Hour } from '@renderer/lib/format'
-import { formatSpeed } from '@renderer/lib/speed-chart'
+
 import { TileSegmentedControl } from '@renderer/routes/dashboard/components/tile-segmented-control'
 import type {
   TaskInspectorActivitySnapshot,
@@ -43,10 +44,6 @@ export interface LifetimeTransferCardProps {
   summary?: ReactNode
   onRangeChange: (range: ActivityChartRange) => void
   onSelectMarker: (markerId: string) => void
-}
-
-function formatAxisSpeed(bytesPerSecond: number): string {
-  return formatSpeed(bytesPerSecond).replace(' ', '\u00a0')
 }
 
 const TRANSFER_BAR_SIZE = 5
@@ -110,6 +107,11 @@ export function LifetimeTransferCard({
   onRangeChange,
   onSelectMarker,
 }: LifetimeTransferCardProps) {
+  const { formatSpeed } = useByteFormat()
+
+  function formatAxisSpeed(bytesPerSecond: number): string {
+    return formatSpeed(bytesPerSecond).replace(' ', '\u00a0')
+  }
   const { t, i18n } = useTranslation()
   const latest = model.points.at(-1)
   const chartConfig = useMemo<ChartConfig>(

--- a/src/renderer/routes/downloads/inspector/multi-selection-summary.test.tsx
+++ b/src/renderer/routes/downloads/inspector/multi-selection-summary.test.tsx
@@ -63,8 +63,6 @@ describe('MultiSelectionSummary', () => {
       />
     )
     expect(screen.getByText(/totals/i)).toBeInTheDocument()
-    // formatBytes(8_000_000_000) = "7.5 GB" (1024-base, value.toFixed(1))
-    // Math: 8e9 / 1024^3 = 7.4506, toFixed(1) = "7.5"
-    expect(screen.getByText(/7\.5 GB/)).toBeInTheDocument()
+    expect(screen.getByText(/8\.00 GB/)).toBeInTheDocument()
   })
 })

--- a/src/renderer/routes/downloads/inspector/multi-selection-summary.tsx
+++ b/src/renderer/routes/downloads/inspector/multi-selection-summary.tsx
@@ -1,8 +1,5 @@
-import {
-  formatBytes,
-  formatDurationHMS,
-  formatProgressPercent,
-} from '@renderer/lib/format'
+import { useByteFormat } from '@renderer/hooks/use-byte-format'
+import { formatDurationHMS, formatProgressPercent } from '@renderer/lib/format'
 import type { DownloadTask, TaskStatus } from '@shared/types/task'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -40,6 +37,8 @@ export function MultiSelectionSummary({
 }: {
   tasks: readonly DownloadTask[]
 }) {
+  const { formatBytes, formatSpeed } = useByteFormat()
+
   const { t } = useTranslation()
   const agg = useMemo(() => {
     const totalSize = tasks.reduce((s, x) => s + x.sizeWhenDone, 0)
@@ -81,11 +80,11 @@ export function MultiSelectionSummary({
       <Card title={t('panel.downloads.inspector.multi.liveSpeed')}>
         <Row
           label={t('panel.downloads.inspector.multi.combinedDown')}
-          value={`${formatBytes(agg.combinedDown)}/s`}
+          value={formatSpeed(agg.combinedDown)}
         />
         <Row
           label={t('panel.downloads.inspector.multi.combinedUp')}
-          value={`${formatBytes(agg.combinedUp)}/s`}
+          value={formatSpeed(agg.combinedUp)}
         />
         <Row
           label={t('panel.downloads.inspector.multi.longestEta')}

--- a/src/renderer/routes/downloads/inspector/overview-tab.tsx
+++ b/src/renderer/routes/downloads/inspector/overview-tab.tsx
@@ -11,9 +11,9 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@renderer/components/ui/tooltip'
+import { useByteFormat } from '@renderer/hooks/use-byte-format'
 import { resolveFailureReason } from '@renderer/lib/failure-reason'
 import {
-  formatBytes,
   formatDateTime,
   formatDurationHMS,
   formatProgressPercent,
@@ -137,6 +137,8 @@ function ErrorPanel({ task }: { task: DownloadTask }) {
 }
 
 export function OverviewTab({ task }: { task: DownloadTask }) {
+  const { formatSpeed, formatBytes } = useByteFormat()
+
   const { t, i18n } = useTranslation()
   const isBt = task.type === TaskType.Bt || task.type === TaskType.Magnet
   return (
@@ -146,11 +148,11 @@ export function OverviewTab({ task }: { task: DownloadTask }) {
         <Card title={t('panel.downloads.inspector.overview.transfer')}>
           <Row
             label={t('panel.downloads.inspector.overview.downSpeed')}
-            value={`${formatBytes(task.downloadSpeed)}/s`}
+            value={formatSpeed(task.downloadSpeed)}
           />
           <Row
             label={t('panel.downloads.inspector.overview.upSpeed')}
-            value={`${formatBytes(task.uploadSpeed)}/s`}
+            value={formatSpeed(task.uploadSpeed)}
           />
           <Row
             label={t('panel.downloads.inspector.overview.eta')}

--- a/src/renderer/routes/downloads/inspector/peers-tab.test.tsx
+++ b/src/renderer/routes/downloads/inspector/peers-tab.test.tsx
@@ -138,7 +138,7 @@ describe('PeerRow', () => {
     )
     // upSpeed > 0 → shows formatted bytes; downSpeed = 0 → dash
     expect(container.textContent).toContain('—')
-    expect(container.textContent).toContain('16.0 KB/s')
+    expect(container.textContent).toContain('16.4 KB/s')
   })
 
   it('renders the country flag and code when showCountry is true and peer.country is present', () => {

--- a/src/renderer/routes/downloads/inspector/peers-tab.tsx
+++ b/src/renderer/routes/downloads/inspector/peers-tab.tsx
@@ -1,8 +1,9 @@
 import { VirtualList } from '@renderer/components/desktop-kit/virtual-list/virtual-list'
+import { useByteFormat } from '@renderer/hooks/use-byte-format'
 import { useGeoIPStatus } from '@renderer/hooks/use-geoip-status'
 import { useTaskPeers } from '@renderer/hooks/use-task-peers'
 import { countryCodeToFlag, countryName } from '@renderer/lib/country-flag'
-import { formatBytes } from '@renderer/lib/format'
+
 import { cn } from '@renderer/lib/utils'
 import type { TaskPeer } from '@shared/types/peer'
 import type { DownloadTask } from '@shared/types/task'
@@ -59,6 +60,8 @@ interface PeerRowProps {
 }
 
 export function PeerRow({ peer, locale, showCountry }: PeerRowProps) {
+  const { formatSpeed } = useByteFormat()
+
   const progressPct = Math.round(peer.progress * 100)
   const flag = peer.country ? countryCodeToFlag(peer.country.code) : ''
   const code = peer.country?.code ?? ''
@@ -98,10 +101,10 @@ export function PeerRow({ peer, locale, showCountry }: PeerRowProps) {
         {clientLabel(peer)}
       </span>
       <span className="text-right text-muted-foreground">
-        {peer.downSpeed > 0 ? `${formatBytes(peer.downSpeed)}/s` : '—'}
+        {peer.downSpeed > 0 ? formatSpeed(peer.downSpeed) : '—'}
       </span>
       <span className="text-right text-muted-foreground">
-        {peer.upSpeed > 0 ? `${formatBytes(peer.upSpeed)}/s` : '—'}
+        {peer.upSpeed > 0 ? formatSpeed(peer.upSpeed) : '—'}
       </span>
       <span className="text-right text-muted-foreground">{progressPct}%</span>
       <span className="text-right text-[11px] text-muted-foreground">
@@ -112,6 +115,8 @@ export function PeerRow({ peer, locale, showCountry }: PeerRowProps) {
 }
 
 export function PeersTab({ task }: { task: DownloadTask }) {
+  const { formatSpeed } = useByteFormat()
+
   const { t, i18n } = useTranslation()
   const { peers } = useTaskPeers(task.id, PEER_LIVE_STATUSES.has(task.status))
   const { status: geoStatus } = useGeoIPStatus()
@@ -145,8 +150,7 @@ export function PeersTab({ task }: { task: DownloadTask }) {
           })}
         </span>
         <span className="font-mono tabular-nums">
-          ↓ {formatBytes(summary.totalDown)}/s · ↑{' '}
-          {formatBytes(summary.totalUp)}/s
+          ↓ {formatSpeed(summary.totalDown)} · ↑ {formatSpeed(summary.totalUp)}
         </span>
       </div>
 

--- a/src/renderer/routes/downloads/inspector/pieces-tab.tsx
+++ b/src/renderer/routes/downloads/inspector/pieces-tab.tsx
@@ -1,5 +1,6 @@
+import { useByteFormat } from '@renderer/hooks/use-byte-format'
 import { useTaskPieces } from '@renderer/hooks/use-task-pieces'
-import { formatBytes } from '@renderer/lib/format'
+
 import type { DownloadTask } from '@shared/types/task'
 import { TaskStatus } from '@shared/types/task'
 import { useLayoutEffect, useMemo, useRef } from 'react'
@@ -116,6 +117,8 @@ function drawPieces(
 }
 
 export function PiecesTab({ task }: { task: DownloadTask }) {
+  const { formatBytes } = useByteFormat()
+
   const { t } = useTranslation()
   const { pieces } = useTaskPieces(
     task.id,

--- a/src/renderer/routes/downloads/inspector/remove-tasks-dialog.test.tsx
+++ b/src/renderer/routes/downloads/inspector/remove-tasks-dialog.test.tsx
@@ -147,7 +147,7 @@ describe('RemoveTasksDialog', () => {
       />
     )
     expect(screen.getByText(/Will delete/)).toBeDefined()
-    expect(screen.getByText(/100/)).toBeDefined()
+    expect(screen.getByText(/104\.86 MB/)).toBeDefined()
   })
 
   it('confirm button calls onConfirm with current deleteFiles state', () => {

--- a/src/renderer/routes/downloads/inspector/remove-tasks-dialog.tsx
+++ b/src/renderer/routes/downloads/inspector/remove-tasks-dialog.tsx
@@ -7,7 +7,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@renderer/components/ui/dialog'
-import { formatBytes } from '@renderer/lib/format'
+import { useByteFormat } from '@renderer/hooks/use-byte-format'
+
 import type { DownloadTask } from '@shared/types/task'
 import { TaskStatus } from '@shared/types/task'
 import { AlertTriangle } from 'lucide-react'
@@ -85,6 +86,8 @@ export function RemoveTasksDialog({
   onOpenChange,
   onConfirm,
 }: RemoveTasksDialogProps) {
+  const { formatBytes } = useByteFormat()
+
   const { t } = useTranslation()
   const checkboxId = useId()
   // Deleting files is always an explicit opt-in (or the Shift shortcut via

--- a/src/renderer/routes/downloads/task-row.test.tsx
+++ b/src/renderer/routes/downloads/task-row.test.tsx
@@ -79,8 +79,7 @@ describe('TaskRow', () => {
   it('renders task name and formatted size', () => {
     render(<TaskRow task={fake()} rowProps={rowProps} />)
     expect(screen.getByText('ubuntu.iso')).toBeInTheDocument()
-    // formatBytes(4_700_000_000) = "4.4 GB" (1024-base, value.toFixed(1))
-    expect(screen.getByText(/4\.4 GB/)).toBeInTheDocument()
+    expect(screen.getByText(/4\.70 GB/)).toBeInTheDocument()
   })
 
   it('renders a dash for speeds when paused', () => {

--- a/src/renderer/routes/downloads/task-row.tsx
+++ b/src/renderer/routes/downloads/task-row.tsx
@@ -1,10 +1,7 @@
 import { Checkbox } from '@renderer/components/ui/checkbox'
+import { useByteFormat } from '@renderer/hooks/use-byte-format'
 import { resolveFailureReason } from '@renderer/lib/failure-reason'
-import {
-  formatBytes,
-  formatDurationHMS,
-  formatProgressPercent,
-} from '@renderer/lib/format'
+import { formatDurationHMS, formatProgressPercent } from '@renderer/lib/format'
 import { getProgressBarTone } from '@renderer/lib/task-status-ui'
 import { cn } from '@renderer/lib/utils'
 import type { DownloadTask } from '@shared/types/task'
@@ -25,6 +22,8 @@ export interface TaskRowProps {
 }
 
 function TaskRowBase({ task, rowProps }: TaskRowProps) {
+  const { formatBytes, formatSpeed } = useByteFormat()
+
   const { t, i18n } = useTranslation()
   const pct = formatProgressPercent(task.progress)
   const showDash = (value: number) =>
@@ -102,14 +101,10 @@ function TaskRowBase({ task, rowProps }: TaskRowProps) {
       </div>
       <StatusPill status={task.status} />
       <span className="tabular-nums">
-        {showDash(task.downloadSpeed)
-          ? '—'
-          : `${formatBytes(task.downloadSpeed)}/s`}
+        {showDash(task.downloadSpeed) ? '—' : formatSpeed(task.downloadSpeed)}
       </span>
       <span className="tabular-nums">
-        {showDash(task.uploadSpeed)
-          ? '—'
-          : `${formatBytes(task.uploadSpeed)}/s`}
+        {showDash(task.uploadSpeed) ? '—' : formatSpeed(task.uploadSpeed)}
       </span>
       <span className="tabular-nums">
         {hideEta ? '—' : formatDurationHMS(task.etaSeconds)}

--- a/src/renderer/routes/settings/cards/appearance-dialog.test.tsx
+++ b/src/renderer/routes/settings/cards/appearance-dialog.test.tsx
@@ -79,7 +79,7 @@ describe('<AppearanceDialog>', () => {
     )
 
     await waitFor(() => {
-      const [themeTrigger, languageTrigger, runModeTrigger] =
+      const [themeTrigger, languageTrigger, byteUnitTrigger, runModeTrigger] =
         screen.getAllByRole('combobox')
 
       expect(themeTrigger).toHaveTextContent(/^System$/)
@@ -88,6 +88,7 @@ describe('<AppearanceDialog>', () => {
       expect(languageTrigger).not.toHaveTextContent(/^en-US$/)
       expect(languageTrigger).toHaveClass('min-w-30', 'max-w-64')
       expect(languageTrigger).not.toHaveClass('w-32')
+      expect(byteUnitTrigger).toHaveTextContent('Follow system (MB, GB)')
       expect(runModeTrigger).toHaveTextContent(/^Dock & Menu Bar$/)
       expect(runModeTrigger).not.toHaveTextContent(/^1$/)
     })
@@ -302,5 +303,32 @@ describe('<AppearanceDialog>', () => {
       app: { language: 'zh-CN' },
     })
     expect(i18n.resolvedLanguage).toBe('en-US')
+  })
+})
+
+it('saves only the chosen unit system when Apply is clicked', async () => {
+  const user = userEvent.setup({ pointerEventsCheck: 0 })
+  render(
+    <AppearanceDialog
+      open
+      onClose={vi.fn()}
+      labelKey="settings.cards.appearance.title"
+      descKey="settings.cards.appearance.desc"
+    />
+  )
+  const select = await screen.findByRole('combobox', {
+    name: 'Size and speed units',
+  })
+  await user.click(select)
+  await user.click(
+    await screen.findByRole('option', { name: 'Binary (MiB, GiB · 1024)' })
+  )
+  expect(transport.invoke).not.toHaveBeenCalledWith(
+    Commands.UpdateSettings,
+    expect.anything()
+  )
+  await user.click(screen.getByRole('button', { name: /apply|save/i }))
+  expect(transport.invoke).toHaveBeenCalledWith(Commands.UpdateSettings, {
+    app: { byteUnitSystem: 'binary' },
   })
 })

--- a/src/renderer/routes/settings/cards/appearance-dialog.tsx
+++ b/src/renderer/routes/settings/cards/appearance-dialog.tsx
@@ -31,6 +31,7 @@ import { isSupportedLocale, SUPPORTED_LOCALES } from '@shared/constants/locales'
 import { Commands } from '@shared/protocol/commands'
 import { Queries } from '@shared/protocol/queries'
 import { DEFAULT_APP_SETTINGS } from '@shared/schemas'
+import { resolveByteUnitSystem } from '@shared/schemas/byte-unit-system'
 import type { AppSettings, MotrixAppSettings } from '@shared/types/settings'
 import { useTheme } from 'next-themes'
 import { useEffect } from 'react'
@@ -43,6 +44,7 @@ type AppearanceFields = Pick<
   | 'theme'
   | 'reduceMotion'
   | 'language'
+  | 'byteUnitSystem'
   | 'traySpeedometer'
   | 'runMode'
   | 'liquidGlassEffect'
@@ -56,6 +58,7 @@ const DEFAULTS: AppearanceFields = {
   theme: DEFAULT_APP_SETTINGS.theme,
   reduceMotion: DEFAULT_APP_SETTINGS.reduceMotion,
   language: DEFAULT_APP_SETTINGS.language,
+  byteUnitSystem: DEFAULT_APP_SETTINGS.byteUnitSystem,
   traySpeedometer: DEFAULT_APP_SETTINGS.traySpeedometer,
   runMode: DEFAULT_APP_SETTINGS.runMode,
   liquidGlassEffect: DEFAULT_APP_SETTINGS.liquidGlassEffect,
@@ -93,6 +96,7 @@ export function AppearanceDialog({
             theme: all.app.theme,
             reduceMotion: all.app.reduceMotion ?? DEFAULTS.reduceMotion,
             language: all.app.language,
+            byteUnitSystem: all.app.byteUnitSystem ?? DEFAULTS.byteUnitSystem,
             traySpeedometer: all.app.traySpeedometer,
             runMode:
               transport.platform !== 'darwin' &&
@@ -122,6 +126,24 @@ export function AppearanceDialog({
     if (dirty.theme !== undefined) setTheme(dirty.theme)
     onClose()
   })
+
+  const systemUnits = resolveByteUnitSystem(
+    'system',
+    transport.platform === 'web' ? navigator.platform : transport.platform
+  )
+  const byteUnitOptions = [
+    {
+      value: 'system',
+      label: t('settings.appearance.byteUnitSystemDefault', {
+        units: systemUnits === 'binary' ? 'MiB, GiB' : 'MB, GB',
+      }),
+    },
+    { value: 'decimal', label: t('settings.appearance.byteUnitDecimal') },
+    { value: 'binary', label: t('settings.appearance.byteUnitBinary') },
+  ] satisfies Array<{
+    value: AppearanceFields['byteUnitSystem']
+    label: string
+  }>
 
   const themeOptions = [
     {
@@ -238,6 +260,48 @@ export function AppearanceDialog({
                         <SelectContent>
                           <SelectGroup>
                             {LANGUAGE_OPTIONS.map((option) => (
+                              <SelectItem
+                                key={option.value}
+                                value={option.value}
+                              >
+                                {option.label}
+                              </SelectItem>
+                            ))}
+                          </SelectGroup>
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="byteUnitSystem"
+                render={({ field }) => (
+                  <FormItem className="flex items-start justify-between gap-4">
+                    <div className="space-y-1">
+                      <FormLabel>
+                        {t('settings.appearance.byteUnitSystem')}
+                      </FormLabel>
+                      <FormDescription className="text-xs">
+                        {t('settings.appearance.byteUnitSystemDesc')}
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Select
+                        items={byteUnitOptions}
+                        value={field.value}
+                        onValueChange={(value) => {
+                          if (value !== null) field.onChange(value)
+                        }}
+                      >
+                        <SettingsSelectTrigger>
+                          <SelectValue />
+                        </SettingsSelectTrigger>
+                        <SelectContent>
+                          <SelectGroup>
+                            {byteUnitOptions.map((option) => (
                               <SelectItem
                                 key={option.value}
                                 value={option.value}

--- a/src/renderer/routes/settings/cards/bt-peer-geo-section.tsx
+++ b/src/renderer/routes/settings/cards/bt-peer-geo-section.tsx
@@ -18,8 +18,9 @@ import {
 } from '@renderer/components/ui/select'
 import { Spinner } from '@renderer/components/ui/spinner'
 import { Switch } from '@renderer/components/ui/switch'
+import { useByteFormat } from '@renderer/hooks/use-byte-format'
 import { useGeoIPStatus } from '@renderer/hooks/use-geoip-status'
-import { formatBytes } from '@renderer/lib/format'
+
 import { transport } from '@renderer/lib/transport'
 import { Commands } from '@shared/protocol/commands'
 import { Queries } from '@shared/protocol/queries'
@@ -57,6 +58,8 @@ function formatTimestamp(ts: number): string {
 }
 
 export function BtPeerGeoSection() {
+  const { formatBytes } = useByteFormat()
+
   const { t } = useTranslation()
   const { status, progress, triggerUpdate } = useGeoIPStatus()
   const [updateError, setUpdateError] = useState<string | null>(null)

--- a/src/renderer/routes/settings/cards/compact-limit-input.tsx
+++ b/src/renderer/routes/settings/cards/compact-limit-input.tsx
@@ -13,7 +13,7 @@ import {
   TooltipTrigger,
 } from '@renderer/components/ui/tooltip'
 import { Infinity as InfinityIcon, RotateCcw } from 'lucide-react'
-import { type ComponentProps, forwardRef } from 'react'
+import { type ComponentProps, forwardRef, useState } from 'react'
 
 type ZeroAction = 'unlimited' | 'inherit'
 
@@ -41,10 +41,15 @@ export const CompactLimitInput = forwardRef<
     resetLabel,
     zeroAction = 'unlimited',
     onKeyDown,
+    onBlur,
     ...props
   },
   ref
 ) {
+  // Preserve partial decimals while editing; the parent rounds to whole bytes.
+  const [draft, setDraft] = useState<{ text: string; unit: string } | null>(
+    null
+  )
   const zero = value <= 0
   const ResetIcon = zeroAction === 'inherit' ? RotateCcw : InfinityIcon
 
@@ -60,7 +65,10 @@ export const CompactLimitInput = forwardRef<
                   variant="outline"
                   size="icon-sm"
                   aria-label={resetLabel}
-                  onClick={() => onValueChange(0)}
+                  onClick={() => {
+                    setDraft(null)
+                    onValueChange(0)
+                  }}
                 >
                   <ResetIcon aria-hidden />
                 </Button>
@@ -75,21 +83,27 @@ export const CompactLimitInput = forwardRef<
           {...props}
           ref={ref}
           data-slot="input-group-control"
-          type="text"
-          role="spinbutton"
-          inputMode="numeric"
+          type="number"
+          min={0}
+          step="any"
+          inputMode="decimal"
           autoComplete="off"
           aria-valuemin={0}
           aria-valuenow={Math.max(0, value)}
           aria-valuetext={zero ? zeroLabel : `${value} ${unit}`}
-          className="h-8 min-w-0 px-2 text-right tabular-nums placeholder:text-right placeholder:text-xs"
-          value={zero ? '' : value}
+          className="h-8 min-w-0 px-2 text-right tabular-nums placeholder:text-right placeholder:text-xs [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+          value={draft?.unit === unit ? draft.text : zero ? '' : value}
           placeholder={zeroLabel}
           onChange={(event) => {
-            const nextValue = Number.parseInt(event.target.value, 10)
+            setDraft({ text: event.target.value, unit })
+            const nextValue = Number(event.target.value)
             onValueChange(
               Number.isFinite(nextValue) ? Math.max(0, nextValue) : 0
             )
+          }}
+          onBlur={(event) => {
+            setDraft(null)
+            onBlur?.(event)
           }}
           onKeyDown={(event) => {
             onKeyDown?.(event)
@@ -100,6 +114,7 @@ export const CompactLimitInput = forwardRef<
               return
             }
             event.preventDefault()
+            setDraft(null)
             const delta = event.key === 'ArrowUp' ? 1 : -1
             onValueChange(Math.max(0, value + delta))
           }}

--- a/src/renderer/routes/settings/cards/downloads-dialog.test.tsx
+++ b/src/renderer/routes/settings/cards/downloads-dialog.test.tsx
@@ -1,3 +1,4 @@
+import { setByteUnitSystem } from '@renderer/hooks/use-byte-format'
 import '@testing-library/jest-dom/vitest'
 import { i18n } from '@renderer/lib/i18n'
 import { transport } from '@renderer/lib/transport'
@@ -6,9 +7,16 @@ import { Commands } from '@shared/protocol/commands'
 import { Queries } from '@shared/protocol/queries'
 import { MAX_CONNECTIONS_PER_SERVER } from '@shared/schemas/engine-settings'
 import { DEFAULT_SPEED_LIMIT_SETTINGS } from '@shared/schemas/speed-limit'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DownloadsDialog } from './downloads-dialog'
 
 const { toastAddMock } = vi.hoisted(() => ({ toastAddMock: vi.fn() }))
@@ -66,6 +74,11 @@ const FIXTURE = {
   },
   speedLimit: DEFAULT_SPEED_LIMIT_SETTINGS,
 }
+
+afterEach(() => {
+  cleanup()
+  setByteUnitSystem('decimal')
+})
 
 describe('<DownloadsDialog>', () => {
   beforeEach(async () => {
@@ -378,14 +391,95 @@ describe('<DownloadsDialog>', () => {
     const baseDown = screen.getByLabelText(
       /standard download limit/i
     ) as HTMLInputElement
-    // 1024 KB/s → bytes/sec: 1024 * 1024 = 1_048_576.
+    // Decimal KB/s → bytes/sec: 1024 * 1000 = 1_024_000.
     fireEvent.change(baseDown, { target: { value: '1024' } })
     await user.click(screen.getByRole('button', { name: /save/i }))
     expect(transport.invoke).toHaveBeenCalledWith(Commands.UpdateSettings, {
-      speedLimit: { base: { download: 1024 * 1024 } },
+      speedLimit: { base: { download: 1024 * 1000 } },
     })
     expect(onClose).toHaveBeenCalled()
   })
+
+  it('converts an existing limit on unit changes without marking it dirty', async () => {
+    vi.mocked(transport.invoke).mockImplementation(async (channel) => {
+      if (channel === Queries.GetSettings)
+        return {
+          ...FIXTURE,
+          speedLimit: {
+            ...DEFAULT_SPEED_LIMIT_SETTINGS,
+            base: { download: 1_048_576, upload: 0 },
+          },
+        }
+      return { saved: true, requiresRestart: false, changedRestartKeys: [] }
+    })
+    render(
+      <DownloadsDialog
+        open
+        onClose={vi.fn()}
+        labelKey="settings.cards.downloads.title"
+        descKey="settings.cards.downloads.desc"
+      />
+    )
+    const input = screen.getByLabelText(/standard download limit/i)
+    await waitFor(() => expect(input).toHaveValue(1048.576))
+    act(() => setByteUnitSystem('binary'))
+    expect(input).toHaveValue(1024)
+    expect(input).toHaveAttribute('aria-valuetext', '1024 KiB/s')
+    await userEvent.setup().click(screen.getByRole('button', { name: /save/i }))
+    expect(transport.invoke).not.toHaveBeenCalledWith(
+      Commands.UpdateSettings,
+      expect.anything()
+    )
+  })
+
+  it('converts binary limit input into exact bytes per second', async () => {
+    setByteUnitSystem('binary')
+    render(
+      <DownloadsDialog
+        open
+        onClose={vi.fn()}
+        labelKey="settings.cards.downloads.title"
+        descKey="settings.cards.downloads.desc"
+      />
+    )
+    await waitFor(() =>
+      expect(screen.getByLabelText(/standard download limit/i)).toBeEnabled()
+    )
+    fireEvent.change(screen.getByLabelText(/standard download limit/i), {
+      target: { value: '1024' },
+    })
+    await userEvent.setup().click(screen.getByRole('button', { name: /save/i }))
+    expect(transport.invoke).toHaveBeenCalledWith(Commands.UpdateSettings, {
+      speedLimit: { base: { download: 1_048_576 } },
+    })
+  })
+
+  it.each(['decimal', 'binary'] as const)(
+    'accepts fractional %s limits typed one character at a time',
+    async (unitSystem) => {
+      setByteUnitSystem(unitSystem)
+      render(
+        <DownloadsDialog
+          open
+          onClose={vi.fn()}
+          labelKey="settings.cards.downloads.title"
+          descKey="settings.cards.downloads.desc"
+        />
+      )
+      const input = screen.getByLabelText(/standard download limit/i)
+      await waitFor(() => expect(input).toBeEnabled())
+      const user = userEvent.setup()
+      await user.clear(input)
+      await user.type(input, '1.1')
+      expect(input).toHaveValue(1.1)
+      await user.click(screen.getByRole('button', { name: /save/i }))
+      expect(transport.invoke).toHaveBeenCalledWith(Commands.UpdateSettings, {
+        speedLimit: {
+          base: { download: unitSystem === 'binary' ? 1126 : 1100 },
+        },
+      })
+    }
+  )
 
   it('groups compact reset actions with their speed limit inputs', async () => {
     vi.mocked(transport.invoke).mockImplementation(async (channel) => {
@@ -437,9 +531,9 @@ describe('<DownloadsDialog>', () => {
     await user.click(setUnlimited)
     await user.click(useStandard as HTMLElement)
 
-    expect(baseDown).toHaveValue('')
+    expect(baseDown).toHaveValue(null)
     expect(baseDown).toHaveAttribute('placeholder', 'Unlimited')
-    expect(altDown).toHaveValue('')
+    expect(altDown).toHaveValue(null)
     expect(altDown).toHaveAttribute('placeholder', 'Standard limit')
 
     await user.click(screen.getByRole('button', { name: /save/i }))

--- a/src/renderer/routes/settings/cards/engine-tuning-section.tsx
+++ b/src/renderer/routes/settings/cards/engine-tuning-section.tsx
@@ -152,7 +152,7 @@ export function EngineTuningSection({
         'lowestSpeedLimit',
         'settings.downloads.reliability.lowestSpeedLimit',
         'settings.downloads.reliability.lowestSpeedLimitDesc',
-        { min: 0, scale: KB } // displayed KB/s → stored bytes/sec
+        { min: 0, scale: KB } // displayed KiB/s → stored bytes/sec
       )}
 
       <Separator className="my-4" />

--- a/src/renderer/routes/settings/cards/performance-section.tsx
+++ b/src/renderer/routes/settings/cards/performance-section.tsx
@@ -72,12 +72,12 @@ export function PerformanceSection({
           {
             icon: RulerIcon,
             label: t('settings.downloads.performance.metrics.minimum'),
-            value: `${Math.round(selectedPerformanceValues.minSplitSize / MB)} MB`,
+            value: `${Math.round(selectedPerformanceValues.minSplitSize / MB)} MiB`,
           },
           {
             icon: DatabaseIcon,
             label: t('settings.downloads.performance.metrics.cache'),
-            value: `${Math.round(selectedPerformanceValues.diskCache / MB)} MB`,
+            value: `${Math.round(selectedPerformanceValues.diskCache / MB)} MiB`,
           },
         ]
       : null
@@ -242,10 +242,10 @@ export function PerformanceSection({
             descKey="settings.downloads.performance.minSplitSizeDesc"
             bounds={{ min: 1, scale: MB }}
             presets={[
-              { label: '1 MB', value: 1 },
-              { label: '4 MB', value: 4 },
-              { label: '10 MB', value: 10 },
-              { label: '20 MB', value: 20 },
+              { label: '1 MiB', value: 1 },
+              { label: '4 MiB', value: 4 },
+              { label: '10 MiB', value: 10 },
+              { label: '20 MiB', value: 20 },
             ]}
           />
           <EngineNumberSettingRow
@@ -255,9 +255,9 @@ export function PerformanceSection({
             descKey="settings.downloads.disk.diskCacheDesc"
             bounds={{ min: 0, max: 128, scale: MB }}
             presets={[
-              { label: '16 MB', value: 16 },
-              { label: '32 MB', value: 32 },
-              { label: '64 MB', value: 64 },
+              { label: '16 MiB', value: 16 },
+              { label: '32 MiB', value: 32 },
+              { label: '64 MiB', value: 64 },
             ]}
           />
         </div>

--- a/src/renderer/routes/settings/cards/speed-limit-section.tsx
+++ b/src/renderer/routes/settings/cards/speed-limit-section.tsx
@@ -15,7 +15,8 @@ import {
   ToggleGroup,
   ToggleGroupItem,
 } from '@renderer/components/ui/toggle-group'
-import { formatBytes } from '@renderer/lib/format'
+import { useByteFormat } from '@renderer/hooks/use-byte-format'
+
 import { transport } from '@renderer/lib/transport'
 import { Queries } from '@shared/protocol/queries'
 import { DEFAULT_SPEED_LIMIT_SETTINGS } from '@shared/schemas/speed-limit'
@@ -25,7 +26,7 @@ import { type ComponentProps, forwardRef, useEffect, useState } from 'react'
 import type { UseFormReturn } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { CompactLimitInput } from './compact-limit-input'
-import { type DownloadsFields, KB, MBPS } from './downloads-form'
+import { type DownloadsFields, MBPS } from './downloads-form'
 
 const TIME_INPUT_CLS = 'h-8 w-24 bg-background font-mono tabular-nums'
 const TIME_24_PATTERN = '(?:[01]\\d|2[0-3]):[0-5]\\d'
@@ -131,20 +132,20 @@ function minCap(values: number[]): number {
   return min
 }
 
-function formatLimit(value: number, t: Translate): string {
-  return value <= 0
-    ? t('settings.downloads.speedLimit.unlimited')
-    : `${formatBytes(value)}/s`
-}
-
 function crossesMidnight(from: string, to: string): boolean {
   return to < from
 }
 
 function effectSummary(
   settings: SpeedLimitSettings,
-  t: Translate
+  t: Translate,
+  formatSpeed: (value: number) => string
 ): { primary: string; secondary?: string } {
+  function formatLimit(value: number, t: Translate): string {
+    return value <= 0
+      ? t('settings.downloads.speedLimit.unlimited')
+      : formatSpeed(value)
+  }
   const regularValues = {
     download: formatLimit(settings.base.download, t),
     upload: formatLimit(settings.base.upload, t),
@@ -246,12 +247,15 @@ export function SpeedLimitSection({
 }: {
   form: UseFormReturn<DownloadsFields>
 }) {
+  const { formatSpeed, unitSystem } = useByteFormat()
+  const kiloByte = unitSystem === 'binary' ? 1024 : 1000
+
   const { t } = useTranslation()
   const settings = form.watch('speedLimit')
   const turtle = settings.turtle
   const scheduleEnabled = settings.auto.schedule.enabled
   const adaptiveEnabled = settings.auto.adaptive.enabled
-  const summary = effectSummary(settings, t)
+  const summary = effectSummary(settings, t, formatSpeed)
 
   const kbLimitRow = (
     name: KbLimitName,
@@ -270,9 +274,11 @@ export function SpeedLimitSection({
           </div>
           <FormControl>
             <CompactLimitInput
-              value={Math.round((field.value as number) / KB)}
-              onValueChange={(value) => field.onChange(value * KB)}
-              unit="KB/s"
+              value={(field.value as number) / kiloByte}
+              onValueChange={(value) =>
+                field.onChange(Math.round(value * kiloByte))
+              }
+              unit={unitSystem === 'binary' ? 'KiB/s' : 'KB/s'}
               zeroAction={zeroAction}
               zeroLabel={t(
                 zeroAction === 'inherit'

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -311,6 +311,11 @@ async function main() {
       defaultSaveDir: configuredDefaultSaveDir,
       onChange: (old, updated) => {
         eventBus.emit(Events.SettingsChanged, { old, updated })
+        if (old.app.byteUnitSystem !== updated.app.byteUnitSystem) {
+          eventBus.emit(Events.ByteUnitSystemChanged, {
+            byteUnitSystem: updated.app.byteUnitSystem,
+          })
+        }
         if (old.app.reduceMotion !== updated.app.reduceMotion) {
           eventBus.emit(Events.ReducedMotionChanged, {
             reduceMotion: updated.app.reduceMotion,

--- a/src/shared/locales/en-US.json
+++ b/src/shared/locales/en-US.json
@@ -1002,7 +1002,12 @@
       "runModeTrayDesktop": "Start in System Tray",
       "runModeLinuxDesc": "System tray availability and activation behavior depend on your desktop environment.",
       "lightweightMode": "Lightweight mode",
-      "lightweightModeDesc": "Release interface memory after the main window closes. Background downloads continue; Windows and Linux keep a tray entry for reopening. Reopening takes a little longer and unsaved interface state is discarded."
+      "lightweightModeDesc": "Release interface memory after the main window closes. Background downloads continue; Windows and Linux keep a tray entry for reopening. Reopening takes a little longer and unsaved interface state is discarded.",
+      "byteUnitSystem": "Size and speed units",
+      "byteUnitSystemDesc": "Applies to file sizes and transfer speeds.",
+      "byteUnitDecimal": "Decimal (MB, GB · 1000)",
+      "byteUnitBinary": "Binary (MiB, GiB · 1024)",
+      "byteUnitSystemDefault": "Follow system ({{units}})"
     },
     "advanced": {
       "rpc": {
@@ -1205,7 +1210,7 @@
         "maxConnectionPerServerDesc": "How many parallel HTTP requests per origin.",
         "split": "Split connections per file",
         "splitDesc": "Number of segments to fetch a single file with.",
-        "minSplitSize": "Minimum segment size (MB)",
+        "minSplitSize": "Minimum segment size (MiB)",
         "minSplitSizeDesc": "Don’t split a file smaller than this."
       },
       "reliability": {
@@ -1220,7 +1225,7 @@
         "maxTriesDesc": "0 = no retry.",
         "retryWait": "Retry wait (s)",
         "retryWaitDesc": "Pause between retries.",
-        "lowestSpeedLimit": "Slow connection threshold (KB/s)",
+        "lowestSpeedLimit": "Slow connection threshold (KiB/s)",
         "lowestSpeedLimitDesc": "Drop connections below this speed. 0 = disabled."
       },
       "disk": {
@@ -1235,7 +1240,7 @@
         "modifiedTimeDesc": "Choose which modification time completed HTTP and FTP downloads use.",
         "modifiedTimeLocal": "Local",
         "modifiedTimeServer": "Server",
-        "diskCache": "Disk cache (MB)",
+        "diskCache": "Disk cache (MiB)",
         "diskCacheDesc": "In-memory write cache.",
         "sessionSaveInterval": "Session save interval (s)",
         "sessionSaveIntervalDesc": "How often aria2 persists download state."

--- a/src/shared/locales/zh-CN.json
+++ b/src/shared/locales/zh-CN.json
@@ -989,7 +989,12 @@
       "runModeTrayDesktop": "在系统托盘中启动",
       "runModeLinuxDesc": "系统托盘的可用性和激活方式取决于桌面环境。",
       "lightweightMode": "轻量模式",
-      "lightweightModeDesc": "关闭主窗口后释放界面内存，后台下载继续运行。Windows 和 Linux 会保留托盘入口；重新打开会稍慢，未保存的界面状态将被丢弃。"
+      "lightweightModeDesc": "关闭主窗口后释放界面内存，后台下载继续运行。Windows 和 Linux 会保留托盘入口；重新打开会稍慢，未保存的界面状态将被丢弃。",
+      "byteUnitSystem": "大小和速度单位",
+      "byteUnitSystemDesc": "用于文件大小与传输速度的显示。",
+      "byteUnitDecimal": "十进制（MB、GB · 1000）",
+      "byteUnitBinary": "二进制（MiB、GiB · 1024）",
+      "byteUnitSystemDefault": "跟随系统（{{units}}）"
     },
     "about": {
       "appIconAlt": "Motrix 应用图标",
@@ -1192,7 +1197,7 @@
         "maxConnectionPerServerDesc": "对同一来源同时发起的 HTTP 请求数。",
         "split": "单文件分段连接数",
         "splitDesc": "用多少个连接并行下载同一文件。",
-        "minSplitSize": "最小分段大小 (MB)",
+        "minSplitSize": "最小分段大小 (MiB)",
         "minSplitSizeDesc": "小于该大小的文件不会被分段下载。"
       },
       "reliability": {
@@ -1207,7 +1212,7 @@
         "maxTriesDesc": "0 表示不重试。",
         "retryWait": "重试间隔 (秒)",
         "retryWaitDesc": "两次重试之间的停顿。",
-        "lowestSpeedLimit": "慢连接阈值 (KB/s)",
+        "lowestSpeedLimit": "慢连接阈值 (KiB/s)",
         "lowestSpeedLimitDesc": "速度低于此值时断开。0 表示关闭。"
       },
       "disk": {
@@ -1222,7 +1227,7 @@
         "modifiedTimeDesc": "选择 HTTP 和 FTP 下载完成后使用的文件修改时间。",
         "modifiedTimeLocal": "本地修改时间",
         "modifiedTimeServer": "服务器修改时间",
-        "diskCache": "磁盘缓存 (MB)",
+        "diskCache": "磁盘缓存 (MiB)",
         "diskCacheDesc": "写入磁盘前的内存缓存上限。",
         "sessionSaveInterval": "会话保存间隔 (秒)",
         "sessionSaveIntervalDesc": "aria2 持久化下载状态的频率。"

--- a/src/shared/locales/zh-TW.json
+++ b/src/shared/locales/zh-TW.json
@@ -989,7 +989,12 @@
       "runModeTrayDesktop": "在系統匣中啟動",
       "runModeLinuxDesc": "系統匣的可用性和啟用方式取決於桌面環境。",
       "lightweightMode": "輕量模式",
-      "lightweightModeDesc": "關閉主視窗後釋放介面記憶體，背景下載會繼續運作。Windows 和 Linux 會保留系統匣入口；重新開啟會稍慢，未儲存的介面狀態將被捨棄。"
+      "lightweightModeDesc": "關閉主視窗後釋放介面記憶體，背景下載會繼續運作。Windows 和 Linux 會保留系統匣入口；重新開啟會稍慢，未儲存的介面狀態將被捨棄。",
+      "byteUnitSystem": "大小與速度單位",
+      "byteUnitSystemDesc": "用於檔案大小與傳輸速度的顯示。",
+      "byteUnitDecimal": "十進位（MB、GB · 1000）",
+      "byteUnitBinary": "二進位（MiB、GiB · 1024）",
+      "byteUnitSystemDefault": "跟隨系統（{{units}}）"
     },
     "advanced": {
       "rpc": {
@@ -1192,7 +1197,7 @@
         "maxConnectionPerServerDesc": "每個來源可同時發出的 HTTP 要求數量。",
         "split": "每個檔案的分割連線數",
         "splitDesc": "下載單一檔案時使用的分段數量。",
-        "minSplitSize": "最小分段大小 (MB)",
+        "minSplitSize": "最小分段大小 (MiB)",
         "minSplitSizeDesc": "小於此大小的檔案不會分割。"
       },
       "reliability": {
@@ -1207,7 +1212,7 @@
         "maxTriesDesc": "0 = 不重試。",
         "retryWait": "重試等待時間 (秒)",
         "retryWaitDesc": "每次重試之間的暫停時間。",
-        "lowestSpeedLimit": "低速連線門檻 (KB/s)",
+        "lowestSpeedLimit": "低速連線門檻 (KiB/s)",
         "lowestSpeedLimitDesc": "低於此速度時中斷連線。0 = 停用。"
       },
       "disk": {
@@ -1222,7 +1227,7 @@
         "modifiedTimeDesc": "選擇 HTTP 與 FTP 下載完成後使用的檔案修改時間。",
         "modifiedTimeLocal": "本機修改時間",
         "modifiedTimeServer": "伺服器修改時間",
-        "diskCache": "磁碟快取 (MB)",
+        "diskCache": "磁碟快取 (MiB)",
         "diskCacheDesc": "記憶體內的寫入快取。",
         "sessionSaveInterval": "工作階段儲存間隔 (秒)",
         "sessionSaveIntervalDesc": "aria2 儲存下載狀態的頻率。"

--- a/src/shared/protocol/events.ts
+++ b/src/shared/protocol/events.ts
@@ -37,6 +37,8 @@ export const Events = {
   SettingsChanged: 'event:settingsChanged',
   // Payload: { reduceMotion: boolean }. Full settings remain host-internal.
   ReducedMotionChanged: 'event:reducedMotionChanged',
+  // Payload: { byteUnitSystem: ByteUnitPreference }.
+  ByteUnitSystemChanged: 'event:byteUnitSystemChanged',
   LocaleChanged: 'event:localeChanged',
   SpeedLimitChanged: 'event:speedLimitChanged',
   // Torrent

--- a/src/shared/protocol/forwardable-events.test.ts
+++ b/src/shared/protocol/forwardable-events.test.ts
@@ -6,6 +6,7 @@ import { ForwardableEvents } from './forwardable-events'
 describe('ForwardableEvents', () => {
   it('forwards the motion preference without exposing the full settings event', () => {
     expect(ForwardableEvents).toContain(Events.ReducedMotionChanged)
+    expect(ForwardableEvents).toContain(Events.ByteUnitSystemChanged)
     expect(ForwardableEvents).not.toContain(Events.SettingsChanged)
   })
 
@@ -21,7 +22,7 @@ describe('ForwardableEvents', () => {
   })
 
   it('has the expected number of forwardable events', () => {
-    expect(ForwardableEvents).toHaveLength(52)
+    expect(ForwardableEvents).toHaveLength(53)
   })
 
   it('includes the bridge approval events (web-shell pairing)', () => {

--- a/src/shared/protocol/forwardable-events.ts
+++ b/src/shared/protocol/forwardable-events.ts
@@ -41,6 +41,7 @@ export const ForwardableEvents = [
   Events.GeoIPStatusChanged,
   Events.LocaleChanged,
   Events.ReducedMotionChanged,
+  Events.ByteUnitSystemChanged,
   Events.PluginConfigChanged,
   Events.PluginGrantsChanged,
   Events.PluginEvicted,

--- a/src/shared/schemas/add-task.ts
+++ b/src/shared/schemas/add-task.ts
@@ -40,6 +40,7 @@ const torrentTabSchema = z
       .array(z.number().int().nonnegative())
       .min(1, { message: 'task.add.errors.noFilesSelected' }),
     saveDir: z.string().min(1, { message: 'task.add.errors.saveDirRequired' }),
+    // Transfer limits are bytes per second, independent of display units.
     dlLimit: z.number().int().nonnegative().optional(),
     ulLimit: z.number().int().nonnegative().optional(),
     seedRatio: z.number().nonnegative().optional(),
@@ -92,6 +93,7 @@ const btTaskRequestSchema = z
     ]),
     selectedFiles: z.array(z.number().int().nonnegative()).default([]),
     saveDir: z.string().min(1),
+    // Transfer limits are bytes per second, independent of display units.
     dlLimit: z.number().int().nonnegative().optional(),
     ulLimit: z.number().int().nonnegative().optional(),
     seedRatio: z.number().nonnegative().optional(),
@@ -169,6 +171,7 @@ export const torrentBatchCreateOptionsSchema = z.object({
     .array(z.number().int().nonnegative())
     .min(1, { message: 'task.add.errors.noFilesSelected' }),
   saveDir: z.string().min(1, { message: 'task.add.errors.saveDirRequired' }),
+  // Transfer limits are bytes per second, independent of display units.
   dlLimit: z.number().int().nonnegative().optional(),
   ulLimit: z.number().int().nonnegative().optional(),
   seedRatio: z.number().nonnegative().optional(),

--- a/src/shared/schemas/app-settings.test.ts
+++ b/src/shared/schemas/app-settings.test.ts
@@ -83,3 +83,17 @@ it('keeps login launches hidden for existing and invalid settings', () => {
       .showMainWindowAtLogin
   ).toBe(true)
 })
+
+it('defaults byte units for old settings and preserves explicit choices', () => {
+  expect(DEFAULT_APP_SETTINGS.byteUnitSystem).toBe('system')
+  for (const byteUnitSystem of [undefined, null, 'MB', 1024]) {
+    expect(appSettingsSchema.parse({ byteUnitSystem }).byteUnitSystem).toBe(
+      'system'
+    )
+  }
+  for (const byteUnitSystem of ['system', 'decimal', 'binary']) {
+    expect(appSettingsSchema.parse({ byteUnitSystem }).byteUnitSystem).toBe(
+      byteUnitSystem
+    )
+  }
+})

--- a/src/shared/schemas/app-settings.ts
+++ b/src/shared/schemas/app-settings.ts
@@ -2,6 +2,10 @@ import { RunMode } from '@shared/constants'
 import { DEFAULT_LOCALE } from '@shared/constants/locales'
 import type { MotrixAppSettings } from '@shared/types/settings'
 import { z } from 'zod'
+import {
+  byteUnitSystemSchema,
+  DEFAULT_BYTE_UNIT_PREFERENCE,
+} from './byte-unit-system'
 import { supportedLocaleSchema } from './locale'
 
 export const appUpdateChannelSchema = z.enum(['stable', 'beta'])
@@ -20,6 +24,7 @@ export const appSettingsSchema = z.object({
   theme: z.enum(['system', 'light', 'dark']).catch('system'),
   reduceMotion: z.boolean().catch(false),
   language: supportedLocaleSchema.catch(DEFAULT_LOCALE),
+  byteUnitSystem: byteUnitSystemSchema.catch(DEFAULT_BYTE_UNIT_PREFERENCE),
   // Empty string is a sentinel: SettingsManager (main/server) seeds the
   // absolute platform download directory on first load. The renderer never
   // observes '' because settings are loaded before the UI mounts.

--- a/src/shared/schemas/byte-unit-system.ts
+++ b/src/shared/schemas/byte-unit-system.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+
+export const byteUnitSystemSchema = z.enum(['system', 'decimal', 'binary'])
+export type ByteUnitPreference = z.infer<typeof byteUnitSystemSchema>
+export type ByteUnitSystem = Exclude<ByteUnitPreference, 'system'>
+export const DEFAULT_BYTE_UNIT_PREFERENCE: ByteUnitPreference = 'system'
+export const DEFAULT_BYTE_UNIT_SYSTEM: ByteUnitSystem = 'decimal'
+
+/** Accepts a native platform or the browser device platform, never the server OS. */
+export function resolveByteUnitSystem(
+  preference: ByteUnitPreference,
+  platform: string
+): ByteUnitSystem {
+  if (preference !== 'system') return preference
+  if (/darwin|mac|iphone|ipad/i.test(platform)) return 'decimal'
+  return /win|linux|android/i.test(platform) ? 'binary' : 'decimal'
+}

--- a/src/shared/types/settings.ts
+++ b/src/shared/types/settings.ts
@@ -1,3 +1,4 @@
+import type { ByteUnitPreference } from '@shared/schemas/byte-unit-system'
 import type { RunMode } from '../constants'
 import type { EnginePerformanceProfile } from '../constants/engine-performance-profiles'
 import type { SupportedLocale } from '../constants/locales'
@@ -217,6 +218,7 @@ export interface MotrixAppSettings {
   showMainWindowAtLogin: boolean
   theme: 'system' | 'light' | 'dark'
   reduceMotion: boolean
+  byteUnitSystem: ByteUnitPreference
   language: SupportedLocale
   defaultSaveDir: string
   notifyOnComplete: boolean

--- a/src/shared/utils/format-bytes.ts
+++ b/src/shared/utils/format-bytes.ts
@@ -1,0 +1,77 @@
+import {
+  type ByteUnitSystem,
+  DEFAULT_BYTE_UNIT_SYSTEM,
+} from '@shared/schemas/byte-unit-system'
+
+const UNITS = {
+  decimal: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB'],
+  binary: ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB'],
+} as const
+
+export type ByteValue = number | bigint | string
+export interface ByteFormatOptions {
+  unitSystem?: ByteUnitSystem
+  decimals?: 0 | 1 | 2
+}
+export interface FormattedByteParts {
+  number: string
+  unit: (typeof UNITS)[ByteUnitSystem][number]
+}
+
+function toByteCount(value: ByteValue): bigint {
+  if (typeof value === 'bigint') return value > 0n ? value : 0n
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || value <= 0) return 0n
+    return BigInt(Math.floor(value))
+  }
+  if (!/^\d+$/.test(value)) return 0n
+  return BigInt(value)
+}
+
+export function formatByteParts(
+  bytes: ByteValue,
+  {
+    unitSystem = DEFAULT_BYTE_UNIT_SYSTEM,
+    decimals = 2,
+  }: ByteFormatOptions = {}
+): FormattedByteParts {
+  const value = toByteCount(bytes)
+  const units = UNITS[unitSystem]
+  const base = unitSystem === 'binary' ? 1024n : 1000n
+  let unitIndex = 0
+  let unitSize = 1n
+  while (unitIndex < units.length - 1 && value >= unitSize * base) {
+    unitIndex += 1
+    unitSize *= base
+  }
+  if (unitIndex === 0) return { number: value.toString(), unit: 'B' }
+
+  const scale = 10n ** BigInt(decimals)
+  let rounded = (value * scale + unitSize / 2n) / unitSize
+  // Promote after rounding as well: never display 1000.00 KB or 1024.00 KiB.
+  if (rounded >= base * scale && unitIndex < units.length - 1) {
+    unitIndex += 1
+    unitSize *= base
+    rounded = (value * scale + unitSize / 2n) / unitSize
+  }
+  const number =
+    decimals === 0
+      ? rounded.toString()
+      : `${rounded / scale}.${(rounded % scale).toString().padStart(decimals, '0')}`
+  return { number, unit: units[unitIndex] }
+}
+
+export function formatBytes(
+  bytes: ByteValue,
+  options?: ByteFormatOptions
+): string {
+  const parts = formatByteParts(bytes, options)
+  return `${parts.number} ${parts.unit}`
+}
+
+export function formatSpeed(
+  bytes: ByteValue,
+  unitSystem = DEFAULT_BYTE_UNIT_SYSTEM
+): string {
+  return `${formatBytes(bytes, { unitSystem, decimals: 1 })}/s`
+}


### PR DESCRIPTION
## Summary / 概述

Motrix previously paired base-1024 values with decimal unit labels. Use matching values and labels throughout the download UI, with an OS-dependent default and an explicit user override.

默认跟随操作系统：macOS 使用十进制 MB/GB，Windows 和 Linux 使用二进制 MiB/GiB；Web 根据访问设备判断。用户可在外观设置中切换，已有实际限速保持不变。

## Related issue / 相关 Issue

Related: #2104, #2103, #1884.

| Issue | Coverage in this PR |
| --- | --- |
| #2104 | Shared size formatting with two decimal places and selectable decimal/IEC units. |
| #2103 | Matching decimal/IEC speed units. Speed precision remains one decimal place; the request for two places is not included. |
| #1884 | IEC units and a unit-system preference. Preference labels are localized in all three supported locales; unit symbols remain standard symbols. |

## Changes / 改动

- Default to Follow system: base 1000 on macOS, base 1024 on Windows/Linux. Web uses the browser device platform rather than the server OS.
- Share precise byte formatting across download rows, file lists, inspectors, and dashboard tiles. File sizes use two decimals; speeds use one; progress percentages retain their existing precision.
- Preserve the tray speedometer's original formatting: minimum KB/s or KiB/s, integer kilobytes, and one decimal for megabytes and above. Switch unit labels and conversion base with the preference; increase SVG width from 134 to 142 pixels at 2x (4 pt), preserving the font, icon, height, and two-line layout.
- Synchronize preference changes live across views and after reconnects.
- Show global and per-task limits in KB/s or KiB/s, accept fractional input, and send explicit whole bytes/sec to aria2. Changing display units does not change saved limits.
- Correct fixed binary engine tuning labels to MiB/KiB and update English, Simplified Chinese, and Traditional Chinese resources.

## Validation / 验证

- [x] `pnpm run check:boundaries`
- [x] `pnpm run lint`
- [x] `pnpm exec tsc --noEmit`
- [x] Relevant automated tests / 相关自动化测试
- [x] Manual verification, if applicable / 必要的手动验证

Validation on macOS:

- `pnpm test` at `074e6191`: 755 test files passed, 3 skipped; 9,291 tests passed, 14 skipped.
- Final tray validation: `pnpm exec vitest run src/main/platform/tray-icon.test.ts src/main/platform/tray-speedometer.test.ts src/main/platform/tray.test.ts` passed all 26 tests. Required static checks and `pnpm exec vite build --config vite.main.config.ts` also passed.
- Rendered the final tray SVG with the shipped SF font and Helvetica fallback. The longest checked IEC label, `1023.9 MiB/s`, fits within 142 × 44 pixels without overlapping the icon or reducing the original icon-to-text clearance.
- `pnpm run check:i18n`: 3 locales and 1,684 translation keys passed.
- `pnpm run check:file-names`: passed.
- `pnpm build`: desktop production build passed.
- `pnpm exec vite build --config vite.renderer.config.ts` and `pnpm exec vite build --config vite.renderer.web.config.ts`: final renderer builds passed.
- `pnpm test:e2e e2e/add-task.spec.ts e2e/downloads-visibility.spec.ts e2e/dashboard.spec.ts`: 5 passed, 2 skipped, 1 cold-start failure before the engine query handler registered. `pnpm test:e2e e2e/add-task.spec.ts -g 'http url'` passed on retry.
- Isolated Electron smoke verified the macOS default, persisted binary preference, unchanged existing limit bytes, live size updates, fractional limit entry and saved bytes, and no document-level horizontal overflow.

## Screenshots or recordings / 截图或录屏

Local visual verification covered the unit selector, download rows, and KiB/s limit fields. Screenshots were captured locally; no attachments are included.

## Checklist / 检查清单

- [x] This pull request targets `main` and contains one focused change.
- [x] User-visible text is localized, and paired English/Chinese documentation stays aligned.
- [x] No credentials, private URLs, personal paths, or other sensitive information are included.
- [x] I have read and followed the [contribution guidelines](https://github.com/agalwood/Motrix/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/agalwood/Motrix/blob/main/CODE_OF_CONDUCT.md).

