### PR TITLE
chore(release): prepare 2.0.0-beta.36

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The same core powers two ways to run Motrix:
 ## 🧪 Beta testing
 
 Motrix Turbo v2 is currently in beta. After its remaining release gates pass,
-download [v2.0.0-beta.35 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.35)
-and read the [full release notes](./docs/release-notes/2.0.0-beta.35.md) before
+download [v2.0.0-beta.36 from GitHub Releases](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.36)
+and read the [full release notes](./docs/release-notes/2.0.0-beta.36.md) before
 installing it.
 
 Back up your existing Motrix data and downloads before testing. Migration from
@@ -176,7 +176,7 @@ downloaded resources:
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.35'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.36'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,8 +22,8 @@ Motrix 是一款界面简洁、功能丰富的桌面下载管理器，可处理 
 ## 🧪 Beta 测试
 
 Motrix Turbo v2 目前仍处于 beta 阶段。剩余发布门禁通过后，请从 GitHub Releases
-下载 [v2.0.0-beta.35](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.35)，
-并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.35.zh-CN.md)。
+下载 [v2.0.0-beta.36](https://github.com/agalwood/Motrix/releases/tag/v2.0.0-beta.36)，
+并在安装前阅读[完整发布说明](./docs/release-notes/2.0.0-beta.36.zh-CN.md)。
 
 测试前请备份现有 Motrix 数据和下载文件。Motrix v1 数据的迁移路径尚未经过
 验证，请勿让本 beta 使用您唯一一份 v1 数据。条件允许时，建议通过独立的系统
@@ -167,7 +167,7 @@ Beta 只发布不可变的版本 tag，不会更新 `latest`；仓库的 `compos
 ```bash
 mkdir -p motrix-data downloads
 sudo chown 1000:1000 motrix-data downloads
-export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.35'
+export MOTRIX_IMAGE='docker.io/motrixapp/motrix-server:2.0.0-beta.36'
 export MOTRIX_PUBLIC_URL='http://nas.example.lan:8080'
 docker compose pull server
 docker compose up -d --wait

--- a/docs/release-notes/2.0.0-beta.36.md
+++ b/docs/release-notes/2.0.0-beta.36.md
@@ -1,0 +1,99 @@
+# Motrix 2.0.0-beta.36
+
+English | [简体中文](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.36/docs/release-notes/2.0.0-beta.36.zh-CN.md)
+
+Motrix 2.0.0-beta.36 improves interrupted download recovery, adds an opt-in
+AppImage browser launch integration, and follows system conventions for size
+and speed units. It is intended for public distribution only after every
+protected release gate passes.
+
+## Highlights
+
+- A browser-specific Native Messaging registration failure no longer stops the
+  desktop bridge or removes healthy registrations for other browsers. Discovery
+  and extension settings remain available, and individual failures are logged
+  ([#2118](https://github.com/agalwood/Motrix/pull/2118)).
+- Interrupted download finalization can recover from the downloaded files using
+  Retry. Transient aria2 stop-cleanup races retry automatically, while persistent
+  failures remain visible instead of leaving tasks stuck in Finalizing
+  ([#2115](https://github.com/agalwood/Motrix/pull/2115)).
+- AppImage users can explicitly install a stable Native Messaging host, repair
+  its registration, select a moved image, or remove the integration in Settings.
+  Full browser cold reconnect with saved pairing credentials also requires the
+  companion Extension update
+  ([#2116](https://github.com/agalwood/Motrix/pull/2116),
+  [Extension #18](https://github.com/motrixapp/motrix-extension/pull/18)).
+- Size and speed units now default to decimal on macOS and binary IEC on
+  Windows/Linux; Web follows the browser device. Appearance settings can override
+  the unit system, and changing display units preserves existing speed limits
+  ([#2114](https://github.com/agalwood/Motrix/pull/2114)).
+- New browser-extension submissions use the current default save directory
+  without restarting the bridge, in both Desktop and Server
+  ([#2113](https://github.com/agalwood/Motrix/pull/2113)).
+- Linux tray icons use the correct light/dark artwork and refresh when the
+  system theme changes
+  ([#2109](https://github.com/agalwood/Motrix/pull/2109)).
+- A Show window at login preference lets users choose whether automatic login
+  launches display the main window; it defaults to off
+  ([#2106](https://github.com/agalwood/Motrix/pull/2106)).
+
+## Before testing
+
+This is prerelease software. Back up existing Motrix application data and
+downloads before installing it. Migration from Motrix v1 data has not yet been
+validated, so do not use your only copy of v1 data with this beta.
+
+When practical, test v2 in parallel using a separate OS account, machine, or
+Docker data directory. Check finalization recovery, save-directory changes on an
+existing browser connection, unit switching without changing speed limits,
+login startup behavior, and Linux tray visibility across theme changes.
+
+AppImage cold reconnect requires a compatible companion Extension. Native Linux
+x64 browser E2E, ordinary Chrome/Edge coverage, and packaged E2E on the final
+rebased AppImage integration commits remain pending. Windows login startup and
+the reported Windows finalization paths also need real-device verification.
+
+After the protected release completes, Snap testers can install the strictly
+confined build with `sudo snap install motrix --edge`. Existing installations
+tracking `latest/edge` should upgrade to the same beta.36 revision set.
+
+## Planned downloads after release gates pass
+
+| Distribution | Architectures | Planned output |
+|--------------|---------------|----------------|
+| macOS 13 or later | `arm64` (Apple Silicon), `x64` (Intel) | DMG and ZIP |
+| Windows | `x64` | Unsigned NSIS installer (`.exe`) and ZIP |
+| Linux | `x64`, `arm64` | AppImage, DEB, RPM, and pacman |
+| Flatpak Native Host companion | `linux/x64`, `linux/arm64` | `Motrix-Native-Host-2.0.0-beta.36-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`, `linux/arm64` | Immutable `2.0.0-beta.36` tag in both registries |
+| Snap Store | `amd64`, `arm64` | Verified build set on `latest/edge` |
+
+After every container gate passes, the versioned image references will be
+`docker.io/motrixapp/motrix-server:2.0.0-beta.36` and
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.36`. See the
+[Docker Server deployment guide](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.36/docs/docker-server.md)
+for storage, networking, remote Extension pairing, and upgrade guidance.
+
+## Distribution notes
+
+- AppImage desktop integration remains opt-in. Browser cold launch uses a
+  separately enabled stable Native Messaging host and a registered AppImage path;
+  saved-pairing reconnect needs the compatible companion Extension update.
+- Flatpak is validated separately and is not published by the release tag; the
+  GitHub prerelease includes its Native Host companion archives.
+- Windows `arm64` and all 32-bit packages are not available.
+- Windows packages are unsigned and may trigger a Windows SmartScreen warning.
+  Download them only from the official GitHub prerelease after it is published.
+- Beta container tags are immutable and do not update `latest`, `stable`, or
+  other stable floating tags.
+- The Snap package is strictly confined. Its approved `personal-files`
+  interface is limited to registering Native Messaging host manifests for
+  supported browsers. Beta publication updates `latest/edge` only; it does not
+  promote the build to `candidate` or `stable`.
+
+## Feedback
+
+Please report reproducible problems through
+[GitHub Issues](https://github.com/agalwood/Motrix/issues). Include your
+operating system, architecture, package type, and the steps needed to reproduce
+the issue.

--- a/docs/release-notes/2.0.0-beta.36.zh-CN.md
+++ b/docs/release-notes/2.0.0-beta.36.zh-CN.md
@@ -1,0 +1,87 @@
+# Motrix 2.0.0-beta.36
+
+[English](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.36/docs/release-notes/2.0.0-beta.36.md) | 简体中文
+
+Motrix 2.0.0-beta.36 改进中断下载的恢复，新增需要主动启用的 AppImage 浏览器
+启动集成，并让容量与速度单位遵循系统习惯。只有在所有受保护发布门禁通过后，
+本版本才适合公开分发。
+
+## 主要改进
+
+- 单个浏览器的 Native Messaging 注册失败不再停止桌面 bridge，也不会移除其他
+  浏览器的正常注册。发现接口和扩展设置保持可用，各项失败会记录到日志
+  （[#2118](https://github.com/agalwood/Motrix/pull/2118)）。
+- 下载完成处理被中断后，可通过“重试”利用已下载文件继续恢复。aria2 停止任务
+  清理过程中的暂时冲突会自动重试，持续失败则明确显示错误，避免任务一直停留在
+  Finalizing 状态
+  （[#2115](https://github.com/agalwood/Motrix/pull/2115)）。
+- AppImage 用户可在设置中主动安装固定路径的 Native Messaging host、修复注册、
+  选择移动后的镜像或移除集成。使用已保存配对凭据完成浏览器冷启动重连，还需要
+  配套的 Extension 更新
+  （[#2116](https://github.com/agalwood/Motrix/pull/2116)、
+  [Extension #18](https://github.com/motrixapp/motrix-extension/pull/18)）。
+- 容量与速度单位默认在 macOS 使用十进制，在 Windows/Linux 使用二进制 IEC；
+  Web 根据浏览器所在设备判断。可在外观设置中切换单位制，切换显示单位不会改变
+  已有的实际限速
+  （[#2114](https://github.com/agalwood/Motrix/pull/2114)）。
+- Desktop 和 Server 的新浏览器扩展下载任务会使用当前默认保存目录，无需重启
+  bridge
+  （[#2113](https://github.com/agalwood/Motrix/pull/2113)）。
+- Linux 托盘使用正确的浅色／深色图标，并在系统主题变化时刷新
+  （[#2109](https://github.com/agalwood/Motrix/pull/2109)）。
+- 新增“登录时显示窗口”偏好，用于选择自动登录启动时是否显示主窗口，默认关闭
+  （[#2106](https://github.com/agalwood/Motrix/pull/2106)）。
+
+## 测试前须知
+
+这是预发布软件。安装前请备份现有 Motrix 应用数据和下载文件。Motrix v1 数据的
+迁移路径尚未经过验证，请勿让本 beta 使用您唯一的一份 v1 数据。
+
+条件允许时，请使用独立的操作系统账号、设备或 Docker 数据目录并行测试 v2。
+请重点检查完成处理恢复、现有浏览器连接上的保存目录变化、切换单位后实际限速
+保持不变、登录启动行为，以及主题切换时 Linux 托盘图标的可见性。
+
+AppImage 冷启动重连需要兼容的配套 Extension。原生 Linux x64 浏览器 E2E、
+普通 Chrome／Edge，以及 AppImage 集成最终 rebase 提交上的打包 E2E 仍待验证。
+Windows 登录启动和用户报告的 Windows 完成处理路径也需要实机验证。
+
+受保护发布完成后，Snap 测试者可使用
+`sudo snap install motrix --edge` 安装严格限制的构建。已跟踪
+`latest/edge` 的安装应升级到同一组 beta.36 revision。
+
+## 发布门禁通过后计划提供的下载
+
+| 分发方式 | 架构 | 计划产物 |
+|---------|------|---------|
+| macOS 13 或更高版本 | `arm64`（Apple Silicon）、`x64`（Intel） | DMG 和 ZIP |
+| Windows | `x64` | 未签名 NSIS 安装程序（`.exe`）和 ZIP |
+| Linux | `x64`、`arm64` | AppImage、DEB、RPM 和 pacman |
+| Flatpak Native Host companion | `linux/x64`、`linux/arm64` | `Motrix-Native-Host-2.0.0-beta.36-linux-<arch>.tar.gz` |
+| Docker Hub / GHCR | `linux/amd64`、`linux/arm64` | 两个仓库中的不可变 `2.0.0-beta.36` 标签 |
+| Snap Store | `amd64`、`arm64` | `latest/edge` 上的已验证构建集 |
+
+所有容器门禁通过后，可使用以下带版本镜像：
+`docker.io/motrixapp/motrix-server:2.0.0-beta.36` 和
+`ghcr.io/agalwood/motrix-server:2.0.0-beta.36`。存储、网络、远程 Extension
+配对与升级说明请参阅
+[Docker Server 部署指南](https://github.com/agalwood/Motrix/blob/v2.0.0-beta.36/docs/docker-server.zh-CN.md)。
+
+## 分发说明
+
+- AppImage 桌面集成仍需主动启用。浏览器冷启动使用单独启用的固定路径 Native
+  Messaging host 与已注册的 AppImage 路径；使用已保存配对重连还需要兼容的
+  配套 Extension 更新。
+- Flatpak 单独验证，不由 release tag 发布；GitHub 预发布版会包含它的 Native
+  Host companion 压缩包。
+- 不提供 Windows `arm64` 和所有 32 位安装包。
+- Windows 安装包未签名，可能触发 Windows SmartScreen 警告。请仅从已发布的
+  官方 GitHub 预发布版下载。
+- Beta 容器标签不可变，也不会更新 `latest`、`stable` 或其他稳定通道浮动标签。
+- Snap 安装包使用严格限制。已批准的 `personal-files` interface 仅用于为支持的
+  浏览器注册 Native Messaging host manifest。Beta 发布只会更新
+  `latest/edge`，不会把构建晋级到 `candidate` 或 `stable`。
+
+## 反馈
+
+如遇到可复现问题，请通过 [GitHub Issues](https://github.com/agalwood/Motrix/issues)
+反馈，并附上操作系统、架构、安装包类型和复现步骤。

--- a/flatpak/app.motrix.native.metainfo.xml
+++ b/flatpak/app.motrix.native.metainfo.xml
@@ -74,6 +74,17 @@
   </screenshots>
 
   <releases>
+    <release version="2.0.0-beta.36" date="2026-09-11">
+      <description>
+        <p>
+          Improves interrupted download finalization recovery, adds opt-in
+          AppImage browser launch integration and system-aware size and speed
+          units, isolates browser registration failures, and improves browser
+          save-directory updates, Linux tray themes, and login startup window
+          preferences.
+        </p>
+      </description>
+    </release>
     <release version="2.0.0-beta.35" date="2026-09-08">
       <description>
         <p>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "productName": "Motrix",
   "homepage": "https://motrix.app",
-  "version": "2.0.0-beta.35",
+  "version": "2.0.0-beta.36",
   "packageManager": "pnpm@11.25.0+sha512.5cde925b4f075f725eb71fbae18a42ffe784524789f19b61c731cb8721ec28aaee160e01a8d5af4fedb2a42cdbf300efe23db356b0d4a17b4d63e11f8ab7c956",
   "description": "A full-featured download manager",
   "keywords": [],


### PR DESCRIPTION
## Summary / 概述

Prepare Motrix `2.0.0-beta.36` from the seven merged first-parent changes in `v2.0.0-beta.35..92d0ff93`: interrupted finalization recovery, opt-in AppImage browser cold launch, system-aware size/speed units, current browser save directories, Linux tray themes, login window preferences, and isolated browser registration failures.

准备 beta.36，同步版本入口与中英文发布说明；发布内容来自上一版之后已合并到 main 的七项变更。

## Related issue / 相关 Issue

Release includes #2106, #2109, #2113, #2114, #2115, #2116, and #2118. AppImage saved-pairing cold reconnect requires the companion Extension update in motrixapp/motrix-extension#18.

## Changes / 改动

- Align package version, both READMEs, paired tag-pinned release notes, and Flatpak metadata.
- Preserve beta.35 references only as release history.
- Document gated macOS arm64/x64 DMG/ZIP, unsigned Windows x64 NSIS/ZIP, Linux x64/arm64 AppImage/DEB/RPM/pacman, Native Host companion archives, immutable multi-platform Docker Hub/GHCR images, and Snap latest/edge publication.
- Disclose unsigned Windows packages and outstanding AppImage browser/Windows real-device verification in both languages. macOS signing and notarization remain required by the formal release workflow.

## Validation / 验证

- [x] `pnpm run check:boundaries`
- [x] `pnpm run lint` — 1,854 files, no fixes
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm run check:flatpak`
- [x] `pnpm run check:file-names`
- [x] Relevant automated tests / 相关自动化测试 — 6 files, 175 tests passed
- [x] `git diff --cached --check`

Focused command:

```bash
pnpm exec vitest run tests/scripts/release-version-contract.test.ts tests/scripts/release-metadata.test.ts tests/scripts/assemble-release-artifacts.test.ts tests/scripts/workflow-release-matrix.test.ts tests/scripts/container-release-metadata.test.ts tests/scripts/release-signing-input.test.ts
```

Full cross-platform tests and packaging are delegated to the protected PR matrix; no application behavior changes are introduced by this release PR. Native Linux x64/ordinary Chrome/Edge AppImage E2E, packaged E2E on the final rebased integration commits, and Windows login/finalization manual acceptance remain outstanding as described in the merged feature PRs and public release notes.

## Checklist / 检查清单

- [x] Targets `main` and contains one focused release change.
- [x] Paired English/Chinese documentation stays aligned.
- [x] No private URLs, personal paths, or sensitive information are included.
- [x] Contribution guidelines and Code of Conduct were reviewed.
